### PR TITLE
feat(inputdropdown): add styles for a square inputdropdown

### DIFF
--- a/src/core/InputDropdown/index.stories.tsx
+++ b/src/core/InputDropdown/index.stories.tsx
@@ -40,3 +40,11 @@ Minimal.args = {
   label: "Dropdown",
   sdsStyle: "minimal",
 };
+
+export const Square = Template.bind({});
+
+Square.args = {
+  disabled: false,
+  label: "Dropdown",
+  sdsStyle: "square",
+};

--- a/src/core/InputDropdown/styles.ts
+++ b/src/core/InputDropdown/styles.ts
@@ -2,8 +2,10 @@ import { css, SerializedStyles } from "@emotion/react";
 import styled from "@emotion/styled";
 import Button from "../Button";
 import {
+  fontBodyXs,
   fontHeaderS,
   getColors,
+  getCorners,
   getIconSizes,
   getPalette,
   getSpacings,
@@ -18,33 +20,30 @@ export interface InputDropdownProps extends Props {
   sdsStyle?: "minimal" | "square" | "rounded";
 }
 
-const isDisabled = (props: InputDropdownProps): SerializedStyles => {
-  const colors = getColors(props);
-
-  return css`
-    span {
-      color: ${colors?.gray[300]};
-    }
-    path {
-      fill: ${colors?.gray[300]};
-    }
-  `;
-};
-
-const minimal = (props: InputDropdownProps): SerializedStyles => {
+const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
   const iconSizes = getIconSizes(props);
   const palette = getPalette(props);
   const spacings = getSpacings(props);
 
   return css`
+    color: ${colors?.gray[500]};
+
     .MuiButton-label {
       display: flex;
       align-items: center;
+      margin: 0 ${spacings?.xs}px;
+
+      span {
+        margin-right: ${spacings?.xs}px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
 
     path {
-      fill: ${colors?.gray[500]};
+      fill: currentColor;
     }
 
     svg {
@@ -52,29 +51,40 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
       width: ${iconSizes?.s.width}px;
     }
 
-    span {
-      ${fontHeaderS(props)}
-      color: ${colors?.gray[500]};
-      margin-right: ${spacings?.xs}px;
-    }
-
     &:hover {
       background-color: unset;
-      span {
-        color: ${colors?.gray[600]};
-      }
-      path {
-        fill: ${colors?.gray[600]};
-      }
+      color: ${colors?.gray[600]};
     }
 
     &:active {
-      span {
-        color: ${palette?.text?.primary};
-      }
+      color: ${palette?.text?.primary};
       path {
         fill: ${colors?.primary[400]};
       }
+    }
+  `;
+};
+
+const minimal = (props: InputDropdownProps): SerializedStyles => {
+  return css`
+    span {
+      ${fontHeaderS(props)}
+    }
+  `;
+};
+
+const square = (props: InputDropdownProps): SerializedStyles => {
+  const corners = getCorners(props);
+  return css`
+    border: 1px solid currentColor;
+    border-radius: ${corners?.m}px;
+
+    .MuiButton-label {
+      justify-content: space-between;
+    }
+
+    span {
+      ${fontBodyXs(props)}
     }
   `;
 };
@@ -91,6 +101,19 @@ const isOpen = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
+const isDisabled = (props: InputDropdownProps): SerializedStyles => {
+  const colors = getColors(props);
+
+  return css`
+    span {
+      color: ${colors?.gray[300]};
+    }
+    path {
+      fill: ${colors?.gray[300]};
+    }
+  `;
+};
+
 const doNotForwardProps = ["sdsStyle"];
 
 export const StyledInputDropdown = styled(Button, {
@@ -100,7 +123,9 @@ export const StyledInputDropdown = styled(Button, {
     const { disabled, open, sdsStyle } = props;
 
     return css`
+      ${inputDropdownStyles(props)}
       ${sdsStyle === "minimal" && minimal(props)}
+      ${sdsStyle === "square" && square(props)}
       ${open && isOpen(props)}
       ${disabled && isDisabled(props)}
     `;


### PR DESCRIPTION
### Summary
- **What:** Add `square` styles for InputDropdown
- **Why:** Needed for Aspen usher project

### Testing
http://localhost:6006/?path=/story/inputdropdown--square

### Demos
![Screen Shot 2021-10-12 at 1 06 43 PM](https://user-images.githubusercontent.com/7562933/137022547-01781967-4aa1-4809-b451-7c6d68a0bf80.png)
![Screen Shot 2021-10-12 at 1 06 52 PM](https://user-images.githubusercontent.com/7562933/137022552-f144c289-96bc-485b-b45d-61069625e912.png)
![Screen Shot 2021-10-12 at 1 07 35 PM](https://user-images.githubusercontent.com/7562933/137022554-aca7f917-3c77-4250-8618-61ed5e3c499d.png)

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)