### PR TITLE
fix(button): fix keyboard navigation for Button. Hover state on focus…

### DIFF
--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -24,11 +24,15 @@ const ButtonBase = styled(Button, {
       padding: ${spacings?.xs}px ${spacings?.l}px;
       min-width: 120px;
       height: 34px;
-      &:hover {
+      &:hover, &:focus {
         color: white;
         background-color: ${colors?.primary[500]};
         border: none;
         box-shadow: none;
+      }
+      &:focus {
+        outline: 5px auto Highlight;
+        outline: 5px auto -webkit-focus-ring-color;
       }
       &:active {
         color: white;
@@ -80,8 +84,12 @@ const MinimalButton = styled(Button, {
     }
     return ``;
   }}
-  &:hover {
+  &:hover, &:focus {
     background-color: transparent;
+  }
+  &:focus {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
   }
 `;
 
@@ -90,7 +98,7 @@ export const PrimaryMinimalButton = styled(MinimalButton)`
     const colors = getColors(props);
 
     return `
-      &:hover {
+      &:hover, &:focus {
         color: ${colors?.primary[500]};
       }
       &:active {
@@ -108,9 +116,10 @@ export const SecondaryMinimalButton = styled(MinimalButton)`
     const colors = getColors(props);
 
     return `
-      &:hover {
+      &:hover, &:focus {
         color: ${colors?.gray[500]};
       }
+      
       &:active {
         color: ${colors?.gray[600]};
       }
@@ -130,6 +139,10 @@ export const StyledButton = styled(Button, {
     return !sdsPropNames.includes(prop.toString());
   },
 })`
+  &:focus {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
   ${(props: IsRounded) => {
     if (!props.isRounded) return ``;
 


### PR DESCRIPTION
… and add default focus borders

MUI removes the default focus borders for buttons, so keyboard users aren't able to navigate. This
PR applies our :hover styles to :focus as well so they will be visible for keyboard users. It also
puts back the focus borders - these are only visible to keyboard users.

This is the focus state for secondary button (same as hover state):
<img width="272" alt="Screen Shot 2021-11-19 at 8 22 39 AM" src="https://user-images.githubusercontent.com/8015489/142656689-435fadb1-e2fa-45d0-9e96-a15df430f853.png">

This is what it looks like when someone uses a keyboard to get to a minimal button - now they can see they are on a button :
<img width="274" alt="Screen Shot 2021-11-19 at 8 23 36 AM" src="https://user-images.githubusercontent.com/8015489/142656790-8221bb31-03db-467f-b078-ce0362da0236.png">
