### PR TITLE
add Chips and export fontCaps mixins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-use-before-define": "off",
+    "consistent-return": "off",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.31",
+  "version": "0.0.33",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {

--- a/src/core/Chip/index.stories.tsx
+++ b/src/core/Chip/index.stories.tsx
@@ -1,0 +1,56 @@
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import Chip from "./index";
+
+const Demo = (props: Args): JSX.Element => {
+  return <Chip size="small" label="default small" {...props} />;
+};
+
+export default {
+  component: Demo,
+  title: "Chip",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Success = Template.bind({});
+
+Success.args = {
+  label: "success",
+  status: "success",
+};
+
+export const Error = Template.bind({});
+
+Error.args = {
+  label: "error",
+  status: "error",
+};
+
+export const Warning = Template.bind({});
+
+Warning.args = {
+  label: "warning",
+  status: "warning",
+};
+
+export const Info = Template.bind({});
+
+Info.args = {
+  label: "info",
+  status: "info",
+};
+
+export const Pending = Template.bind({});
+
+Pending.args = {
+  label: "pending",
+  status: "pending",
+};
+
+export const Beta = Template.bind({});
+
+Beta.args = {
+  label: "beta",
+  status: "beta",
+};

--- a/src/core/Chip/index.tsx
+++ b/src/core/Chip/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { ExtraProps, StyledChip } from "./style";
+
+type ChipProps = ExtraProps;
+
+export { ChipProps };
+
+const Chip = (props: ChipProps): JSX.Element => {
+  return <StyledChip {...props} />;
+};
+
+export default Chip;

--- a/src/core/Chip/style.ts
+++ b/src/core/Chip/style.ts
@@ -1,0 +1,124 @@
+import { css, SerializedStyles } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Chip, ChipProps } from "@material-ui/core";
+import {
+  fontCapsXxxxs,
+  getColors,
+  getCorners,
+  getSpacings,
+  Props,
+} from "../styles";
+
+export interface ExtraProps extends Props, ChipProps {
+  status?: "success" | "error" | "warning" | "info" | "pending" | "beta";
+}
+
+const small = (props: ExtraProps): SerializedStyles => {
+  const spacings = getSpacings(props);
+
+  return css`
+    height: ${spacings?.l}px;
+    padding: ${spacings?.xxs}px ${spacings?.xs}px;
+
+    .MuiChip-label {
+      ${fontCapsXxxxs(props)}
+      padding: 0;
+    }
+  `;
+};
+
+const success = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "success");
+};
+
+const error = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "error");
+};
+
+const beta = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "beta");
+};
+
+const pending = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "pending");
+};
+
+const warning = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "warning");
+};
+
+const info = (props: ExtraProps): SerializedStyles | undefined => {
+  return createStatusCss(props, "info");
+};
+
+function createStatusCss(
+  props: ExtraProps,
+  status: NonNullable<ExtraProps["status"]>
+): SerializedStyles | undefined {
+  const colors = getColors(props);
+
+  if (!colors) return;
+
+  const statusToColors = {
+    beta: {
+      dark: colors.beta[600],
+      light: colors.beta[200],
+    },
+    error: {
+      dark: colors.error[600],
+      light: colors.error[200],
+    },
+    info: {
+      dark: colors.info[600],
+      light: colors.info[200],
+    },
+    pending: {
+      dark: colors.gray[600],
+      light: colors.gray[200],
+    },
+    success: {
+      dark: colors.success[600],
+      light: colors.success[200],
+    },
+    warning: {
+      dark: colors.warning[600],
+      light: colors.warning[200],
+    },
+  };
+
+  const statusColors = statusToColors[status];
+
+  return css`
+    background-color: ${statusColors.light};
+
+    .MuiChip-label {
+      color: ${statusColors.dark};
+    }
+  `;
+}
+
+const statusToCss = {
+  beta,
+  error,
+  info,
+  pending,
+  success,
+  warning,
+};
+
+export const StyledChip = styled(Chip)`
+  color: white;
+
+  ${(props: ExtraProps) => {
+    const { size, status } = props;
+
+    const corners = getCorners(props);
+
+    return css`
+      border-radius: ${corners?.l}px;
+
+      ${size === "small" && small(props)}
+      ${status && statusToCss[status](props)}
+    `;
+  }}
+`;

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import { Args, Story } from "@storybook/react";
 import React from "react";
@@ -31,4 +32,14 @@ export const Info = Template.bind({});
 
 Info.args = {
   inverted: false,
+};
+
+export const StyledArrow = Template.bind({});
+
+const arrow = css`
+  left: 0 !important;
+`;
+
+StyledArrow.args = {
+  classes: { arrow },
 };

--- a/src/core/styles/common/mixins/fonts.ts
+++ b/src/core/styles/common/mixins/fonts.ts
@@ -26,6 +26,29 @@ export const fontBodyXs = fontBody("xs");
 export const fontBodyXxs = fontBody("xxs");
 export const fontBodyXxxs = fontBody("xxxs");
 
+type FontCapsSize = keyof Typography["styles"]["caps"];
+
+export const fontCaps = (fontSize: FontCapsSize) => {
+  return (props: Props): SerializedStyles | null => {
+    const typography = getTypography(props);
+
+    if (!typography) return null;
+
+    const {
+      styles: { caps },
+    } = typography;
+
+    return css`
+      ${themeToCss(caps[fontSize])}
+      text-transform: uppercase;
+    `;
+  };
+};
+
+export const fontCapsXxs = fontCaps("xxs");
+export const fontCapsXxxs = fontCaps("xxxs");
+export const fontCapsXxxxs = fontCaps("xxxxs");
+
 type FontHeaderSize = keyof Typography["styles"]["header"];
 
 export const fontHeader = (fontSize: FontHeaderSize) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/export */
 export { default as Button } from "./core/Button";
 export { default as Checkbox } from "./core/Checkbox";
+export * from "./core/Chip";
+export { default as Chip } from "./core/Chip";
 export * from "./core/Link";
 export { default as Link } from "./core/Link";
 export * from "./core/List";


### PR DESCRIPTION
1. Add chip (or tag as called in our design system)
2. Export `fontCaps` mixins
3. Add Tooltip styling arrow example 

<img width="91" alt="Screen Shot 2021-05-10 at 10 08 46 AM" src="https://user-images.githubusercontent.com/6309723/117716183-22aa7180-b18e-11eb-962d-67d80b939323.png">
<img width="72" alt="Screen Shot 2021-05-10 at 10 08 50 AM" src="https://user-images.githubusercontent.com/6309723/117716185-23430800-b18e-11eb-9b01-b99527f4d484.png">
<img width="95" alt="Screen Shot 2021-05-10 at 10 08 53 AM" src="https://user-images.githubusercontent.com/6309723/117716188-23db9e80-b18e-11eb-9437-87fc517014b5.png">
<img width="74" alt="Screen Shot 2021-05-10 at 10 08 55 AM" src="https://user-images.githubusercontent.com/6309723/117716194-23db9e80-b18e-11eb-8ca7-a8418d6cccf3.png">
<img width="92" alt="Screen Shot 2021-05-10 at 12 50 21 PM" src="https://user-images.githubusercontent.com/6309723/117716335-4ff71f80-b18e-11eb-8811-f4fc84fb3ba7.png">
<img width="83" alt="Screen Shot 2021-05-10 at 12 50 24 PM" src="https://user-images.githubusercontent.com/6309723/117716339-51284c80-b18e-11eb-8022-1667a509ca3f.png">

![demo](https://user-images.githubusercontent.com/6309723/117716393-62715900-b18e-11eb-8072-3c4686273156.gif)

