### PR TITLE
Thuang add ref to button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -2,6 +2,7 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/react";
 import React from "react";
+import Tooltip from "../Tooltip";
 import Button from "./index";
 
 export const text = "Click me!";
@@ -59,4 +60,17 @@ storiesOf("Button", module).add("startIcon", () => (
   >
     {text}
   </Button>
+));
+
+storiesOf("Button", module).add("with Tooltip", () => (
+  <Tooltip title="tooltip here">
+    <Button
+      variant="contained"
+      startIcon={<DeleteIcon />}
+      onClick={actions.onClick}
+      color="primary"
+    >
+      With Tooltip!
+    </Button>
+  </Tooltip>
 ));

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -6,8 +6,10 @@ export interface ButtonProps extends RawButtonProps {
   isRounded?: boolean;
 }
 
-const Button = (props: ButtonProps): JSX.Element => {
-  return <StyledButton {...props} />;
-};
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref): JSX.Element => {
+    return <StyledButton {...props} ref={ref} />;
+  }
+);
 
 export default Button;


### PR DESCRIPTION
This PR is needed to work with our Tooltip component per https://material-ui.com/components/tooltips/#custom-child-element. Essentially if we supply a child element to Tooltip that's NOT MUI component, we'll need to forward ref 💡 😄 👌 !

PTAL thank you!