### PR TITLE
feat(menuselect): add onInputChange prop to MenuSelect

### DIFF
--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -5,6 +5,7 @@ import {
   AutocompleteRenderOptionState,
 } from "@material-ui/lab";
 import React from "react";
+import { noop } from "src/common/utils";
 import {
   InputBaseWrapper,
   StyledAutocomplete,
@@ -21,6 +22,7 @@ export interface DefaultMenuSelectOption {
 
 interface ExtraProps extends StyleProps {
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode;
+  onInputChange?: (event: React.SyntheticEvent) => void;
 }
 
 type CustomAutocompleteProps<
@@ -57,6 +59,7 @@ export default function MenuSelect<
     disableCloseOnSelect = multiple,
     noOptionsText = "No options",
     search = false,
+    onInputChange = noop,
   } = props;
 
   return (
@@ -74,6 +77,7 @@ export default function MenuSelect<
             placeholder="Search"
             ref={params.InputProps.ref}
             inputProps={params.inputProps}
+            onChange={onInputChange}
             autoFocus
             endAdornment={
               <InputAdornment position="end">


### PR DESCRIPTION
This PR adds an `onInputChange` prop of type `(event: React.SyntheticEvent) => void` that is passed to the `onChange` prop of the child `StyledInputBase` component. This allows anyone using the `MenuSelect` component to pass a callback function that fires whenever a user changes input in the search box.

This functionality is needed by Aspen - we want a dropdown list of locations, but there are >20,000 possibilities. We need this functionality to limit what options are passed to the component based on what the user is searching for.