### PR TITLE
thuang-fix-rollup-svgr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "czifui",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "repository": {
@@ -17,6 +17,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@rollup/plugin-typescript": "^8.2.0",
+    "@rollup/plugin-url": "^6.1.0",
     "@storybook/addon-actions": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",
     "@storybook/addon-links": "^6.3.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import svgr from "@svgr/rollup";
 import ts from "@wessberg/rollup-plugin-ts";
 import del from "rollup-plugin-delete";
 import pkg from "./package.json";
+import url from "@rollup/plugin-url";
 
 const config = [
   {
@@ -24,6 +25,7 @@ const config = [
       del({
         targets: ["dist/*", "playground/src/components"],
       }),
+      url(),
       svgr(),
       ts(),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,15 @@
     "@rollup/pluginutils" "^3.1.0"
     resolve "^1.17.0"
 
+"@rollup/plugin-url@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-url/-/plugin-url-6.1.0.tgz#1234bba9aa30b5972050bdfcf8fcbb1cb8070465"
+  integrity sha512-FJNWBnBB7nLzbcaGmu1no+U/LlRR67TtgfRFP+VEKSrWlDTE6n9jMns/N4Q/VL6l4x6kTHQX4HQfwTcldaAfHQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    make-dir "^3.1.0"
+    mime "^2.4.6"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -8254,7 +8263,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.4:
+mime@^2.4.4, mime@^2.4.6:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==


### PR DESCRIPTION
This PR adds `@rollup/plugin-url` to mirror our Storybook webpack setup, which uses (svgr and url loader), otherwise `yarn build` will break, because `@rollup/svgr` by default exports the `ReactComponent`, but adding the url loader will set change `ReactComponent` as named export. 

E.g.,

```ts
// Default Import -- without url loader, default export is ReactComponent
import IconCheckboxChecked  from "../../common/svgs/IconCheckboxChecked.svg";

// Named Import -- with url loader, default is the blob url
import { ReactComponent as IconCheckboxChecked } from "../../common/svgs/IconCheckboxChecked.svg";
```

And since before this PR, Webpack uses both svgr and url loader already, storybook wants Named Import, but `yarn build` runs Rollup, which didn't have url loader, so it still wanted Default Import, so we'd get error like:

>[!] Error: 'ReactComponent' is not exported by src/common/svgs/IconCheckboxChecked.svg, imported by src/core/Checkbox/index.tsx

Now both Storybook and Rollup should both work now 🙆‍♂️ 

PTAL thank you!