### PR TITLE
tweak styles for minimal input dropdown when open

### DIFF
--- a/src/core/InputDropdown/index.stories.tsx
+++ b/src/core/InputDropdown/index.stories.tsx
@@ -1,17 +1,28 @@
 import { Args, Story } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 import InputDropdown from "./index";
 
 const Demo = (props: Args): JSX.Element => {
-  const { disabled, label, onClick, sdsStyle, ...rest } = props;
+  const { disabled, label, sdsStyle, ...rest } = props;
+
+  const [open, setOpen] = useState<boolean>(false);
+  const onClick = () => {
+    setOpen(!open);
+  };
+
   return (
-    <InputDropdown
-      disabled={disabled}
-      label={label}
-      onClick={onClick}
-      sdsStyle={sdsStyle}
-      {...rest}
-    />
+    <>
+      <InputDropdown
+        disabled={disabled}
+        label={label}
+        onClick={onClick}
+        open={open}
+        sdsStyle={sdsStyle}
+        {...rest}
+      />
+      <br />
+      {open && <div>This is a menu.</div>}
+    </>
   );
 };
 
@@ -27,6 +38,5 @@ export const Minimal = Template.bind({});
 Minimal.args = {
   disabled: false,
   label: "Dropdown",
-  onClick: () => null,
   sdsStyle: "minimal",
 };

--- a/src/core/InputDropdown/styles.ts
+++ b/src/core/InputDropdown/styles.ts
@@ -14,6 +14,7 @@ export interface InputDropdownProps extends Props {
   disabled?: boolean;
   label: string;
   onClick: (event: React.MouseEvent<HTMLElement>) => void;
+  open?: boolean;
   sdsStyle?: "minimal" | "square" | "rounded";
 }
 
@@ -72,21 +73,35 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
         color: ${palette?.text?.primary};
       }
       path {
-        fill: ${palette?.text?.primary};
+        fill: ${colors?.primary[400]};
       }
     }
   `;
 };
+
+const isOpen = (props: InputDropdownProps): SerializedStyles => {
+  const palette = getPalette(props);
+  return css`
+    span {
+      color: ${palette?.text?.primary};
+    }
+    path {
+      fill: ${palette?.text?.primary};
+    }
+  `;
+};
+
 const doNotForwardProps = ["sdsStyle"];
 
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: InputDropdownProps) => {
-    const { disabled, sdsStyle } = props;
+    const { disabled, open, sdsStyle } = props;
 
     return css`
       ${sdsStyle === "minimal" && minimal(props)}
+      ${open && isOpen(props)}
       ${disabled && isDisabled(props)}
     `;
   }}


### PR DESCRIPTION
### Summary
- **What:** Fix styles for inputdropdown when menu is open
- **Why:** I missed that there was a separate state for this when implementing
- **Env:** http://localhost:6006/?path=/story/inputdropdown--minimal

### Demos
#### Before: 
![before](https://user-images.githubusercontent.com/7562933/134257602-1a275d37-dc38-4c7e-b23a-050097fd6ba1.gif)

#### After: 
![after](https://user-images.githubusercontent.com/7562933/134257614-848b2d1b-751e-454c-ab97-4ccea0b993e2.gif)

### Checklist
- [X] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)