### PR TITLE
allow menu consumers to customize menu placement when necessary

### DIFF
--- a/src/core/Menu/index.stories.tsx
+++ b/src/core/Menu/index.stories.tsx
@@ -16,7 +16,12 @@ const Demo = (props: Args): JSX.Element => {
   };
 
   return (
-    <>
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-around",
+      }}
+    >
       <Button onClick={handleClick}>Click me!</Button>
       <Menu
         anchorEl={anchorEl}
@@ -31,7 +36,7 @@ const Demo = (props: Args): JSX.Element => {
         <MenuItem onClick={handleClose}>Privacy Policy</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>
       </Menu>
-    </>
+    </div>
   );
 };
 
@@ -45,3 +50,18 @@ const Template: Story = (args) => <Demo {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {};
+
+export const CustomPlacement = Template.bind({});
+
+CustomPlacement.args = {
+  ...Default.args,
+  anchorOrigin: {
+    horizontal: "right",
+    vertical: "bottom",
+  },
+  column: "column value",
+  transformOrigin: {
+    horizontal: "right",
+    vertical: "top",
+  },
+};

--- a/src/core/Menu/index.tsx
+++ b/src/core/Menu/index.tsx
@@ -17,9 +17,9 @@ export { MenuProps };
 const Menu = (props: MenuProps): JSX.Element => {
   return (
     <StyledMenu
-      {...props}
       anchorOrigin={ANCHOR_ORIGIN}
       transformOrigin={TRANSFORM_ORIGIN}
+      {...props}
     />
   );
 };


### PR DESCRIPTION
### Summary
- **What:** Customize the placement of the czifui `Menu`, relative to its anchor element
- **Why:** Depending on where the anchor is on the screen, the default may not be desirable
- **Env:** http://localhost:6006/?path=/story/menu--custom-placement

### Demos
![Screen Shot 2021-09-29 at 5 12 26 PM](https://user-images.githubusercontent.com/7562933/135365292-935fc0fb-05c3-47e8-b16e-ebb06e93def4.png)
![Screen Shot 2021-09-29 at 5 12 31 PM](https://user-images.githubusercontent.com/7562933/135365297-390061ee-80d6-43b0-b6bc-7a940f991051.png)

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)