### PR TITLE
thuang-tooltip-optional-arrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -27,6 +27,7 @@ const Template: Story = (args) => <Demo {...args} />;
 export const Action = Template.bind({});
 
 Action.args = {
+  arrow: true,
   inverted: true,
   title: tooltipContent,
 };
@@ -34,6 +35,7 @@ Action.args = {
 export const Info = Template.bind({});
 
 Info.args = {
+  arrow: true,
   inverted: false,
   title: tooltipContent,
 };
@@ -77,5 +79,7 @@ const arrow = css`
 `;
 
 StyledArrow.args = {
+  arrow: true,
   classes: { arrow },
+  title: tooltipContent,
 };

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -35,9 +35,9 @@ const Tooltip = (props: TooltipProps): JSX.Element => {
     props,
   });
 
-  return (
-    <RawTooltip arrow classes={{ arrow, tooltip }} interactive {...rest} />
-  );
+  // (thuang): {...rest} needs to be first, otherwise it will overwrite latter
+  // props
+  return <RawTooltip {...rest} interactive classes={{ arrow, tooltip }} />;
 };
 
 function mergeClass({


### PR DESCRIPTION
Make Tooltip `arrow` optional, since TableTooltip doesn't need the arrow 😄 

Thank you!

TableTooltip:

<img width="338" alt="Screen Shot 2021-05-11 at 2 45 15 PM" src="https://user-images.githubusercontent.com/6309723/117888895-8eacd880-b267-11eb-9329-a8007a2d4eed.png">

Regular Tooltip:
<img width="376" alt="Screen Shot 2021-05-11 at 2 45 25 PM" src="https://user-images.githubusercontent.com/6309723/117888908-94a2b980-b267-11eb-8333-913a04696864.png">

Styled arrow positioned at `left: 0`:
<img width="361" alt="Screen Shot 2021-05-11 at 2 45 29 PM" src="https://user-images.githubusercontent.com/6309723/117888943-9ff5e500-b267-11eb-83de-07501b89a11c.png">
