### PR TITLE
Button updates

### DIFF
--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -84,6 +84,17 @@ storiesOf("Button", module).add("Minimal Primary", () => (
   </Button>
 ));
 
+storiesOf("Button", module).add("Minimal Primary AllCaps", () => (
+  <Button
+    isAllCaps
+    onClick={actions.onClick}
+    sdsStyle="minimal"
+    sdsType="primary"
+  >
+    {text}
+  </Button>
+));
+
 storiesOf("Button", module).add("Minimal Primary Disabled", () => (
   <Button
     disabled

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -2,7 +2,6 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/react";
 import React from "react";
-import Tooltip from "../Tooltip";
 import Button from "./index";
 
 export const text = "Click me!";
@@ -130,15 +129,13 @@ storiesOf("Button", module).add("With Icon", () => (
   </Button>
 ));
 
-storiesOf("Button", module).add("With Tooltip", () => (
-  <Tooltip title="tooltip here">
-    <Button
-      startIcon={<DeleteIcon />}
-      onClick={actions.onClick}
-      sdsStyle="square"
-      sdsType="secondary"
-    >
-      With Tooltip!
-    </Button>
-  </Tooltip>
+storiesOf("Button", module).add("Minimal With Icon", () => (
+  <Button
+    startIcon={<DeleteIcon />}
+    onClick={actions.onClick}
+    sdsStyle="minimal"
+    sdsType="primary"
+  >
+    {text}
+  </Button>
 ));

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -84,17 +84,6 @@ storiesOf("Button", module).add("Minimal Primary", () => (
   </Button>
 ));
 
-storiesOf("Button", module).add("Minimal Primary AllCaps", () => (
-  <Button
-    isAllCaps
-    onClick={actions.onClick}
-    sdsStyle="minimal"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
-
 storiesOf("Button", module).add("Minimal Primary Disabled", () => (
   <Button
     disabled
@@ -118,6 +107,17 @@ storiesOf("Button", module).add("Minimal Secondary Disabled", () => (
     onClick={actions.onClick}
     sdsStyle="minimal"
     sdsType="secondary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Minimal No Caps - use sparingly", () => (
+  <Button
+    isAllCaps={false}
+    onClick={actions.onClick}
+    sdsStyle="minimal"
+    sdsType="primary"
   >
     {text}
   </Button>

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -11,64 +11,132 @@ export const actions = {
   onClick: action("onClick"),
 };
 
-storiesOf("Button", module).add("default", () => (
-  <Button variant="contained" onClick={actions.onClick}>
+storiesOf("Button", module).add("Default", () => (
+  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
     {text}
   </Button>
 ));
 
-storiesOf("Button", module).add("primary", () => (
-  <Button variant="contained" onClick={actions.onClick} color="primary">
+storiesOf("Button", module).add("Rounded Primary", () => (
+  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
     {text}
   </Button>
 ));
 
-storiesOf("Button", module).add("primaryRounded", () => (
+storiesOf("Button", module).add("Rounded Primary Disabled", () => (
   <Button
-    variant="contained"
-    onClick={actions.onClick}
-    color="primary"
-    isRounded
-  >
-    {text}
-  </Button>
-));
-
-storiesOf("Button", module).add("secondary", () => (
-  <Button variant="outlined" onClick={actions.onClick} color="primary">
-    {text}
-  </Button>
-));
-
-storiesOf("Button", module).add("disabled", () => (
-  <Button
-    variant="contained"
     disabled
     onClick={actions.onClick}
-    color="primary"
+    sdsStyle="rounded"
+    sdsType="primary"
   >
     {text}
   </Button>
 ));
 
-storiesOf("Button", module).add("startIcon", () => (
+storiesOf("Button", module).add("Rounded Secondary", () => (
+  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="secondary">
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Rounded Secondary Disabled", () => (
   <Button
-    variant="contained"
+    disabled
+    onClick={actions.onClick}
+    sdsStyle="rounded"
+    sdsType="secondary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Square Primary", () => (
+  <Button onClick={actions.onClick} sdsStyle="square" sdsType="primary">
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Square Primary Disabled", () => (
+  <Button
+    disabled
+    onClick={actions.onClick}
+    sdsStyle="square"
+    sdsType="primary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Square Secondary", () => (
+  <Button onClick={actions.onClick} sdsStyle="square" sdsType="secondary">
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Square Secondary Disabled", () => (
+  <Button
+    disabled
+    onClick={actions.onClick}
+    sdsStyle="square"
+    sdsType="secondary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Minimal Primary", () => (
+  <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="primary">
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Minimal Primary Disabled", () => (
+  <Button
+    disabled
+    onClick={actions.onClick}
+    sdsStyle="minimal"
+    sdsType="primary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Minimal Secondary", () => (
+  <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="secondary">
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("Minimal Secondary Disabled", () => (
+  <Button
+    disabled
+    onClick={actions.onClick}
+    sdsStyle="minimal"
+    sdsType="secondary"
+  >
+    {text}
+  </Button>
+));
+
+storiesOf("Button", module).add("With Icon", () => (
+  <Button
     startIcon={<DeleteIcon />}
     onClick={actions.onClick}
-    color="primary"
+    sdsStyle="rounded"
+    sdsType="primary"
   >
     {text}
   </Button>
 ));
 
-storiesOf("Button", module).add("with Tooltip", () => (
+storiesOf("Button", module).add("With Tooltip", () => (
   <Tooltip title="tooltip here">
     <Button
-      variant="contained"
       startIcon={<DeleteIcon />}
       onClick={actions.onClick}
-      color="primary"
+      sdsStyle="square"
+      sdsType="secondary"
     >
       With Tooltip!
     </Button>

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -10,12 +10,6 @@ export const actions = {
   onClick: action("onClick"),
 };
 
-storiesOf("Button", module).add("Default", () => (
-  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
-    {text}
-  </Button>
-));
-
 storiesOf("Button", module).add("Rounded Primary", () => (
   <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
     {text}

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -8,21 +8,30 @@ import {
   StyledButton,
 } from "./style";
 
-export interface ButtonProps extends RawButtonProps {
+interface SdsProps {
+  isAllCaps?: boolean;
   isRounded?: boolean;
   sdsStyle?: "minimal" | "rounded" | "square";
   sdsType?: "primary" | "secondary";
 }
+export type ButtonProps = RawButtonProps & SdsProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (props: ButtonProps, ref): JSX.Element | null => {
     const sdsStyle = props?.sdsStyle;
     const sdsType = props?.sdsType;
+    const isAllCaps = props?.isAllCaps;
 
     if (!sdsStyle || !sdsType) {
       // eslint-disable-next-line no-console
       console.warn(
         "Warning: Buttons without sdsStyle or sdsType props will be deprecated."
+      );
+    }
+    if (isAllCaps && sdsStyle !== "minimal") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Warning: isAllCaps is only applied to buttons with sdsStyle='minimal'."
       );
     }
 

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -15,7 +15,7 @@ export interface ButtonProps extends RawButtonProps {
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref): JSX.Element | null => {
+  (props: ButtonProps, ref): JSX.Element | null => {
     const sdsStyle = props?.sdsStyle;
     const sdsType = props?.sdsType;
 

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -1,14 +1,89 @@
 import { ButtonProps as RawButtonProps } from "@material-ui/core";
 import React from "react";
-import { StyledButton } from "./style";
+import {
+  PrimaryMinimalButton,
+  RoundedButton,
+  SecondaryMinimalButton,
+  SquareButton,
+  StyledButton,
+} from "./style";
 
 export interface ButtonProps extends RawButtonProps {
   isRounded?: boolean;
+  sdsStyle?: "minimal" | "rounded" | "square";
+  sdsType?: "primary" | "secondary";
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref): JSX.Element => {
-    return <StyledButton {...props} ref={ref} />;
+  (props, ref): JSX.Element | null => {
+    const sdsStyle = props?.sdsStyle;
+    const sdsType = props?.sdsType;
+
+    if (!sdsStyle || !sdsType) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Warning: Buttons without sdsStyle or sdsType props will be deprecated."
+      );
+    }
+
+    switch (true) {
+      case sdsStyle === "rounded" && sdsType === "primary":
+        return (
+          <RoundedButton
+            color="primary"
+            ref={ref}
+            variant="contained"
+            {...props}
+          />
+        );
+      case sdsStyle === "rounded" && sdsType === "secondary":
+        return (
+          <RoundedButton
+            color="primary"
+            ref={ref}
+            variant="outlined"
+            {...props}
+          />
+        );
+      case sdsStyle === "square" && sdsType === "primary":
+        return (
+          <SquareButton
+            color="primary"
+            ref={ref}
+            variant="contained"
+            {...props}
+          />
+        );
+      case sdsStyle === "square" && sdsType === "secondary":
+        return (
+          <SquareButton
+            color="primary"
+            ref={ref}
+            variant="outlined"
+            {...props}
+          />
+        );
+      case sdsStyle === "minimal" && sdsType === "primary":
+        return (
+          <PrimaryMinimalButton
+            color="primary"
+            ref={ref}
+            variant="text"
+            {...props}
+          />
+        );
+      case sdsStyle === "minimal" && sdsType === "secondary":
+        return (
+          <SecondaryMinimalButton
+            color="default"
+            ref={ref}
+            variant="text"
+            {...props}
+          />
+        );
+      default:
+        return <StyledButton {...props} ref={ref} />;
+    }
   }
 );
 

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -20,7 +20,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (props: ButtonProps, ref): JSX.Element | null => {
     const sdsStyle = props?.sdsStyle;
     const sdsType = props?.sdsType;
-    const isAllCaps = props?.isAllCaps;
 
     if (!sdsStyle || !sdsType) {
       // eslint-disable-next-line no-console
@@ -28,12 +27,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         "Warning: Buttons without sdsStyle or sdsType props will be deprecated."
       );
     }
-    if (isAllCaps && sdsStyle !== "minimal") {
+
+    if (typeof props?.isAllCaps === "boolean" && sdsStyle !== "minimal") {
       // eslint-disable-next-line no-console
       console.warn(
         "Warning: isAllCaps is only applied to buttons with sdsStyle='minimal'."
       );
     }
+
+    // isAllCaps is only used for the Minimal Button.  It defaults to true.
+    const isAllCaps =
+      typeof props?.isAllCaps === "boolean" ? props?.isAllCaps : true;
+    const propsWithDefault = { ...props, isAllCaps };
 
     switch (true) {
       case sdsStyle === "rounded" && sdsType === "primary":
@@ -42,7 +47,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="primary"
             ref={ref}
             variant="contained"
-            {...props}
+            {...propsWithDefault}
           />
         );
       case sdsStyle === "rounded" && sdsType === "secondary":
@@ -51,7 +56,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="primary"
             ref={ref}
             variant="outlined"
-            {...props}
+            {...propsWithDefault}
           />
         );
       case sdsStyle === "square" && sdsType === "primary":
@@ -60,7 +65,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="primary"
             ref={ref}
             variant="contained"
-            {...props}
+            {...propsWithDefault}
           />
         );
       case sdsStyle === "square" && sdsType === "secondary":
@@ -69,7 +74,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="primary"
             ref={ref}
             variant="outlined"
-            {...props}
+            {...propsWithDefault}
           />
         );
       case sdsStyle === "minimal" && sdsType === "primary":
@@ -78,7 +83,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="primary"
             ref={ref}
             variant="text"
-            {...props}
+            {...propsWithDefault}
           />
         );
       case sdsStyle === "minimal" && sdsType === "secondary":
@@ -87,11 +92,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             color="default"
             ref={ref}
             variant="text"
-            {...props}
+            {...propsWithDefault}
           />
         );
       default:
-        return <StyledButton {...props} ref={ref} />;
+        return <StyledButton {...propsWithDefault} ref={ref} />;
     }
   }
 );

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -1,11 +1,93 @@
 import styled from "@emotion/styled";
 import { Button } from "@material-ui/core";
-import { getCorners, getSpacings, Props } from "../styles";
+import { getColors, getCorners, getSpacings, Props } from "../styles";
 
+const ButtonBase = styled(Button)`
+  box-shadow: none;
+  ${(props) => {
+    const colors = getColors(props);
+    const spacings = getSpacings(props);
+
+    return `
+      padding: ${spacings?.xs}px ${spacings?.l}px;
+      min-width: 120px;
+      height: 34px;
+      &:hover {
+        color: white;
+        background-color: ${colors?.primary[500]};
+        box-shadow: none;
+      }
+      &:active {
+        color: white;
+        background-color: ${colors?.primary[600]};
+      }
+      &:disabled {
+        color: ${colors?.gray[400]};
+        background-color: ${colors?.gray[300]} 
+        border-color: ${colors?.gray[300]} 
+      }
+    `;
+  }}
+`;
+
+export const RoundedButton = styled(ButtonBase)`
+  ${(props) => {
+    const corners = getCorners(props);
+
+    return `
+      border-radius: ${corners?.l}px;
+    `;
+  }}
+`;
+
+export const SquareButton = styled(ButtonBase)``;
+
+const MinimalButton = styled(Button)`
+  &:hover {
+    background-color: transparent;
+  }
+`;
+
+export const PrimaryMinimalButton = styled(MinimalButton)`
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      &:hover {
+        color: ${colors?.primary[500]};
+      }
+      &:active {
+        color: ${colors?.primary[600]};
+      }
+      &:disabled {
+        color: ${colors?.gray[400]};
+      }
+    `;
+  }}
+`;
+
+export const SecondaryMinimalButton = styled(MinimalButton)`
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      &:hover {
+        color: ${colors?.gray[500]};
+      }
+      &:active {
+        color: ${colors?.gray[600]};
+      }
+      &:disabled {
+        color: ${colors?.gray[300]};
+      }
+    `;
+  }}
+`;
+
+// Legacy support for backwards-compatible props
 export interface IsRounded extends Props {
   isRounded?: boolean;
 }
-
 export const StyledButton = styled(Button, {
   shouldForwardProp: (prop) => prop !== "isRounded",
 })`

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -43,7 +43,7 @@ export const RoundedButton = styled(ButtonBase)`
   }}
 `;
 
-export const SquareButton = styled(ButtonBase)``;
+export const SquareButton = ButtonBase;
 
 const MinimalButton = styled(Button)`
   &:hover {

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -15,11 +15,13 @@ const ButtonBase = styled(Button)`
       &:hover {
         color: white;
         background-color: ${colors?.primary[500]};
+        border: none;
         box-shadow: none;
       }
       &:active {
         color: white;
         background-color: ${colors?.primary[600]};
+        border: none;
         box-shadow: none;
       }
       &:disabled {

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -1,8 +1,20 @@
 import styled from "@emotion/styled";
 import { Button } from "@material-ui/core";
-import { getColors, getCorners, getSpacings, Props } from "../styles";
+import {
+  fontCapsXxxs,
+  getColors,
+  getCorners,
+  getSpacings,
+  Props,
+} from "../styles";
 
-const ButtonBase = styled(Button)`
+const sdsPropNames = ["isAllCaps", "isRounded", "sdsStyle", "sdsType"];
+
+const ButtonBase = styled(Button, {
+  shouldForwardProp: (prop) => {
+    return !sdsPropNames.includes(prop.toString());
+  },
+})`
   box-shadow: none;
   ${(props) => {
     const colors = getColors(props);
@@ -45,18 +57,32 @@ export const RoundedButton = styled(ButtonBase)`
 
 export const SquareButton = ButtonBase;
 
-const MinimalButton = styled(Button)`
-  &:hover {
-    background-color: transparent;
-  }
-  ${(props) => {
+interface IsAllCaps extends Props {
+  isAllCaps?: boolean;
+}
+
+const MinimalButton = styled(Button, {
+  shouldForwardProp: (prop) => {
+    return !sdsPropNames.includes(prop.toString());
+  },
+})`
+  ${(props: IsAllCaps) => {
     const spacings = getSpacings(props);
 
     return `
-      padding-top: ${spacings?.xxs}
-      padding-bottom: ${spacings?.xxs}
+      padding: ${spacings?.xxs}px 0;
     `;
   }}
+
+  ${(props: IsAllCaps) => {
+    if (props?.isAllCaps) {
+      return fontCapsXxxs;
+    }
+    return ``;
+  }}
+  &:hover {
+    background-color: transparent;
+  }
 `;
 
 export const PrimaryMinimalButton = styled(MinimalButton)`
@@ -96,11 +122,13 @@ export const SecondaryMinimalButton = styled(MinimalButton)`
 `;
 
 // Legacy support for backwards-compatible props
-export interface IsRounded extends Props {
+interface IsRounded extends Props {
   isRounded?: boolean;
 }
 export const StyledButton = styled(Button, {
-  shouldForwardProp: (prop) => prop !== "isRounded",
+  shouldForwardProp: (prop) => {
+    return !sdsPropNames.includes(prop.toString());
+  },
 })`
   ${(props: IsRounded) => {
     if (!props.isRounded) return ``;

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -20,11 +20,12 @@ const ButtonBase = styled(Button)`
       &:active {
         color: white;
         background-color: ${colors?.primary[600]};
+        box-shadow: none;
       }
       &:disabled {
         color: ${colors?.gray[400]};
-        background-color: ${colors?.gray[300]} 
-        border-color: ${colors?.gray[300]} 
+        background-color: ${colors?.gray[300]};
+        border-color: ${colors?.gray[300]};
       }
     `;
   }}
@@ -46,6 +47,14 @@ const MinimalButton = styled(Button)`
   &:hover {
     background-color: transparent;
   }
+  ${(props) => {
+    const spacings = getSpacings(props);
+
+    return `
+      padding-top: ${spacings?.xxs}
+      padding-bottom: ${spacings?.xxs}
+    `;
+  }}
 `;
 
 export const PrimaryMinimalButton = styled(MinimalButton)`

--- a/src/core/ComplexFilter/index.tsx
+++ b/src/core/ComplexFilter/index.tsx
@@ -46,6 +46,7 @@ interface ComplexFilterProps<Multiple> {
   InputDropdownComponent?: typeof InputDropdown;
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export default function ComplexFilter<
   Multiple extends boolean | undefined = false
 >({


### PR DESCRIPTION
- Style updates to existing buttons.  
- Implements sdsType and sdsStyle as optional props
- Adds more stories to storybook

This is backward compatible, but we should clean up at some point once teams update.

Default state:
<img width="172" alt="Screen Shot 2021-09-23 at 4 55 11 PM" src="https://user-images.githubusercontent.com/8015489/134599580-bf145a0d-c28c-435b-98c8-888e7864898b.png">

Hover state:
<img width="156" alt="Screen Shot 2021-09-23 at 4 55 15 PM" src="https://user-images.githubusercontent.com/8015489/134599581-2d347d07-3360-4003-90ff-48c155b1fa9b.png">

(Couldn't screenshot the click state, but it's there)

Different states in Storybook:
<img width="285" alt="Screen Shot 2021-09-23 at 5 03 56 PM" src="https://user-images.githubusercontent.com/8015489/134599577-5a5568d5-d4d8-4740-9a37-eecd9e659318.png">
<img width="373" alt="Screen Shot 2021-09-23 at 5 03 42 PM" src="https://user-images.githubusercontent.com/8015489/134599579-82f80328-a9de-48b6-8f43-adf5f0139dc4.png">



