### PR TITLE
fix(complexfilter): fix ComplexFilter show virtual keyboard on hidden…

### DIFF
--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -79,6 +79,7 @@ export default function MenuSelect<
             inputProps={params.inputProps}
             onChange={onInputChange}
             autoFocus
+            readOnly={!search}
             endAdornment={
               <InputAdornment position="end">
                 <StyledSearchIcon />


### PR DESCRIPTION
… input

ComplexFilter and MenuSelect has autoFocus on input field, even when search is not enabled. This
causes mobile devices to show virtual keyboard on the hidden input field unnecessarily