### PR TITLE
feat(component): Create Tabs

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,4 @@
 import { muiTheme } from "storybook-addon-material-ui";
 import { defaultTheme } from "../src/core/styles";
 
-export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-};
-
 export const decorators = [muiTheme([defaultTheme])];

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.13.8",
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^4.11.3",
@@ -71,5 +72,6 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, Story } from "@storybook/react";
+import React, { useState } from "react";
+import { Tab, Tabs, TabsProps } from "./index";
+
+export default {
+  component: Tabs,
+  title: "Tabs",
+} as Meta;
+
+interface TabsArgs extends TabsProps {
+  tabOneLabel: string;
+  tabTwoLabel: string;
+}
+
+const Template: Story<TabsArgs> = ({
+  tabOneLabel,
+  tabTwoLabel,
+  ...args
+}: TabsArgs) => {
+  const [value, setValue] = useState(0);
+  const handleTabsChange = (
+    event: React.SyntheticEvent,
+    tabsValue: unknown
+  ) => {
+    console.log("hello");
+    console.log({ tabsValue });
+    setValue(tabsValue as number);
+  };
+  return (
+    // @ts-ignore -- mui-org/material-ui/issues/17454 will be fixed in 5.x
+    <Tabs value={value} onChange={handleTabsChange} {...args}>
+      <Tab label={tabOneLabel} />
+      <Tab label={tabTwoLabel} />
+    </Tabs>
+  );
+};
+export const Default = Template.bind({});
+Default.args = {
+  tabOneLabel: "Upload from Your Computer",
+  tabTwoLabel: "Upload from Basespace",
+  underlined: true,
+};

--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from "@storybook/react";
 import React, { useState } from "react";
-import { Tab, Tabs, TabsProps } from "./index";
+import Tabs, { Tab, TabsProps } from "./index";
 
 export default {
   component: Tabs,
@@ -22,16 +22,16 @@ const Template: Story<TabsArgs> = ({
     event: React.SyntheticEvent,
     tabsValue: unknown
   ) => {
-    console.log("hello");
-    console.log({ tabsValue });
     setValue(tabsValue as number);
   };
   return (
+    /* eslint-disable react/jsx-props-no-spreading,  @typescript-eslint/ban-ts-comment -- Need to spread and disable ts-ignore */
     // @ts-ignore -- mui-org/material-ui/issues/17454 will be fixed in 5.x
     <Tabs value={value} onChange={handleTabsChange} {...args}>
       <Tab label={tabOneLabel} />
       <Tab label={tabTwoLabel} />
     </Tabs>
+    /* eslint-disable react/jsx-props-no-spreading,  @typescript-eslint/ban-ts-comment -- Need to spread and disable ts-ignore */
   );
 };
 export const Default = Template.bind({});

--- a/src/core/Tabs/index.tsx
+++ b/src/core/Tabs/index.tsx
@@ -1,0 +1,67 @@
+import { css } from "@emotion/css";
+import styled from "@emotion/styled";
+import {
+  StylesProvider,
+  Tab as RawTab,
+  Tabs as RawTabs,
+  TabsProps as RawTabsProps,
+} from "@material-ui/core";
+import React from "react";
+import { defaultThemeOptions } from "../styles";
+
+export interface TabsProps extends RawTabsProps {
+  underlined?: boolean;
+}
+
+const StyledTabs = styled(RawTabs)<TabsProps>`
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+  border-bottom: ${({ underlined }) =>
+    underlined
+      ? `3px solid ${defaultThemeOptions.app.colors.gray[200]};`
+      : "none"};
+  position: relative;
+  z-index: 1;
+  overflow: inherit;
+  & .MuiTabs-scroller {
+    overflow: inherit !important;
+  }
+`;
+const TabIndicator = css`
+  background-color: ${defaultThemeOptions.app.colors.primary[400]};
+  height: 3px;
+  bottom: -3px;
+  z-index: 2;
+`;
+
+const Tabs = (props: TabsProps) => {
+  return (
+    <StylesProvider injectFirst>
+      {/*  eslint-disable-next-line react/jsx-props-no-spreading -- disable prop spread for extension */}
+      <StyledTabs {...props} TabIndicatorProps={{ className: TabIndicator }} />
+    </StylesProvider>
+  );
+};
+
+export default Tabs;
+
+export const Tab = styled(RawTab)`
+  color: ${defaultThemeOptions.app.colors.gray[500]};
+  text-transform: none;
+  height: 20px;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  padding-bottom: ${defaultThemeOptions.app.spacing.xxs}px;
+  &:hover {
+    color: ${defaultThemeOptions.app.colors.gray[600]};
+  }
+  &:active {
+    color: ${defaultThemeOptions.palette?.text?.primary};
+  }
+  &:disabled {
+    color: ${defaultThemeOptions.app.colors.gray[200]};
+  }
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "@material-ui/core";
 export * as Button from "./core/Button";
 export * as Checkbox from "./core/Checkbox";
 export * as defaultTheme from "./core/styles";
+export * as Tabs from "./core/Tabs";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,7 +1089,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@emotion/babel-plugin@^11.1.2":
+"@emotion/babel-plugin@^11.0.0", "@emotion/babel-plugin@^11.1.2":
   version "11.2.0"
   resolved "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.2.0.tgz"
   integrity sha512-lsnQBnl3l4wu/FJoyHnYRpHJeIPNkOBMbtDUIXcO8luulwRKZXPvA10zd2eXVN6dABIWNX4E34en/jkejIg/yA==
@@ -1148,6 +1148,17 @@
     "@emotion/serialize" "^0.11.15"
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
+
+"@emotion/css@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.1.3.tgz#9ed44478b19e5d281ccbbd46d74d123d59be793f"
+  integrity sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==
+  dependencies:
+    "@emotion/babel-plugin" "^11.0.0"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
 
 "@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
This isn't feature complete but definitely demoable.

A Major change is removing the automatic action creation based on regex match.  This was removing any controlled functionality connected to event handling.

Adds @emotion/css import to allow exporting a css definition as a class name

![image](https://user-images.githubusercontent.com/8716829/110981393-ef796c80-831b-11eb-9f3e-231f6343085f.png)
![image](https://user-images.githubusercontent.com/8716829/110981410-f7d1a780-831b-11eb-9b29-78092c2474b9.png)
