### PR TITLE
hotfix checkbox alignment

### DIFF
--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -43,11 +43,25 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
     <StyledCheckbox
       {...newProps}
       checkedIcon={
-        <SvgIcon fillContrast="white" component={IconCheckboxChecked} />
+        <SvgIcon
+          fillContrast="white"
+          component={IconCheckboxChecked}
+          viewBox="0 0 16 16"
+        />
       }
-      icon={<SvgIcon fillContrast="white" component={IconCheckboxUnchecked} />}
+      icon={
+        <SvgIcon
+          fillContrast="white"
+          component={IconCheckboxUnchecked}
+          viewBox="0 0 16 16"
+        />
+      }
       indeterminateIcon={
-        <SvgIcon fillContrast="white" component={IconCheckboxIndeterminate} />
+        <SvgIcon
+          fillContrast="white"
+          component={IconCheckboxIndeterminate}
+          viewBox="0 0 16 16"
+        />
       }
     />
   );

--- a/src/core/Checkbox/styles.ts
+++ b/src/core/Checkbox/styles.ts
@@ -1,10 +1,11 @@
 import styled from "@emotion/styled";
 import { Checkbox as RawCheckbox } from "@material-ui/core";
-import { getColors } from "../styles/common/selectors/theme";
+import { getColors, getIconSizes } from "../styles/common/selectors/theme";
 
 export const StyledCheckbox = styled(RawCheckbox)`
   ${(props) => {
     const colors = getColors(props);
+    const iconSizes = getIconSizes(props);
     return `
       color: ${colors?.gray[400]};
       &:hover {
@@ -23,6 +24,11 @@ export const StyledCheckbox = styled(RawCheckbox)`
         &.Mui-disabled {
           color: ${colors?.primary[300]}
         }
+      }
+
+      .MuiSvgIcon-root {
+        height: ${iconSizes?.input.height}px;
+        width: ${iconSizes?.input.width}px;
       }
     `;
   }}

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -113,7 +113,7 @@ export const defaultAppTheme: AppTheme = {
     semibold: 600,
   },
   iconSizes: {
-    input: { height: 16, width: 16 },
+    input: { height: 16, width: 16 }, // for use with input icons only (radio and checkbox)
     l: { height: 22, width: 22 },
     s: { height: 14, width: 14 },
     xl: { height: 32, width: 32 },

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -113,6 +113,7 @@ export const defaultAppTheme: AppTheme = {
     semibold: 600,
   },
   iconSizes: {
+    input: { height: 16, width: 16 },
     l: { height: 22, width: 22 },
     s: { height: 14, width: 14 },
     xl: { height: 32, width: 32 },
@@ -501,6 +502,7 @@ export interface IconSizes {
   s: IconSize;
   l: IconSize;
   xl: IconSize;
+  input: IconSize;
 }
 
 export interface Border {


### PR DESCRIPTION
[ticket link](https://app.clubhouse.io/sci-design-system/story/160102/hotfix-align-label-for-svg-inputs)

See comment [here](https://github.com/chanzuckerberg/sci-components/pull/52#discussion_r703744174). The misalignment on the radio button is also seen on the checkbox icons. 

This ticket adds an input object to the icon size object in the default theme and adds new css rules to ensure the correct size is used for the icon

**Because the checkbox is already implemented, this change could cause shifts in layout once it's released.**

<img width="428" alt="Screen Shot 2021-09-08 at 10 18 16 AM" src="https://user-images.githubusercontent.com/35696944/132526699-ab04d722-ddb0-42ec-a329-1a008a79ccf5.png">
<img width="428" alt="Screen Shot 2021-09-08 at 10 18 24 AM" src="https://user-images.githubusercontent.com/35696944/132526738-81f2bf9d-592b-440c-981a-d45b42aecd42.png">
<img width="428" alt="Screen Shot 2021-09-08 at 10 18 29 AM" src="https://user-images.githubusercontent.com/35696944/132526766-b3caed17-73aa-448a-932e-4f2b1cd8cb1b.png">
