### PR TITLE
fix(complexfilter): update ComplexFilter value type to be based on mu…

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ const config = [
     external: [
       ...Object.keys(pkg.peerDependencies || {}),
       "@material-ui/core/styles",
+      "@material-ui/core/Popper",
     ],
     input: "src/index.ts",
     output: [

--- a/src/core/ComplexFilter/index.stories.tsx
+++ b/src/core/ComplexFilter/index.stories.tsx
@@ -2,7 +2,8 @@ import { Args, Story } from "@storybook/react";
 import React, { useState } from "react";
 import { noop } from "src/common/utils";
 import Button from "../Button";
-import ComplexFilter, { ComplexFilterValue } from "./index";
+import { DefaultMenuSelectOption } from "../MenuSelect";
+import ComplexFilter from "./index";
 
 const Demo = (props: Args): JSX.Element => {
   return (
@@ -31,7 +32,9 @@ SingleSelectWithSearch.args = {
 };
 
 export const SingleSelectControlled = (): JSX.Element => {
-  const [value, setValue] = useState<ComplexFilterValue>(GITHUB_LABELS[0]);
+  const [value, setValue] = useState<DefaultMenuSelectOption | null>(
+    GITHUB_LABELS[0]
+  );
 
   return (
     <>
@@ -54,7 +57,7 @@ export const SingleSelectControlled = (): JSX.Element => {
     setValue(GITHUB_LABELS[1]);
   }
 
-  function handleChange(newValue: ComplexFilterValue) {
+  function handleChange(newValue: DefaultMenuSelectOption | null) {
     setValue(newValue);
   }
 };
@@ -93,7 +96,7 @@ function ResizableWrapper({
 }
 
 export const MultipleSelectControlled = (): JSX.Element => {
-  const [value, setValue] = useState<ComplexFilterValue>([
+  const [value, setValue] = useState<DefaultMenuSelectOption[] | null>([
     GITHUB_LABELS[0],
     GITHUB_LABELS[1],
     GITHUB_LABELS[2],
@@ -130,7 +133,7 @@ export const MultipleSelectControlled = (): JSX.Element => {
     setValue([GITHUB_LABELS[7], GITHUB_LABELS[8], GITHUB_LABELS[9]]);
   }
 
-  function handleChange(newValue: ComplexFilterValue) {
+  function handleChange(newValue: DefaultMenuSelectOption[] | null) {
     setValue(newValue);
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
@@ -52,9 +52,13 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true,
   },
   "include": [
     "src/**/*",
     ".eslintrc.js"
-  ]
+  ],
+  "exclude": [
+    "node_modules",
+  ],
 }


### PR DESCRIPTION
…ltiple prop

Previously onChange's argument is a union of DefaultMenuSelectOption | DefaultMenuSelectOption[] |
null, which doesn't utilize the value of multiple prop to narrow down the possible value. Now we do!

BREAKING CHANGE: type ComplexFilterValue is no longer needed, since now TypeScript is able to infer
the value type based on the value of multiple being true or false