### PR TITLE
Maya/dropdown

### DIFF
--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -1,5 +1,6 @@
+import { Dialog } from "@material-ui/core";
 import { Args, Story } from "@storybook/react";
-import React from "react";
+import React, { useState } from "react";
 import { noop } from "src/common/utils";
 import Dropdown from "./index";
 
@@ -52,6 +53,28 @@ MultipleSelectWithSearch.args = {
   multiple: true,
   onChange: noop,
   search: true,
+};
+
+export const InsideModal = (): JSX.Element => {
+  const [value, setValue] = useState<DefaultMenuSelectOption | null>(
+    GITHUB_LABELS[0]
+  );
+
+  return (
+    <Dialog open disableEnforceFocus>
+      <Dropdown
+        label="Dropdown"
+        options={GITHUB_LABELS}
+        onChange={handleChange}
+        value={value}
+        InputDropdownProps={{ sdsStyle: "square" }}
+      />
+    </Dialog>
+  );
+
+  function handleChange(newValue: DefaultMenuSelectOption | null) {
+    setValue(newValue);
+  }
 };
 
 // From https://github.com/abdonrd/github-labels

--- a/src/core/Dropdown/style.ts
+++ b/src/core/Dropdown/style.ts
@@ -35,6 +35,7 @@ export const StyledPopper = styled(Popper)`
       color: ${colors?.gray[500]};
       padding: ${spacings?.s}px;
       min-width: 244px;
+      z-index: 1400; // allows the dropdown to be used in modals
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Increase default z-index of `Dropdown`'s menu.
- **Why:** The dropdown's `MenuSelect` (menu option component) did not have a sufficiently high z-index to allow Dropdown to be used inside of modal/dialogs.

### Testing
http://localhost:6006/?path=/story/dropdown--inside-modal

### Demos
#### Before: 
![Screen Shot 2021-10-14 at 2 57 44 PM](https://user-images.githubusercontent.com/7562933/137401247-3e322f1a-3982-4887-91ac-4f9b78609e83.png)

#### After: 
![Screen Shot 2021-10-14 at 2 56 58 PM](https://user-images.githubusercontent.com/7562933/137401254-725322cf-c3fe-40e5-8011-f35511d2821d.png)

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)