### PR TITLE
thuang-tooltip-merge-classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.28",
+  "version": "0.0.31",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {

--- a/src/core/Menu/index.tsx
+++ b/src/core/Menu/index.tsx
@@ -16,9 +16,9 @@ export { MenuProps };
 const Menu = (props: MenuProps): JSX.Element => {
   return (
     <RawMenu
+      {...props}
       anchorOrigin={ANCHOR_ORIGIN}
       transformOrigin={TRANSFORM_ORIGIN}
-      {...props}
     />
   );
 };

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -8,7 +8,7 @@ const tooltipContent =
 
 const Demo = (props: Args): JSX.Element => {
   return (
-    <Tooltip title={tooltipContent} {...props}>
+    <Tooltip {...props} title={tooltipContent}>
       <InfoOutlinedIcon />
     </Tooltip>
   );

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@emotion/react";
 import {
   Tooltip as RawTooltip,
+  TooltipClassKey,
   TooltipProps as RawTooltipProps,
 } from "@material-ui/core";
 import React from "react";
@@ -22,11 +23,38 @@ const Tooltip = (props: TooltipProps): JSX.Element => {
     /* stylelint-enable property-no-unknown -- false positive */
   };
 
-  const tooltip = tooltipCss(extraProps);
-  const arrow = arrowCss(extraProps);
+  const tooltip = mergeClass({
+    className: tooltipCss(extraProps),
+    key: "tooltip",
+    props,
+  });
 
-  return <RawTooltip arrow classes={{ arrow, tooltip }} {...rest} />;
+  const arrow = mergeClass({
+    className: arrowCss(extraProps),
+    key: "arrow",
+    props,
+  });
+
+  return <RawTooltip {...rest} arrow classes={{ arrow, tooltip }} />;
 };
+
+function mergeClass({
+  props,
+  className,
+  key,
+}: {
+  props: TooltipProps;
+  className: string;
+  key: TooltipClassKey;
+}) {
+  const { classes } = props;
+
+  if (!classes) return className;
+
+  const propClassName = classes[key];
+
+  return propClassName ? `${propClassName} ${className}` : className;
+}
 
 Tooltip.defaultProps = {
   inverted: false,

--- a/src/core/Tooltip/style.ts
+++ b/src/core/Tooltip/style.ts
@@ -36,6 +36,7 @@ export const arrowCss = (props: ExtraProps): string => {
 
   return css`
     color: ${inverted ? "black" : "white"};
+
     &:before {
       border: 1px solid ${colors?.gray[300]};
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export * from "./core/styles";
 export * from "./core/Tabs";
 export { default as Tabs } from "./core/Tabs";
 export * from "./core/Tooltip";
+export { default as Tooltip } from "./core/Tooltip";


### PR DESCRIPTION
I had to add code to merge class names, so Aspen can also add `classes` prop to our Tooltip. Otherwise Aspen's `classes` will overwrite component library's `classes` 

E.g.,

```tsx
const arrow = css`
  left: 0 !important;
`;

<Tooltip
  classes={{ arrow }} // <--- THIS!
  title={LINEAGE_TOOLTIP_TEXT}
  placement="bottom-start"
>
  <div className={dataTableStyle.headerCellContent}>{header.text}</div>
</Tooltip>
```