### PR TITLE
Add Tooltip

### DIFF
--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -1,0 +1,26 @@
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import TooltipInfo from "./index";
+
+const tooltipContent =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+const Demo = (props: Args): JSX.Element => {
+  return (
+    <TooltipInfo title={tooltipContent} {...props}>
+      <InfoOutlinedIcon />
+    </TooltipInfo>
+  );
+};
+
+export default {
+  component: Demo,
+  title: "Tooltip",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Info = Template.bind({});
+
+Info.args = {};

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -1,16 +1,16 @@
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import { Args, Story } from "@storybook/react";
 import React from "react";
-import TooltipInfo from "./index";
+import Tooltip from "./index";
 
 const tooltipContent =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 const Demo = (props: Args): JSX.Element => {
   return (
-    <TooltipInfo title={tooltipContent} {...props}>
+    <Tooltip title={tooltipContent} {...props}>
       <InfoOutlinedIcon />
-    </TooltipInfo>
+    </Tooltip>
   );
 };
 
@@ -21,6 +21,14 @@ export default {
 
 const Template: Story = (args) => <Demo {...args} />;
 
+export const Action = Template.bind({});
+
+Action.args = {
+  inverted: true,
+};
+
 export const Info = Template.bind({});
 
-Info.args = {};
+Info.args = {
+  inverted: false,
+};

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -1,0 +1,39 @@
+import {
+  makeStyles,
+  Tooltip as RawTooltip,
+  TooltipProps,
+} from "@material-ui/core";
+import React from "react";
+import { AppThemeOptions } from "../styles";
+
+export { TooltipProps };
+
+const useStyles = makeStyles((theme: AppThemeOptions) => {
+  return {
+    arrow: {
+      "&::before": {
+        border: `1px solid ${theme?.app?.colors.gray["300"]}`,
+      },
+      color: "white",
+    },
+    tooltip: {
+      backgroundColor: "white",
+      border: `1px solid ${theme?.app?.colors.gray["300"]}`,
+      boxShadow: theme?.app?.shadows["m"],
+      color: "black",
+      padding: theme?.app?.spacing.l,
+      fontSize: "13px",
+      lineHeight: "20px",
+      letterSpacing: "0.3px",
+      fontWeight: theme?.app?.fontWeights.regular,
+    },
+  };
+});
+
+const TooltipInfo = (props: TooltipProps): JSX.Element => {
+  const classes = useStyles();
+
+  return <RawTooltip arrow classes={classes} {...props} />;
+};
+
+export default TooltipInfo;

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -4,21 +4,28 @@ import {
   TooltipProps as RawTooltipProps,
 } from "@material-ui/core";
 import React from "react";
-import { arrowCss, tooltipCss } from "./style";
-
-interface ExtraProps {
-  inverted?: boolean;
-}
+import { arrowCss, ExtraProps, tooltipCss } from "./style";
 
 type TooltipProps = ExtraProps & RawTooltipProps;
+
 export { TooltipProps };
 
 const Tooltip = (props: TooltipProps): JSX.Element => {
-  const theme = useTheme();
-  const tooltip = tooltipCss({ ...props }, theme);
-  const arrow = arrowCss({ ...props }, theme);
+  const { inverted, ...rest } = props;
 
-  return <RawTooltip arrow classes={{ arrow, tooltip }} {...props} />;
+  const theme = useTheme();
+
+  const extraProps = {
+    /* stylelint-disable property-no-unknown -- false positive */
+    inverted,
+    theme,
+    /* stylelint-enable property-no-unknown -- false positive */
+  };
+
+  const tooltip = tooltipCss(extraProps);
+  const arrow = arrowCss(extraProps);
+
+  return <RawTooltip arrow classes={{ arrow, tooltip }} {...rest} />;
 };
 
 Tooltip.defaultProps = {

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -1,16 +1,28 @@
 import { useTheme } from "@emotion/react";
-import { Tooltip as RawTooltip, TooltipProps } from "@material-ui/core";
+import {
+  Tooltip as RawTooltip,
+  TooltipProps as RawTooltipProps,
+} from "@material-ui/core";
 import React from "react";
 import { arrowCss, tooltipCss } from "./style";
 
+interface ExtraProps {
+  inverted?: boolean;
+}
+
+type TooltipProps = ExtraProps & RawTooltipProps;
 export { TooltipProps };
 
-const TooltipInfo = (props: TooltipProps): JSX.Element => {
+const Tooltip = (props: TooltipProps): JSX.Element => {
   const theme = useTheme();
-  const tooltip = tooltipCss(theme);
-  const arrow = arrowCss(theme);
+  const tooltip = tooltipCss({ ...props }, theme);
+  const arrow = arrowCss({ ...props }, theme);
 
   return <RawTooltip arrow classes={{ arrow, tooltip }} {...props} />;
 };
 
-export default TooltipInfo;
+Tooltip.defaultProps = {
+  inverted: false,
+};
+
+export default Tooltip;

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -1,39 +1,16 @@
-import {
-  makeStyles,
-  Tooltip as RawTooltip,
-  TooltipProps,
-} from "@material-ui/core";
+import { useTheme } from "@emotion/react";
+import { Tooltip as RawTooltip, TooltipProps } from "@material-ui/core";
 import React from "react";
-import { AppThemeOptions } from "../styles";
+import { arrowCss, tooltipCss } from "./style";
 
 export { TooltipProps };
 
-const useStyles = makeStyles((theme: AppThemeOptions) => {
-  return {
-    arrow: {
-      "&::before": {
-        border: `1px solid ${theme?.app?.colors.gray["300"]}`,
-      },
-      color: "white",
-    },
-    tooltip: {
-      backgroundColor: "white",
-      border: `1px solid ${theme?.app?.colors.gray["300"]}`,
-      boxShadow: theme?.app?.shadows["m"],
-      color: "black",
-      padding: theme?.app?.spacing.l,
-      fontSize: "13px",
-      lineHeight: "20px",
-      letterSpacing: "0.3px",
-      fontWeight: theme?.app?.fontWeights.regular,
-    },
-  };
-});
-
 const TooltipInfo = (props: TooltipProps): JSX.Element => {
-  const classes = useStyles();
+  const theme = useTheme();
+  const tooltip = tooltipCss(theme);
+  const arrow = arrowCss(theme);
 
-  return <RawTooltip arrow classes={classes} {...props} />;
+  return <RawTooltip arrow classes={{ arrow, tooltip }} {...props} />;
 };
 
 export default TooltipInfo;

--- a/src/core/Tooltip/style.ts
+++ b/src/core/Tooltip/style.ts
@@ -1,0 +1,37 @@
+import { css } from "@emotion/css";
+import {
+  AppThemeOptions,
+  fontBodyXs,
+  getColors,
+  getShadows,
+  getSpacings,
+} from "../styles";
+
+export const tooltipCss = (theme: AppThemeOptions): string => {
+  const props = { theme };
+  const colors = getColors(props);
+  const shadows = getShadows(props);
+  const spacings = getSpacings(props);
+
+  return css`
+    ${fontBodyXs(props)}
+
+    background-color: white;
+    border: 1px solid ${colors?.gray["300"]};
+    box-shadow: ${shadows?.m};
+    color: black;
+    padding: ${spacings?.l}px;
+  `;
+};
+
+export const arrowCss = (theme: AppThemeOptions): string => {
+  const props = { theme };
+  const colors = getColors(props);
+
+  return css`
+    color: white;
+    &:before {
+      border: 1px solid ${colors?.gray[300]};
+    }
+  `;
+};

--- a/src/core/Tooltip/style.ts
+++ b/src/core/Tooltip/style.ts
@@ -7,7 +7,10 @@ import {
   getSpacings,
 } from "../styles";
 
-export const tooltipCss = (theme: AppThemeOptions): string => {
+export const tooltipCss = (
+  { inverted = false },
+  theme: AppThemeOptions
+): string => {
   const props = { theme };
   const colors = getColors(props);
   const shadows = getShadows(props);
@@ -16,20 +19,23 @@ export const tooltipCss = (theme: AppThemeOptions): string => {
   return css`
     ${fontBodyXs(props)}
 
-    background-color: white;
+    background-color: ${inverted ? "black" : "white"};
     border: 1px solid ${colors?.gray["300"]};
     box-shadow: ${shadows?.m};
-    color: black;
+    color: ${inverted ? "white" : "black"};
     padding: ${spacings?.l}px;
   `;
 };
 
-export const arrowCss = (theme: AppThemeOptions): string => {
+export const arrowCss = (
+  { inverted = false },
+  theme: AppThemeOptions
+): string => {
   const props = { theme };
   const colors = getColors(props);
 
   return css`
-    color: white;
+    color: ${inverted ? "black" : "white"};
     &:before {
       border: 1px solid ${colors?.gray[300]};
     }

--- a/src/core/Tooltip/style.ts
+++ b/src/core/Tooltip/style.ts
@@ -1,17 +1,19 @@
 import { css } from "@emotion/css";
 import {
-  AppThemeOptions,
   fontBodyXs,
   getColors,
   getShadows,
   getSpacings,
+  Props,
 } from "../styles";
 
-export const tooltipCss = (
-  { inverted = false },
-  theme: AppThemeOptions
-): string => {
-  const props = { theme };
+export interface ExtraProps extends Props {
+  inverted?: boolean;
+}
+
+export const tooltipCss = (props: ExtraProps): string => {
+  const { inverted } = props;
+
   const colors = getColors(props);
   const shadows = getShadows(props);
   const spacings = getSpacings(props);
@@ -27,11 +29,9 @@ export const tooltipCss = (
   `;
 };
 
-export const arrowCss = (
-  { inverted = false },
-  theme: AppThemeOptions
-): string => {
-  const props = { theme };
+export const arrowCss = (props: ExtraProps): string => {
+  const { inverted } = props;
+
   const colors = getColors(props);
 
   return css`

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export { default as MenuItem } from "./core/MenuItem";
 export * from "./core/styles";
 export * from "./core/Tabs";
 export { default as Tabs } from "./core/Tabs";
+export * from "./core/Tooltip";


### PR DESCRIPTION
Adds `Tooltip`, with inverted options. White (info) by default, black for action tooltip.

~~**Design Link:** https://chanzuckerberg.invisionapp.com/console/share/UWVLU4OH37F/511021232/play~~
**Design Link (updated):** https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=642%3A4116

Default white info tooltip:
![image](https://user-images.githubusercontent.com/53838890/117222719-fb842680-adc0-11eb-89fb-aa945acc8e35.png)

Inverted black action tooltip:
![image](https://user-images.githubusercontent.com/53838890/117359436-44dd8000-ae6c-11eb-80f3-f9bdabd7ff49.png)