### PR TITLE
refactor(tooltip component): update Tooltip props and styling

### DIFF
--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -1,19 +1,27 @@
 import { css } from "@emotion/css";
+import { Box, Grid } from "@material-ui/core/";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import { Args, Story } from "@storybook/react";
 import React from "react";
+import Button from "../Button";
 import TooltipTableContent from "../TooltipTableContent/index";
 import Tooltip from "./index";
-
-const tooltipContent =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
 const Demo = (props: Args): JSX.Element => {
   const { title } = props;
   return (
-    <Tooltip title={title} {...props}>
-      <InfoOutlinedIcon />
-    </Tooltip>
+    <div>
+      Hover over the info icon to view the tooltip.
+      <div
+        style={{
+          margin: "125px",
+        }}
+      >
+        <Tooltip title={title} {...props}>
+          <InfoOutlinedIcon />
+        </Tooltip>
+      </div>
+    </div>
   );
 };
 
@@ -24,20 +32,35 @@ export default {
 
 const Template: Story = (args) => <Demo {...args} />;
 
-export const Action = Template.bind({});
+export const Dark = Template.bind({});
 
-Action.args = {
+Dark.args = {
   arrow: true,
-  inverted: true,
-  title: tooltipContent,
+  placement: "top",
+  sdsStyle: "dark",
+  subtitle: "dolor sit amet",
+  title: "Lorem ipsum",
 };
 
-export const Info = Template.bind({});
+export const Light = Template.bind({});
 
-Info.args = {
+Light.args = {
   arrow: true,
-  inverted: false,
-  title: tooltipContent,
+  placement: "top",
+  sdsStyle: "light",
+  title:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+};
+
+export const LightWide = Template.bind({});
+
+LightWide.args = {
+  arrow: true,
+  placement: "top",
+  sdsStyle: "light",
+  title:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  width: "wide",
 };
 
 const rows = [
@@ -69,6 +92,7 @@ const alert = "Some values do not pass the selected filters.";
 export const Table = Template.bind({});
 
 Table.args = {
+  followCursor: true,
   title: <TooltipTableContent alert={alert} data={data} />,
 };
 
@@ -81,5 +105,93 @@ const arrow = css`
 StyledArrow.args = {
   arrow: true,
   classes: { arrow },
-  title: tooltipContent,
+  title:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
 };
+
+const PlacementDemo = (): JSX.Element => {
+  return (
+    <Box sx={{ width: 500, margin: 75 }}>
+      <Grid container spacing={8} justifyContent="center">
+        <Grid item>
+          <Tooltip title="Text" placement="top-start" arrow open>
+            <Button>top-start</Button>
+          </Tooltip>
+          <Tooltip title="Text" placement="top" arrow open>
+            <Button>top</Button>
+          </Tooltip>
+          <Tooltip title="Text" placement="top-end" arrow open>
+            <Button>top-end</Button>
+          </Tooltip>
+        </Grid>
+      </Grid>
+      <Grid container justifyContent="center">
+        <Grid
+          item
+          container
+          spacing={8}
+          xs={6}
+          alignItems="flex-start"
+          direction="column"
+        >
+          <Grid item>
+            <Tooltip title="Text" placement="left-start" arrow open>
+              <Button>left-start</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Text" placement="left" arrow open>
+              <Button>left</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Text" placement="left-end" arrow open>
+              <Button>left-end</Button>
+            </Tooltip>
+          </Grid>
+        </Grid>
+        <Grid
+          item
+          container
+          spacing={8}
+          xs={6}
+          alignItems="flex-end"
+          direction="column"
+        >
+          <Grid item>
+            <Tooltip title="Text" placement="right-start" arrow open>
+              <Button>right-start</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Text" placement="right" arrow open>
+              <Button>right</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Text" placement="right-end" arrow open>
+              <Button>right-end</Button>
+            </Tooltip>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid container spacing={8} justifyContent="center">
+        <Grid item>
+          <Tooltip title="Text" placement="bottom-start" arrow open>
+            <Button>bottom-start</Button>
+          </Tooltip>
+          <Tooltip title="Text" placement="bottom" arrow open>
+            <Button>bottom</Button>
+          </Tooltip>
+          <Tooltip title="Text" placement="bottom-end" arrow open>
+            <Button>bottom-end</Button>
+          </Tooltip>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+const PlacementTemplate: Story = (args) => <PlacementDemo />;
+
+export const PlacementPreview = PlacementTemplate.bind({});

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -5,21 +5,37 @@ import {
   TooltipProps as RawTooltipProps,
 } from "@material-ui/core";
 import React from "react";
-import { arrowCss, ExtraProps, tooltipCss } from "./style";
+import { arrowCss, ExtraProps, Subtitle, tooltipCss } from "./style";
 
 type TooltipProps = ExtraProps & RawTooltipProps;
 
 export { TooltipProps };
 
 const Tooltip = (props: TooltipProps): JSX.Element => {
-  const { inverted = false, ...rest } = props;
+  const {
+    inverted = false,
+    sdsStyle = "light",
+    subtitle,
+    title,
+    width,
+    ...rest
+  } = props;
+
+  if (props.hasOwnProperty("inverted")) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Warning: Tooltips using the inverted prop will be deprecated. Please use sdsStyle: 'dark' | 'light' instead."
+    );
+  }
 
   const theme = useTheme();
 
   const extraProps = {
     /* stylelint-disable property-no-unknown -- false positive */
     inverted,
+    sdsStyle,
     theme,
+    width,
     /* stylelint-enable property-no-unknown -- false positive */
   };
 
@@ -35,9 +51,26 @@ const Tooltip = (props: TooltipProps): JSX.Element => {
     props,
   });
 
+  const content = (
+    <>
+      {title}
+      {subtitle && <Subtitle>{subtitle}</Subtitle>}
+    </>
+  );
+
+  const leaveDelay = inverted || sdsStyle === "dark" ? 0 : 500;
+
   // (thuang): {...rest} needs to be first, otherwise it will overwrite latter
   // props
-  return <RawTooltip {...rest} interactive classes={{ arrow, tooltip }} />;
+  return (
+    <RawTooltip
+      {...rest}
+      classes={{ arrow, tooltip }}
+      leaveDelay={leaveDelay}
+      interactive
+      title={content}
+    />
+  );
 };
 
 function mergeClass({

--- a/src/core/Tooltip/style.ts
+++ b/src/core/Tooltip/style.ts
@@ -1,6 +1,10 @@
 import { css } from "@emotion/css";
+import styled from "@emotion/styled";
 import {
   fontBodyXs,
+  fontHeaderXs,
+  fontHeaderXxs,
+  getBorders,
   getColors,
   getShadows,
   getSpacings,
@@ -9,36 +13,80 @@ import {
 
 export interface ExtraProps extends Props {
   inverted?: boolean;
+  sdsStyle?: "dark" | "light";
+  subtitle?: string;
+  width?: "wide";
 }
 
-export const tooltipCss = (props: ExtraProps): string => {
-  const { inverted } = props;
+const dark = (props: ExtraProps): string => {
+  const spacings = getSpacings(props);
 
-  const colors = getColors(props);
-  const shadows = getShadows(props);
+  return css`
+    ${fontHeaderXs(props)}
+    background-color: black;
+    color: white;
+    text-align: center;
+    max-width: 250px;
+    padding: ${spacings?.s}px ${spacings?.l}px;
+  `;
+};
+
+const light = (props: ExtraProps): string => {
   const spacings = getSpacings(props);
 
   return css`
     ${fontBodyXs(props)}
+    background-color: white;
+    color: black;
+    text-align: left;
+    max-width: 250px;
+    padding: ${spacings?.xs}px ${spacings?.l}px;
+  `;
+};
 
-    background-color: ${inverted ? "black" : "white"};
-    border: 1px solid ${colors?.gray["300"]};
+const wide = (): string => {
+  return css`
+    max-width: 550px;
+  `;
+};
+
+export const Subtitle = styled.div`
+  ${fontHeaderXxs}
+
+  ${(props: ExtraProps) => {
+    const colors = getColors(props);
+
+    return `
+      color: ${colors?.gray["400"]};
+    `;
+  }}
+`;
+
+export const tooltipCss = (props: ExtraProps): string => {
+  const { inverted, sdsStyle, width } = props;
+
+  const borders = getBorders(props);
+  const shadows = getShadows(props);
+
+  return css`
+    ${sdsStyle === "dark" || inverted ? dark(props) : light(props)}
+    ${width === "wide" && wide()}
+
+    border: ${borders?.gray["300"]};
     box-shadow: ${shadows?.m};
-    color: ${inverted ? "white" : "black"};
-    padding: ${spacings?.l}px;
   `;
 };
 
 export const arrowCss = (props: ExtraProps): string => {
-  const { inverted } = props;
+  const { inverted, sdsStyle } = props;
 
-  const colors = getColors(props);
+  const borders = getBorders(props);
 
   return css`
-    color: ${inverted ? "black" : "white"};
+    color: ${inverted || sdsStyle === "dark" ? "black" : "white"};
 
     &:before {
-      border: 1px solid ${colors?.gray[300]};
+      border: ${inverted || sdsStyle === "dark" ? null : borders?.gray["300"]};
     }
   `;
 };


### PR DESCRIPTION
[[SC-152181](https://app.shortcut.com/sci-design-system/story/152181/update-tooltip-component-for-sds)] Update Tooltip component for SDS

**Figma Link:** https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=4175%3A25153 

* Adds sdsStyle: 'dark' | 'light' to replace the `inverted` prop
  * Currently backwards compatible with `inverted` so not a breaking change, but added a warning that `inverted` will be deprecated
* Subtitle text option for dark tooltips
* Additional width option for light tooltips
* Set `leaveDelay` to 500ms for light tooltips
* Added a story demonstrating the difference placement options for the tooltip
  * Synced with @clarsen-czi and decided to use MUI's native `placement` prop rather than the `orientation` currently outlined in Figma.

**Dark tooltip (with subtitle):**
![Screen Shot 2021-10-15 at 3 41 52 PM](https://user-images.githubusercontent.com/53838890/137562460-3ebfdec3-d5e1-4f59-91d7-1cff063ba198.png)


**Light tooltip:**
![Screen Shot 2021-10-15 at 3 41 58 PM](https://user-images.githubusercontent.com/53838890/137562470-fd3f0447-ecc4-4379-9fbb-ac979ed113c0.png)


**Light tooltip ("wide"):**
![Screen Shot 2021-10-15 at 3 42 08 PM](https://user-images.githubusercontent.com/53838890/137562485-f7d2b982-d91e-484d-a6a6-9b0514831cd2.png)

**Placement demo:**
![Screen Shot 2021-10-15 at 3 42 15 PM](https://user-images.githubusercontent.com/53838890/137562493-af073195-19e3-4235-b9c1-01b8ec10beaa.png)
