### PR TITLE
Add TooltipTable (content) and stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -52,13 +52,13 @@ const rows = [
 
 const data = [
   {
-    label: "Section 1",
     dataRows: rows.slice(0, 3),
+    label: "Section 1",
   },
   {
-    label: "Section 2",
     dataRows: rows.slice(3, 9),
     disabled: true,
+    label: "Section 2",
   },
 ];
 

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -2,14 +2,16 @@ import { css } from "@emotion/css";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import { Args, Story } from "@storybook/react";
 import React from "react";
+import TooltipTableContent from "../TooltipTableContent/index";
 import Tooltip from "./index";
 
 const tooltipContent =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 const Demo = (props: Args): JSX.Element => {
+  const { title } = props;
   return (
-    <Tooltip {...props} title={tooltipContent}>
+    <Tooltip title={title} {...props}>
       <InfoOutlinedIcon />
     </Tooltip>
   );
@@ -26,12 +28,46 @@ export const Action = Template.bind({});
 
 Action.args = {
   inverted: true,
+  title: tooltipContent,
 };
 
 export const Info = Template.bind({});
 
 Info.args = {
   inverted: false,
+  title: tooltipContent,
+};
+
+const rows = [
+  { label: "Sample", value: "Sample Name" },
+  { label: "Name", value: "Taxon Name" },
+  { label: "Category", value: "Species" },
+  { label: "NT Z Score", value: 100 },
+  { label: "NT rPM", value: 200 },
+  { label: "NT r (total reads)", value: 333 },
+  { label: "NR Z Score", value: 404 },
+  { label: "NR rPM", value: 524 },
+  { label: "NR r (total reads)", value: 600 },
+];
+
+const data = [
+  {
+    label: "Section 1",
+    dataRows: rows.slice(0, 3),
+  },
+  {
+    label: "Section 2",
+    dataRows: rows.slice(3, 9),
+    disabled: true,
+  },
+];
+
+const alert = "Some values do not pass the selected filters.";
+
+export const Table = Template.bind({});
+
+Table.args = {
+  title: <TooltipTableContent alert={alert} data={data} />,
 };
 
 export const StyledArrow = Template.bind({});

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -35,7 +35,9 @@ const Tooltip = (props: TooltipProps): JSX.Element => {
     props,
   });
 
-  return <RawTooltip {...rest} arrow classes={{ arrow, tooltip }} />;
+  return (
+    <RawTooltip arrow classes={{ arrow, tooltip }} interactive {...rest} />
+  );
 };
 
 function mergeClass({

--- a/src/core/TooltipTableContent/index.stories.tsx
+++ b/src/core/TooltipTableContent/index.stories.tsx
@@ -17,12 +17,12 @@ const rows = [
 
 const data = [
   {
-    label: "Section 1",
     dataRows: rows.slice(0, 5),
+    label: "Section 1",
   },
   {
-    label: "Section 2",
     dataRows: rows.slice(5, 10),
+    label: "Section 2",
   },
 ];
 
@@ -40,6 +40,6 @@ const Template: Story = (args) => <Demo {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  data: data,
-  alert: alert,
+  alert,
+  data,
 };

--- a/src/core/TooltipTableContent/index.stories.tsx
+++ b/src/core/TooltipTableContent/index.stories.tsx
@@ -2,26 +2,27 @@ import { Args, Story } from "@storybook/react";
 import React from "react";
 import TooltipTableContent from "./index";
 
-function createDataRow(label: any, value: any) {
-  return { label, value };
-}
-
 const rows = [
-  createDataRow("Frozen yoghurt", 159),
-  createDataRow("Ice cream sandwich", 237),
-  createDataRow("Eclair", 262),
-  createDataRow("Cupcake", 305),
-  createDataRow("Gingerbread", 356),
+  { label: "Harley Thomas", value: 1 },
+  { label: "Janeece Pourroy", value: 2 },
+  { label: "Jennifer Tang", value: 3 },
+  { label: "Jonathan Sheu", value: 4 },
+  { label: "Julie Han", value: 5 },
+  { label: "Katrina Kalantar", value: 6 },
+  { label: "Omar Valenzuela", value: 7 },
+  { label: "Seve Badajoz", value: 8 },
+  { label: "Tiago Carvalho", value: 9 },
+  { label: "Timmy Huang", value: 10 },
 ];
 
 const data = [
   {
     label: "Section 1",
-    dataRows: rows,
+    dataRows: rows.slice(0, 5),
   },
   {
     label: "Section 2",
-    dataRows: rows,
+    dataRows: rows.slice(5, 10),
   },
 ];
 

--- a/src/core/TooltipTableContent/index.stories.tsx
+++ b/src/core/TooltipTableContent/index.stories.tsx
@@ -1,0 +1,44 @@
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import TooltipTableContent from "./index";
+
+function createDataRow(label: any, value: any) {
+  return { label, value };
+}
+
+const rows = [
+  createDataRow("Frozen yoghurt", 159),
+  createDataRow("Ice cream sandwich", 237),
+  createDataRow("Eclair", 262),
+  createDataRow("Cupcake", 305),
+  createDataRow("Gingerbread", 356),
+];
+
+const data = [
+  {
+    label: "Section 1",
+    dataRows: rows,
+  },
+  {
+    label: "Section 2",
+    dataRows: rows,
+  },
+];
+
+const Demo = (props: Args): JSX.Element => {
+  return <TooltipTableContent {...props} />;
+};
+
+export default {
+  component: Demo,
+  title: "TooltipTableContent",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  data: data,
+  alert: alert,
+};

--- a/src/core/TooltipTableContent/index.tsx
+++ b/src/core/TooltipTableContent/index.tsx
@@ -26,7 +26,9 @@ const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
   const theme = useTheme();
 
   const extraProps = {
+    /* stylelint-disable property-no-unknown -- false positive */
     theme,
+    /* stylelint-enable property-no-unknown -- false positive */
   };
 
   const alertClassName = alertCss(extraProps);

--- a/src/core/TooltipTableContent/index.tsx
+++ b/src/core/TooltipTableContent/index.tsx
@@ -1,0 +1,75 @@
+import { useTheme } from "@emotion/react";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableRow from "@material-ui/core/TableRow";
+import cx from "classnames";
+import React from "react";
+import {
+  alertCss,
+  disabledCss,
+  ExtraProps,
+  rowLabelCss,
+  rowValueCss,
+  sectionCss,
+  sectionLabelCss,
+} from "./style";
+
+type TooltipTableContentProps = ExtraProps;
+
+export { TooltipTableContentProps };
+
+const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
+  const { alert, data, ...rest } = props;
+
+  const theme = useTheme();
+
+  const extraProps = {
+    theme,
+  };
+
+  const alertClassName = alertCss(extraProps);
+  const disabled = disabledCss(extraProps);
+  const sectionClassName = sectionCss(extraProps);
+  const sectionLabel = sectionLabelCss(extraProps);
+  const rowLabel = rowLabelCss(extraProps);
+  const rowValue = rowValueCss(extraProps);
+
+  return (
+    <TableContainer {...rest}>
+      {alert && <div className={alertClassName}>{alert}</div>}
+      {data?.map((section) => (
+        <div
+          className={cx(sectionClassName, section.disabled && disabled)}
+          key={`${section.label}`}
+        >
+          <div className={cx(sectionLabel, section.disabled && disabled)}>
+            {section.label}
+          </div>
+          <Table size="small">
+            <TableBody>
+              {section.dataRows.map((row) => (
+                <TableRow key={row.label}>
+                  <TableCell
+                    className={cx(rowLabel, section.disabled && disabled)}
+                  >
+                    {row.label}
+                  </TableCell>
+                  <TableCell
+                    className={cx(rowValue, section.disabled && disabled)}
+                    align="left"
+                  >
+                    {row.value}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ))}
+    </TableContainer>
+  );
+};
+
+export default TooltipTableContent;

--- a/src/core/TooltipTableContent/index.tsx
+++ b/src/core/TooltipTableContent/index.tsx
@@ -1,19 +1,15 @@
-import { useTheme } from "@emotion/react";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
-import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableRow from "@material-ui/core/TableRow";
-import cx from "classnames";
 import React from "react";
 import {
-  alertCss,
-  disabledCss,
+  Alert,
   ExtraProps,
-  rowLabelCss,
-  rowValueCss,
-  sectionCss,
-  sectionLabelCss,
+  RowLabel,
+  RowValue,
+  Section,
+  SectionLabel,
 } from "./style";
 
 type TooltipTableContentProps = ExtraProps;
@@ -23,52 +19,27 @@ export { TooltipTableContentProps };
 const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
   const { alert, data, ...rest } = props;
 
-  const theme = useTheme();
-
-  const extraProps = {
-    /* stylelint-disable property-no-unknown -- false positive */
-    theme,
-    /* stylelint-enable property-no-unknown -- false positive */
-  };
-
-  const alertClassName = alertCss(extraProps);
-  const disabled = disabledCss(extraProps);
-  const sectionClassName = sectionCss(extraProps);
-  const sectionLabel = sectionLabelCss(extraProps);
-  const rowLabel = rowLabelCss(extraProps);
-  const rowValue = rowValueCss(extraProps);
-
   return (
     <TableContainer {...rest}>
-      {alert && <div className={alertClassName}>{alert}</div>}
+      {alert && <Alert>{alert}</Alert>}
       {data?.map((section) => (
-        <div
-          className={cx(sectionClassName, section.disabled && disabled)}
-          key={`${section.label}`}
-        >
-          <div className={cx(sectionLabel, section.disabled && disabled)}>
+        <Section disabled={section.disabled} key={`${section.label}`}>
+          <SectionLabel disabled={section.disabled}>
             {section.label}
-          </div>
+          </SectionLabel>
           <Table size="small">
             <TableBody>
               {section.dataRows.map((row) => (
                 <TableRow key={row.label}>
-                  <TableCell
-                    className={cx(rowLabel, section.disabled && disabled)}
-                  >
-                    {row.label}
-                  </TableCell>
-                  <TableCell
-                    className={cx(rowValue, section.disabled && disabled)}
-                    align="left"
-                  >
+                  <RowLabel disabled={section.disabled}>{row.label}</RowLabel>
+                  <RowValue disabled={section.disabled} align="left">
                     {row.value}
-                  </TableCell>
+                  </RowValue>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
-        </div>
+        </Section>
       ))}
     </TableContainer>
   );

--- a/src/core/TooltipTableContent/style.ts
+++ b/src/core/TooltipTableContent/style.ts
@@ -1,0 +1,82 @@
+import { css } from "@emotion/css";
+import {
+  fontBodyXs,
+  fontBodyXxs,
+  fontCapsXxxxs,
+  fontHeaderXs,
+  getColors,
+  getSpacings,
+  Props,
+} from "../styles";
+
+export interface ExtraProps extends Props {
+  data?: Array<{
+    label: string;
+    dataRows: {
+      label: any;
+      value: any;
+    }[];
+    disabled?: boolean;
+  }>;
+  alert?: string | Element;
+}
+
+export const alertCss = (props: ExtraProps): string => {
+  return css`
+    ${fontBodyXxs(props)};
+  `;
+};
+
+export const disabledCss = (props: ExtraProps): string => {
+  const colors = getColors(props);
+
+  return css`
+    color: ${colors?.gray["300"]};
+  `;
+};
+
+export const sectionCss = (props: ExtraProps): string => {
+  const colors = getColors(props);
+  const spacings = getSpacings(props);
+
+  return css`
+    &:not(:last-child) {
+      padding-bottom: ${spacings?.l}px;
+      border-bottom: 1px solid ${colors?.gray["200"]};
+    }
+
+    &:not(:first-child) {
+      padding-top: ${spacings?.l}px;
+    }
+  `;
+};
+
+export const sectionLabelCss = (props: ExtraProps): string => {
+  const colors = getColors(props);
+  const spacings = getSpacings(props);
+
+  return css`
+    ${fontCapsXxxxs(props)};
+    margin-bottom: ${spacings?.m}px;
+    color: ${colors?.gray["500"]};
+
+    &.disabled {
+      color: ${colors?.gray["300"]};
+    }
+  `;
+};
+
+export const rowLabelCss = (props: ExtraProps): string => {
+  return css`
+    ${fontHeaderXs(props)};
+    padding: 0;
+  `;
+};
+
+export const rowValueCss = (props: ExtraProps): string => {
+  return css`
+    ${fontBodyXs(props)};
+    padding-top: 0;
+    padding-bottom: 0;
+  `;
+};

--- a/src/core/TooltipTableContent/style.ts
+++ b/src/core/TooltipTableContent/style.ts
@@ -23,7 +23,7 @@ export interface ExtraProps extends Props {
 
 export const alertCss = (props: ExtraProps): string => {
   return css`
-    ${fontBodyXxs(props)};
+    ${fontBodyXxs(props)}
   `;
 };
 
@@ -56,7 +56,7 @@ export const sectionLabelCss = (props: ExtraProps): string => {
   const spacings = getSpacings(props);
 
   return css`
-    ${fontCapsXxxxs(props)};
+    ${fontCapsXxxxs(props)}
     margin-bottom: ${spacings?.m}px;
     color: ${colors?.gray["500"]};
 
@@ -68,7 +68,7 @@ export const sectionLabelCss = (props: ExtraProps): string => {
 
 export const rowLabelCss = (props: ExtraProps): string => {
   return css`
-    ${fontHeaderXs(props)};
+    ${fontHeaderXs(props)}
     padding: 0;
     width: 50%;
   `;
@@ -76,7 +76,7 @@ export const rowLabelCss = (props: ExtraProps): string => {
 
 export const rowValueCss = (props: ExtraProps): string => {
   return css`
-    ${fontBodyXs(props)};
+    ${fontBodyXs(props)}
     padding-top: 0;
     padding-bottom: 0;
   `;

--- a/src/core/TooltipTableContent/style.ts
+++ b/src/core/TooltipTableContent/style.ts
@@ -70,6 +70,7 @@ export const rowLabelCss = (props: ExtraProps): string => {
   return css`
     ${fontHeaderXs(props)};
     padding: 0;
+    width: 50%;
   `;
 };
 

--- a/src/core/TooltipTableContent/style.ts
+++ b/src/core/TooltipTableContent/style.ts
@@ -22,7 +22,7 @@ export interface ExtraProps extends Props {
   alert?: string | Element;
 }
 
-export const disabled = (props: SectionProps): string => {
+export const disabledStyle = (props: SectionProps): string => {
   const colors = getColors(props);
   const { disabled } = props;
 
@@ -38,7 +38,7 @@ interface SectionProps extends Props {
 }
 
 export const Section = styled.div`
-  ${disabled}
+  ${disabledStyle}
 
   ${(props: SectionProps) => {
     const colors = getColors(props);
@@ -59,7 +59,7 @@ export const Section = styled.div`
 
 export const SectionLabel = styled.div`
   ${fontCapsXxxxs}
-  ${disabled}
+  ${disabledStyle}
 
   ${(props: SectionProps) => {
     const colors = getColors(props);
@@ -74,7 +74,7 @@ export const SectionLabel = styled.div`
 
 export const RowLabel = styled(TableCell)`
   ${fontHeaderXs}
-  ${disabled}
+  ${disabledStyle}
 
   padding: 0;
   width: 50%;
@@ -82,7 +82,7 @@ export const RowLabel = styled(TableCell)`
 
 export const RowValue = styled(TableCell)`
   ${fontBodyXs}
-  ${disabled}
+  ${disabledStyle}
 
   padding-top: 0;
   padding-bottom: 0;

--- a/src/core/TooltipTableContent/style.ts
+++ b/src/core/TooltipTableContent/style.ts
@@ -1,4 +1,5 @@
-import { css } from "@emotion/css";
+import styled from "@emotion/styled";
+import { TableCell } from "@material-ui/core";
 import {
   fontBodyXs,
   fontBodyXxs,
@@ -13,71 +14,80 @@ export interface ExtraProps extends Props {
   data?: Array<{
     label: string;
     dataRows: {
-      label: any;
-      value: any;
+      label: string;
+      value: string | number;
     }[];
     disabled?: boolean;
   }>;
   alert?: string | Element;
 }
 
-export const alertCss = (props: ExtraProps): string => {
-  return css`
-    ${fontBodyXxs(props)}
-  `;
-};
-
-export const disabledCss = (props: ExtraProps): string => {
+export const disabled = (props: SectionProps): string => {
   const colors = getColors(props);
+  const { disabled } = props;
 
-  return css`
+  if (!disabled) return "";
+
+  return `
     color: ${colors?.gray["300"]};
   `;
 };
 
-export const sectionCss = (props: ExtraProps): string => {
-  const colors = getColors(props);
-  const spacings = getSpacings(props);
+interface SectionProps extends Props {
+  disabled?: boolean;
+}
 
-  return css`
-    &:not(:last-child) {
-      padding-bottom: ${spacings?.l}px;
-      border-bottom: 1px solid ${colors?.gray["200"]};
-    }
+export const Section = styled.div`
+  ${disabled}
 
-    &:not(:first-child) {
-      padding-top: ${spacings?.l}px;
-    }
-  `;
-};
+  ${(props: SectionProps) => {
+    const colors = getColors(props);
+    const spacings = getSpacings(props);
 
-export const sectionLabelCss = (props: ExtraProps): string => {
-  const colors = getColors(props);
-  const spacings = getSpacings(props);
+    return `
+      &:not(:last-child) {
+        padding-bottom: ${spacings?.l}px;
+        border-bottom: 1px solid ${colors?.gray["200"]};
+      }
 
-  return css`
-    ${fontCapsXxxxs(props)}
-    margin-bottom: ${spacings?.m}px;
-    color: ${colors?.gray["500"]};
+      &:not(:first-child) {
+        padding-top: ${spacings?.l}px;
+      }
+    `;
+  }}
+`;
 
-    &.disabled {
-      color: ${colors?.gray["300"]};
-    }
-  `;
-};
+export const SectionLabel = styled.div`
+  ${fontCapsXxxxs}
+  ${disabled}
 
-export const rowLabelCss = (props: ExtraProps): string => {
-  return css`
-    ${fontHeaderXs(props)}
-    padding: 0;
-    width: 50%;
-  `;
-};
+  ${(props: SectionProps) => {
+    const colors = getColors(props);
+    const spacings = getSpacings(props);
 
-export const rowValueCss = (props: ExtraProps): string => {
-  return css`
-    ${fontBodyXs(props)}
-    padding-top: 0;
-    padding-bottom: 0;
-  `;
-};
+    return `
+      margin-bottom: ${spacings?.m}px;
+      color: ${colors?.gray["500"]};
+    `;
+  }}
+`;
+
+export const RowLabel = styled(TableCell)`
+  ${fontHeaderXs}
+  ${disabled}
+
+  padding: 0;
+  width: 50%;
+`;
+
+export const RowValue = styled(TableCell)`
+  ${fontBodyXs}
+  ${disabled}
+
+  padding-top: 0;
+  padding-bottom: 0;
+`;
+
+export const Alert = styled.div`
+  ${fontBodyXxs}
+`;

--- a/src/core/styles/common/mixins/fonts.ts
+++ b/src/core/styles/common/mixins/fonts.ts
@@ -74,26 +74,6 @@ export const fontHeaderXs = fontHeader("xs");
 export const fontHeaderXxs = fontHeader("xxs");
 export const fontHeaderXxxs = fontHeader("xxxs");
 
-type FontCapsSize = keyof Typography["styles"]["caps"];
-
-export const fontCaps = (fontSize: FontCapsSize) => {
-  return (props: Props): SerializedStyles | null => {
-    const typography = getTypography(props);
-
-    if (!typography) return null;
-
-    const {
-      styles: { caps },
-    } = typography;
-
-    return themeToCss(caps[fontSize]);
-  };
-};
-
-export const fontCapsXxs = fontCaps("xxs");
-export const fontCapsXxxs = fontCaps("xxxs");
-export const fontCapsXxxxs = fontCaps("xxxxs");
-
 function themeToCss(fontTheme: TypographyStyle) {
   return css`
     font-size: ${fontTheme.fontSize}px;

--- a/src/core/styles/common/mixins/fonts.ts
+++ b/src/core/styles/common/mixins/fonts.ts
@@ -74,11 +74,32 @@ export const fontHeaderXs = fontHeader("xs");
 export const fontHeaderXxs = fontHeader("xxs");
 export const fontHeaderXxxs = fontHeader("xxxs");
 
+type FontCapsSize = keyof Typography["styles"]["caps"];
+
+export const fontCaps = (fontSize: FontCapsSize) => {
+  return (props: Props): SerializedStyles | null => {
+    const typography = getTypography(props);
+
+    if (!typography) return null;
+
+    const {
+      styles: { caps },
+    } = typography;
+
+    return themeToCss(caps[fontSize]);
+  };
+};
+
+export const fontCapsXxs = fontCaps("xxs");
+export const fontCapsXxxs = fontCaps("xxxs");
+export const fontCapsXxxxs = fontCaps("xxxxs");
+
 function themeToCss(fontTheme: TypographyStyle) {
   return css`
     font-size: ${fontTheme.fontSize}px;
     line-height: ${fontTheme.lineHeight};
     letter-spacing: ${fontTheme.letterSpacing};
     font-weight: ${fontTheme.fontWeight};
+    text-transform: ${fontTheme.textTransform};
   `;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,5 @@ export * from "./core/Tabs";
 export { default as Tabs } from "./core/Tabs";
 export * from "./core/Tooltip";
 export { default as Tooltip } from "./core/Tooltip";
+export * from "./core/TooltipTableContent";
+export { default as TooltipTableContent } from "./core/TooltipTableContent";


### PR DESCRIPTION
Adds the TooltipTableContent component and shows an example of how to pass it in to the Tooltip component.

I decided to make the content its own component since in IDseq, we have this tooltip follow the user's cursor. (The table is passed in to `ReactDOM.createPortal()`

I also added the option to include a short message/alert and to disable sections of the table contents. We use this in IDseq in the heatmap:
**Example from current IDseq**
![image](https://user-images.githubusercontent.com/53838890/117733603-b0925680-b1a6-11eb-8a35-4374ad23e94c.png)

**Design link:** https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=642%3A4116


**Base `TooltipTableContent` example:**
![image](https://user-images.githubusercontent.com/53838890/117733493-7fb22180-b1a6-11eb-8b66-cb173454ed1e.png)

**`TooltipTable` example:**
![image](https://user-images.githubusercontent.com/53838890/117733509-86d92f80-b1a6-11eb-9d16-c8f20827045e.png)
