### PR TITLE
Maya/155222 list style updates

### DIFF
--- a/src/core/List/index.stories.tsx
+++ b/src/core/List/index.stories.tsx
@@ -8,39 +8,33 @@ const Demo = (props: Args): JSX.Element => {
   return (
     <div>
       <List
-        subheader={<ListSubheader disableSticky>This is a list</ListSubheader>}
+        subheader={
+          <ListSubheader disableSticky>
+            Font sizes and spacing for an unordered list
+          </ListSubheader>
+        }
         {...props}
       >
-        <ListItem fontSize="l" marginBottom="s">
-          fontSize=l marginBottom=s
-        </ListItem>
-        <ListItem fontSize="m" marginBottom="s">
-          fontSize=m marginBottom=s
-        </ListItem>
-        <ListItem fontSize="s" marginBottom="xs">
-          fontSize=s marginBottom=xs
-        </ListItem>
-        <ListItem fontSize="xs" marginBottom="xs">
-          fontSize=xs marginBottom=xs
-        </ListItem>
-        <ListItem fontSize="xxs" marginBottom="xs">
-          fontSize=xxs marginBottom=xs
-        </ListItem>
-        <ListItem fontSize="xxxs" marginBottom="xxs">
-          fontSize=xxxs marginBottom=xxs
-        </ListItem>
-        <ListItem fontSize="m" marginBottom="s">
+        <ListItem fontSize="l">fontSize=l marginBottom=s</ListItem>
+        <ListItem fontSize="m">fontSize=m marginBottom=s</ListItem>
+        <ListItem fontSize="s">fontSize=s marginBottom=xs</ListItem>
+        <ListItem fontSize="xs">fontSize=xs marginBottom=xs</ListItem>
+        <ListItem fontSize="xxs">fontSize=xxs marginBottom=xs</ListItem>
+        <ListItem fontSize="xxxs">fontSize=xxxs marginBottom=xxs</ListItem>
+        <ListItem fontSize="m">
           <div style={{ width: "200px" }}>
             Really long list item here to make it wrap, so we can see if the
             bullet is top aligned
           </div>
         </ListItem>
       </List>
+      <br />
+      <br />
       <List
         ordered
         subheader={
           <ListSubheader disableSticky>
-            This is a nested ordered list
+            Font sizes and spacing for a nested ordered list
           </ListSubheader>
         }
         {...props}
@@ -49,13 +43,13 @@ const Demo = (props: Args): JSX.Element => {
           <span>
             Nested List 1
             <List ordered>
-              <ListItem ordered fontSize="l" marginBottom="s">
+              <ListItem ordered fontSize="l">
                 fontSize=l marginBottom=s
               </ListItem>
-              <ListItem ordered fontSize="m" marginBottom="s">
+              <ListItem ordered fontSize="m">
                 fontSize=m marginBottom=s
               </ListItem>
-              <ListItem ordered fontSize="s" marginBottom="xs">
+              <ListItem ordered fontSize="s">
                 fontSize=s marginBottom=xs
               </ListItem>
             </List>
@@ -65,13 +59,26 @@ const Demo = (props: Args): JSX.Element => {
           <span>
             Nested List 2
             <List ordered>
-              <ListItem ordered fontSize="l" marginBottom="s">
-                fontSize=l marginBottom=s
+              <ListItem ordered fontSize="l">
+                <span>
+                  Nested List 2
+                  <List ordered>
+                    <ListItem ordered fontSize="l">
+                      fontSize=l marginBottom=s
+                    </ListItem>
+                    <ListItem ordered fontSize="m">
+                      fontSize=m marginBottom=s
+                    </ListItem>
+                    <ListItem ordered fontSize="s">
+                      fontSize=s marginBottom=xs
+                    </ListItem>
+                  </List>
+                </span>
               </ListItem>
-              <ListItem ordered fontSize="m" marginBottom="s">
+              <ListItem ordered fontSize="m">
                 fontSize=m marginBottom=s
               </ListItem>
-              <ListItem ordered fontSize="s" marginBottom="xs">
+              <ListItem ordered fontSize="s">
                 fontSize=s marginBottom=xs
               </ListItem>
             </List>
@@ -81,18 +88,48 @@ const Demo = (props: Args): JSX.Element => {
           <span>
             Nested List 3
             <List ordered>
-              <ListItem ordered fontSize="l" marginBottom="s">
+              <ListItem ordered fontSize="l">
                 fontSize=l marginBottom=s
               </ListItem>
-              <ListItem ordered fontSize="m" marginBottom="s">
+              <ListItem ordered fontSize="m">
                 fontSize=m marginBottom=s
               </ListItem>
-              <ListItem ordered fontSize="s" marginBottom="xs">
+              <ListItem ordered fontSize="s">
                 fontSize=s marginBottom=xs
               </ListItem>
             </List>
           </span>
         </ListItem>
+      </List>
+      <br />
+      <br />
+      <List
+        ordered
+        subheader={
+          <ListSubheader disableSticky>This is an ordered list</ListSubheader>
+        }
+        {...props}
+      >
+        <ListItem ordered>This is an ordered list item 1.</ListItem>
+        <ListItem ordered>This is an ordered list item 2.</ListItem>
+        <ListItem ordered>This is an ordered list item 3.</ListItem>
+        <ListItem ordered>This is an ordered list item 4.</ListItem>
+        <ListItem ordered>This is an ordered list item 5.</ListItem>
+      </List>
+      <br />
+      <br />
+      <List
+        ordered
+        subheader={
+          <ListSubheader disableSticky>This is an unordered list</ListSubheader>
+        }
+        {...props}
+      >
+        <ListItem>This is an ordered list item 1.</ListItem>
+        <ListItem>This is an ordered list item 2.</ListItem>
+        <ListItem>This is an ordered list item 3.</ListItem>
+        <ListItem>This is an ordered list item 4.</ListItem>
+        <ListItem>This is an ordered list item 5.</ListItem>
       </List>
     </div>
   );

--- a/src/core/List/index.stories.tsx
+++ b/src/core/List/index.stories.tsx
@@ -115,6 +115,12 @@ const Demo = (props: Args): JSX.Element => {
         <ListItem ordered>This is an ordered list item 3.</ListItem>
         <ListItem ordered>This is an ordered list item 4.</ListItem>
         <ListItem ordered>This is an ordered list item 5.</ListItem>
+        <ListItem ordered>This is an ordered list item 6.</ListItem>
+        <ListItem ordered>This is an ordered list item 7.</ListItem>
+        <ListItem ordered>This is an ordered list item 8.</ListItem>
+        <ListItem ordered>This is an ordered list item 9.</ListItem>
+        <ListItem ordered>This is an ordered list item 10.</ListItem>
+        <ListItem ordered>This is an ordered list item 11.</ListItem>
       </List>
       <br />
       <br />
@@ -125,11 +131,74 @@ const Demo = (props: Args): JSX.Element => {
         }
         {...props}
       >
-        <ListItem>This is an ordered list item 1.</ListItem>
-        <ListItem>This is an ordered list item 2.</ListItem>
-        <ListItem>This is an ordered list item 3.</ListItem>
-        <ListItem>This is an ordered list item 4.</ListItem>
-        <ListItem>This is an ordered list item 5.</ListItem>
+        <ListItem>This is an unordered list item 1.</ListItem>
+        <ListItem>This is an unordered list item 2.</ListItem>
+        <ListItem>This is an unordered list item 3.</ListItem>
+        <ListItem>This is an unordered list item 4.</ListItem>
+        <ListItem>This is an unordered list item 5.</ListItem>
+        <ListItem>This is an unordered list item 6.</ListItem>
+        <ListItem>This is an unordered list item 7.</ListItem>
+        <ListItem>This is an unordered list item 8.</ListItem>
+        <ListItem>This is an unordered list item 9.</ListItem>
+        <ListItem>This is an unordered list item 10.</ListItem>
+        <ListItem>This is an unordered list item 11.</ListItem>
+      </List>
+      <List
+        ordered
+        subheader={
+          <ListSubheader disableSticky>
+            Font sizes and spacing for a nested ordered list
+          </ListSubheader>
+        }
+        {...props}
+      >
+        <ListItem ordered>
+          <span>
+            Nested List 1
+            <List ordered>
+              <ListItem ordered>Nested List item</ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+            </List>
+          </span>
+        </ListItem>
+        <ListItem ordered>
+          <span>
+            Nested List 2
+            <List ordered>
+              <ListItem ordered>
+                <span>
+                  Nested List 2
+                  <List ordered>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                    <ListItem ordered>Nested List item</ListItem>
+                  </List>
+                </span>
+              </ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+            </List>
+          </span>
+        </ListItem>
+        <ListItem ordered>
+          <span>
+            Nested List 3
+            <List ordered>
+              <ListItem ordered>Nested List item</ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+              <ListItem ordered>Nested List item</ListItem>
+            </List>
+          </span>
+        </ListItem>
       </List>
     </div>
   );

--- a/src/core/List/style.ts
+++ b/src/core/List/style.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { List } from "@material-ui/core";
-import { Props } from "../styles";
+import { getSpacings, Props } from "../styles";
 
 export interface ExtraProps extends Props {
   ordered?: boolean;
@@ -13,6 +13,10 @@ const doNotForwardProps = ["ordered"];
 export const StyledList = styled(List, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
+  .MuiListSubheader-root {
+    ${propsToMarginBottom}
+  }
+
   ${(props: ExtraProps) => {
     if (!props.ordered) return "";
 
@@ -21,3 +25,25 @@ export const StyledList = styled(List, {
     `;
   }}
 `;
+
+function propsToMarginBottom(props: ExtraProps) {
+  const spacings = getSpacings(props);
+
+  const propsToMarginBottomMap: Record<
+    NonNullable<ExtraProps["marginBottom"]>,
+    number | undefined
+  > = {
+    l: spacings?.l,
+    m: spacings?.l,
+    s: spacings?.m,
+    xs: spacings?.m,
+    xxs: spacings?.m,
+    xxxs: spacings?.s,
+  };
+
+  const { marginBottom } = props;
+
+  return `
+    margin-bottom: ${propsToMarginBottomMap[marginBottom || "s"]}px;
+  `;
+}

--- a/src/core/List/style.ts
+++ b/src/core/List/style.ts
@@ -3,12 +3,13 @@ import { List } from "@material-ui/core";
 import { getSpacings, Props } from "../styles";
 
 export interface ExtraProps extends Props {
-  ordered?: boolean;
   component?: unknown;
+  marginBottom?: "xxxs" | "xxs" | "xs" | "s" | "m" | "l";
+  ordered?: boolean;
 }
 
 // (thuang): Please keep this in sync with the props used in `ExtraProps`
-const doNotForwardProps = ["ordered"];
+const doNotForwardProps = ["marginBotton", "ordered"];
 
 export const StyledList = styled(List, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),

--- a/src/core/ListItem/style.ts
+++ b/src/core/ListItem/style.ts
@@ -30,7 +30,6 @@ export const StyledListItem = styled(ListItem, {
     padding: 0;
 
     ${(props) => {
-      const spacings = getSpacings(props);
       const { ordered } = props;
 
       const {
@@ -38,8 +37,8 @@ export const StyledListItem = styled(ListItem, {
       } = props;
 
       return `
+        align-items: flex-start;
         font-family: ${(typography as TypographyOptions).fontFamily};
-        margin-left: ${markerMargin(Boolean(ordered), spacings?.m || 1)}px;
         ${ordered ? "counter-increment: section;" : ""}
       `;
     }}
@@ -47,25 +46,19 @@ export const StyledListItem = styled(ListItem, {
     &:before {
       display: inline-block;
       font-weight: 600;
-      position: absolute;
-      top: 0;
 
       ${(props) => {
         const spacings = getSpacings(props);
         const { ordered } = props;
 
         return `
-          content: ${ordered ? `counters(section, ".")` : `"•"`};
-          left: -${markerMargin(Boolean(ordered), spacings?.m || 1)}px;
+          content: ${ordered ? `counters(section, ".")"."` : `"•"`};
+          margin-right: ${ordered ? spacings?.xs : spacings?.s}px;
         `;
       }}
     }
   }
 `;
-
-function markerMargin(ordered: boolean, spacing = 1) {
-  return ordered ? 3 * spacing : spacing;
-}
 
 function propsToFontBody(props: ExtraProps) {
   const propsToFontBodyMap: Record<


### PR DESCRIPTION
### Summary
- **What:** 
  - Change spacing between list item markers and content
  - Set custom spacing between list headers of various sizes and lists
  - Add a final `.` after the last counter symbol in ordered lists
- **Ticket:** [[sc-155222]](https://app.shortcut.com/sci-design-system/story/155222)

### Demos
| before | after|
|----|-----|
| <img width="794" alt="Screen Shot 2021-10-06 at 1 20 03 PM" src="https://user-images.githubusercontent.com/7562933/136277309-fa5d0d10-e937-4725-bb56-c181ad3ad574.png"> | <img width="794" alt="Screen Shot 2021-10-06 at 1 19 33 PM" src="https://user-images.githubusercontent.com/7562933/136277417-ec9058d0-5903-41f9-810b-1a023105d296.png"> |
| <img width="794" alt="Screen Shot 2021-10-06 at 1 20 06 PM" src="https://user-images.githubusercontent.com/7562933/136277353-e18809b8-8238-48a0-925c-05cf6e737203.png"> | <img width="794" alt="Screen Shot 2021-10-06 at 1 19 36 PM" src="https://user-images.githubusercontent.com/7562933/136277427-4b487cae-c10a-40e0-9d18-a8a86cde35dd.png"> |

### Notes
I chose to take an easier to understand approach to spacing between markers and content. This also resolved an unknown problem with nested lists where deeply nested lists would eventually have markers so long they would overlap with content.

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)