### PR TITLE
fix(inputdropdown): add error, warning, disabled states for input dropdown; fix minimal styles

### DIFF
--- a/src/core/ComplexFilter/index.tsx
+++ b/src/core/ComplexFilter/index.tsx
@@ -79,6 +79,7 @@ export default function ComplexFilter<
         <InputDropdownComponent
           label={label}
           onClick={handleClick}
+          sdsStage={open ? "userInput" : "default"}
           {...InputDropdownProps}
         />
 

--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -65,10 +65,11 @@ MultipleSelectWithSearch.args = {
   search: true,
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
+  /* stylelint-disable-next-line */
   paper: {
-    width: "200px",
     padding: "50px",
+    width: "200px",
   },
 }));
 

--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import { Args, Story } from "@storybook/react";
 import React, { useState } from "react";
 import { noop } from "src/common/utils";
@@ -23,6 +24,14 @@ export default {
 
 const Template: Story = (args) => <Demo {...args} />;
 const LABEL = "Click Target";
+
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  disabled: true,
+  label: LABEL,
+  onChange: noop,
+};
 
 export const SingleSelect = Template.bind({});
 
@@ -56,13 +65,22 @@ MultipleSelectWithSearch.args = {
   search: true,
 };
 
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    width: "200px",
+    padding: "50px",
+  },
+}));
+
 export const InsideModal = (): JSX.Element => {
   const [value, setValue] = useState<DefaultMenuSelectOption | null>(
     GITHUB_LABELS[0]
   );
 
+  const classes = useStyles();
+
   return (
-    <Dialog open disableEnforceFocus>
+    <Dialog open disableEnforceFocus classes={{ paper: classes.paper }}>
       <Dropdown
         label="Dropdown"
         options={GITHUB_LABELS}

--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -50,6 +50,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
   PopperComponent = StyledPopper,
   PaperComponent = StyledPaper,
   InputDropdownComponent = InputDropdown,
+  ...rest
 }: DropdownProps<Multiple>): JSX.Element {
   const isControlled = propValue !== undefined;
 
@@ -80,7 +81,9 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
       <InputDropdownComponent
         label={label}
         onClick={handleClick}
+        sdsStage={open ? "userInput" : "default"}
         {...InputDropdownProps}
+        {...rest}
       />
       <PopperComponent open={open} anchorEl={anchorEl}>
         <MenuSelect

--- a/src/core/InputDropdown/index.stories.tsx
+++ b/src/core/InputDropdown/index.stories.tsx
@@ -16,7 +16,7 @@ const Demo = (props: Args): JSX.Element => {
         disabled={disabled}
         label={label}
         onClick={onClick}
-        open={open}
+        sdsStage={open ? "userInput" : "default"}
         sdsStyle={sdsStyle}
         {...rest}
       />
@@ -33,6 +33,23 @@ export default {
 
 const Template: Story = (args) => <Demo {...args} />;
 
+export const Error = Template.bind({});
+
+Error.args = {
+  disabled: false,
+  intent: "error",
+  label: "Dropdown",
+  sdsStyle: "square",
+};
+
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  disabled: true,
+  label: "Dropdown",
+  sdsStyle: "square",
+};
+
 export const Minimal = Template.bind({});
 
 Minimal.args = {
@@ -45,6 +62,15 @@ export const Square = Template.bind({});
 
 Square.args = {
   disabled: false,
+  label: "Dropdown",
+  sdsStyle: "square",
+};
+
+export const Warning = Template.bind({});
+
+Warning.args = {
+  disabled: false,
+  intent: "warning",
   label: "Dropdown",
   sdsStyle: "square",
 };

--- a/src/core/InputDropdown/index.tsx
+++ b/src/core/InputDropdown/index.tsx
@@ -6,7 +6,14 @@ import { InputDropdownProps, StyledInputDropdown } from "./styles";
 export { InputDropdownProps };
 
 const InputDropdown = (props: InputDropdownProps): JSX.Element => {
-  const { label } = props;
+  const { label, open } = props;
+
+  if (open !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Warning: InputDropdown prop `open` has been replaced by `sdsStage` and will be deprecated."
+    );
+  }
 
   return (
     <StyledInputDropdown {...props}>

--- a/src/core/InputDropdown/styles.ts
+++ b/src/core/InputDropdown/styles.ts
@@ -14,9 +14,11 @@ import {
 
 export interface InputDropdownProps extends Props {
   disabled?: boolean;
+  intent?: "default" | "error" | "warning";
   label: string;
   onClick: (event: React.MouseEvent<HTMLElement>) => void;
   open?: boolean;
+  sdsStage: "default" | "userInput";
   sdsStyle?: "minimal" | "square" | "rounded";
 }
 
@@ -156,18 +158,19 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const doNotForwardProps = ["intent", "sdsStage", "sdsStyle"];
+const doNotForwardProps = ["intent", "open", "sdsStage", "sdsStyle"];
 
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: InputDropdownProps) => {
-    const { disabled, intent, sdsStage, sdsStyle } = props;
+    const { disabled, intent, open, sdsStage, sdsStyle } = props;
 
     return css`
       ${inputDropdownStyles(props)}
       ${sdsStyle === "minimal" && minimal(props)}
       ${sdsStyle === "square" && square(props)}
+      ${open && userInput(props)}
       ${sdsStage === "userInput" && userInput(props)}
       ${intent === "warning" && warning(props)}
       ${intent === "error" && error(props)}

--- a/src/core/InputDropdown/styles.ts
+++ b/src/core/InputDropdown/styles.ts
@@ -130,15 +130,33 @@ const userInput = (props: InputDropdownProps): SerializedStyles => {
 
 const warning = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
+  const yellow = colors?.warning[400];
   return css`
-    border-color: ${colors?.warning[400]};
+    border-color: ${yellow};
+
+    &:hover {
+      border-color: ${yellow};
+    }
+
+    &:active {
+      border-color: ${yellow};
+    }
   `;
 };
 
 const error = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
+  const red = colors?.error[400];
   return css`
-    border-color: ${colors?.error[400]};
+    border-color: ${red};
+
+    &:hover {
+      border-color: ${red};
+    }
+
+    &:active {
+      border-color: ${red};
+    }
   `;
 };
 

--- a/src/core/InputDropdown/styles.ts
+++ b/src/core/InputDropdown/styles.ts
@@ -27,7 +27,9 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
   const spacings = getSpacings(props);
 
   return css`
+    border: 1px solid ${colors?.gray[400]};
     color: ${colors?.gray[500]};
+    cursor: pointer;
 
     .MuiButton-label {
       display: flex;
@@ -53,11 +55,18 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 
     &:hover {
       background-color: unset;
-      color: ${colors?.gray[600]};
+      border-color: ${colors?.gray[500]};
+      color: ${palette?.text?.primary};
+
+      path {
+        fill: ${colors?.gray[600]};
+      }
     }
 
     &:active {
+      border-color: ${colors?.primary[400]};
       color: ${palette?.text?.primary};
+
       path {
         fill: ${colors?.primary[400]};
       }
@@ -66,18 +75,33 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 };
 
 const minimal = (props: InputDropdownProps): SerializedStyles => {
+  const colors = getColors(props);
+  const palette = getPalette(props);
+
   return css`
+    border: none;
+
     span {
       ${fontHeaderS(props)}
+    }
+
+    &:hover {
+      color: ${colors?.gray[600]};
+    }
+
+    &:active {
+      color: ${palette?.text?.primary};
     }
   `;
 };
 
 const square = (props: InputDropdownProps): SerializedStyles => {
   const corners = getCorners(props);
+
   return css`
-    border: 1px solid currentColor;
     border-radius: ${corners?.m}px;
+    height: 34px;
+    min-width: 90px;
 
     .MuiButton-label {
       justify-content: space-between;
@@ -89,15 +113,30 @@ const square = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const isOpen = (props: InputDropdownProps): SerializedStyles => {
+const userInput = (props: InputDropdownProps): SerializedStyles => {
+  const colors = getColors(props);
   const palette = getPalette(props);
   return css`
     span {
       color: ${palette?.text?.primary};
     }
     path {
-      fill: ${palette?.text?.primary};
+      fill: ${colors?.gray[500]};
     }
+  `;
+};
+
+const warning = (props: InputDropdownProps): SerializedStyles => {
+  const colors = getColors(props);
+  return css`
+    border-color: ${colors?.warning[400]};
+  `;
+};
+
+const error = (props: InputDropdownProps): SerializedStyles => {
+  const colors = getColors(props);
+  return css`
+    border-color: ${colors?.error[400]};
   `;
 };
 
@@ -105,28 +144,33 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
 
   return css`
+    cursor: default;
+
     span {
       color: ${colors?.gray[300]};
     }
+
     path {
       fill: ${colors?.gray[300]};
     }
   `;
 };
 
-const doNotForwardProps = ["sdsStyle"];
+const doNotForwardProps = ["intent", "sdsStage", "sdsStyle"];
 
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: InputDropdownProps) => {
-    const { disabled, open, sdsStyle } = props;
+    const { disabled, intent, sdsStage, sdsStyle } = props;
 
     return css`
       ${inputDropdownStyles(props)}
       ${sdsStyle === "minimal" && minimal(props)}
       ${sdsStyle === "square" && square(props)}
-      ${open && isOpen(props)}
+      ${sdsStage === "userInput" && userInput(props)}
+      ${intent === "warning" && warning(props)}
+      ${intent === "error" && error(props)}
       ${disabled && isDisabled(props)}
     `;
   }}


### PR DESCRIPTION
### Summary
- **What:**
  - Add error and warning states to InputDropdown
  - Add a story for disabled state
  - Improve visibility of modal state for Dropdown
  - Adding props `intent` and `sdsStage`
  - Add deprecation warning for prop `open`
- **Why:** To match [spec](https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=1876%3A21139)

### Testing
http://localhost:6006/?path=/story/dropdown--disabled
http://localhost:6006/?path=/story/dropdown--inside-modal
http://localhost:6006/?path=/story/inputdropdown--error
http://localhost:6006/?path=/story/inputdropdown--disabled
http://localhost:6006/?path=/story/inputdropdown--warning

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)