### PR TITLE
Fix svg type declaration.

### DIFF
--- a/src/common/types/svg.d.ts
+++ b/src/common/types/svg.d.ts
@@ -3,6 +3,7 @@ interface CustomSVGProps extends React.SVGAttributes<SVGElement> {
 }
 
 declare module "*.svg" {
-  const value: React.FunctionComponent<CustomSVGProps>;
-  export default value;
+  export const ReactComponent: React.FunctionComponent<CustomSVGProps>;
+  const src: string;
+  export default src;
 }

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -1,8 +1,8 @@
 import { CheckboxProps as MUICheckboxProps, SvgIcon } from "@material-ui/core";
 import React from "react";
-import IconCheckboxChecked from "../../common/svgs/IconCheckboxChecked.svg";
-import IconCheckboxIndeterminate from "../../common/svgs/IconCheckboxIndeterminate.svg";
-import IconCheckboxUnchecked from "../../common/svgs/IconCheckboxUnchecked.svg";
+import { ReactComponent as IconCheckboxChecked } from "../../common/svgs/IconCheckboxChecked.svg";
+import { ReactComponent as IconCheckboxIndeterminate } from "../../common/svgs/IconCheckboxIndeterminate.svg";
+import { ReactComponent as IconCheckboxUnchecked } from "../../common/svgs/IconCheckboxUnchecked.svg";
 import { StyledCheckbox } from "./styles";
 
 export interface CheckboxProps


### PR DESCRIPTION
In svgr, the react component is not the default export.  Assuming the default incorrectly was causing storybook not to load.  Now the type definition is accurate and imports need to use `import {ReactComponent as SomeSvgName}...`