### PR TITLE
chore: update commit linter

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,11 +1,19 @@
-name: Lint Commit Messages
-on: [pull_request]
+name: Lint PR commit
+
+on:
+  pull_request:
+    types:
+      - reopened
+      - opened
+      - edited
+      - synchronize
 
 jobs:
-  commitlint:
+  main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: amannn/action-semantic-pull-request@v3.4.2
         with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+          validateSingleCommit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -108,6 +108,8 @@ This repo uses [Commitizen](https://github.com/commitizen/cz-cli) to ensure the
 commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/),
 so we can do semantic versioning properly
 
+NOTE: If your PR has more than one commit, please kindly make sure the first line of your commit reflects the most important commit type, so Semantic Release will trigger the right release version. More details [here](https://github.com/amannn/action-semantic-pull-request#action-semantic-pull-request)
+
 NOTE: Commitizen command is automatically triggered through [Husky](https://github.com/typicode/husky) when you write a commit message. However, you can always do `^ + C` to skip Commitizen if you're not ready to submit a PR!
 
 ## Major/Breaking Change Release


### PR DESCRIPTION
Update github action linter used to lint both PR title and commit messages! Thank you!