### PR TITLE
docs(readme): update setup docs to reflect how to use default theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ To use the default theme, please do the following:
 1. Import the default theme object and use it in Material UI's `<ThemeProvider />`:
 
    ```tsx
-     import { defaultTheme } from '@chanzuckerberg/czifui/core/styles`
+     import { defaultTheme } from "czifui";
      import { ThemeProvider } from "@material-ui/core/styles";
+      import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
 
-     <ThemeProvider theme={defaultTheme}>
-       <YourApp />
-     </ThemeProvider>
+    <EmotionThemeProvider theme={defaultTheme}>
+      <ThemeProvider theme={defaultTheme}>
+        <YourApp />
+      </ThemeProvider>
+    </EmotionThemeProvider>
    ```
 
 1. Optional: If you want to override the default theme, please use `defaultAppTheme`, override the options, and then call `createTheme` to generate
@@ -104,7 +107,7 @@ To use the default theme, please do the following:
 
 ```tsx
   import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
-  import { defaultAppTheme, makeThemeOptions } from '@chanzuckerberg/czifui/core/styles`
+  import { defaultAppTheme, makeThemeOptions } from "czifui";
   import { StylesProvider, ThemeProvider } from "@material-ui/core/styles";
   import createTheme from "@material-ui/core/styles/createTheme";
 

--- a/src/core/ComplexFilter/style.ts
+++ b/src/core/ComplexFilter/style.ts
@@ -35,6 +35,7 @@ export const StyledPopper = styled(Popper)`
       color: ${colors?.gray[500]};
       padding: ${spacings?.s}px;
       min-width: 244px;
+      z-index: 1400; // allows the dropdown to be used in modals
     `;
   }}
 `;


### PR DESCRIPTION
## Summary

**Documentation**
Shortcut ticket: [sh-164653](https://app.shortcut.com/sci-design-system/story/164653/spike-test-styling-an-sds-component-with-css-modules-in-a-sandbox-environment)
Update docs to reflect how default theme is implemented in a project (add emotion theme wrapper)
Also add z-index to ComplexFilter dropdown to allow it to be rendered in a portal as IDseq will be doing

## Visual
N/A

## Checklist

~- [ ] Default Story~
~- [ ] LivePreview Story~
~- [ ] Test Story~
~- [ ] Tests written~
~- [ ] Variables from `defaultTheme.ts` used wherever possible~
~- [ ] If updating an existing component, depreciate flag has been used where necessary~