### PR TITLE
fix(complexfilter): click target preserves pending value

### DIFF
--- a/src/core/ComplexFilter/index.tsx
+++ b/src/core/ComplexFilter/index.tsx
@@ -55,12 +55,13 @@ export default function ComplexFilter<
     getInitialValue()
   );
 
-  const [pendingValue, setPendingValue] = useState<
-    Value<DefaultMenuSelectOption, true>
-  >([]);
+  const [pendingValue, setPendingValue] = useState<DefaultMenuSelectOption[]>(
+    getInitialValue() as DefaultMenuSelectOption[]
+  );
 
   useEffect(() => {
     onChange(value);
+    setPendingValue(value as DefaultMenuSelectOption[]);
   }, [value]);
 
   useEffect(() => {
@@ -117,10 +118,6 @@ export default function ComplexFilter<
   );
 
   function handleClick(event: React.MouseEvent<HTMLElement>) {
-    if (multiple) {
-      setPendingValue(value as DefaultMenuSelectOption[]);
-    }
-
     setAnchorEl(event.currentTarget);
   }
 
@@ -164,9 +161,8 @@ export default function ComplexFilter<
     }
 
     const newValue =
-      (value as Value<DefaultMenuSelectOption, true>)?.filter(
-        (item) => item !== option
-      ) || null;
+      (value as DefaultMenuSelectOption[])?.filter((item) => item !== option) ||
+      null;
 
     setValue(newValue as Value<DefaultMenuSelectOption, Multiple>);
   }

--- a/src/core/MenuSelect/style.ts
+++ b/src/core/MenuSelect/style.ts
@@ -49,7 +49,9 @@ export const InputBaseWrapper = styled.div`
   }}
 `;
 
-export const StyledInputBase = styled(InputBase)<{ search: boolean }>`
+export const StyledInputBase = styled(InputBase, {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})<{ search: boolean }>`
   width: 100%;
   /* (thuang): Works with attribute inputMode: "none" to hide mobile keyboard */
   caret-color: ${({ search }) => (search ? "auto" : "transparent")};


### PR DESCRIPTION
I think the reason why `pendingValue` is `[]` is because I added `<ClickAwayListener />` component, following MUIv5's example [here](https://mui.com/components/autocomplete/#githubs-picker), which also has the same problem 😆 

The problem is:

1. Click on click target to open menu dropdown
2. Select an option (value: [], pendingValue: [1])
3. Click on click target, `handleClick()` will `setPendingValue(value)` (value: [], pendingValue: []) <--- pendingValue is back to `[]`
4. Now `ClickAwayListener` detects we're clicking outside of the container it's watching, so it fires `handleClose()`, which then `setValue(pendingValue)` (value: [], pendingValue[]) <-- both value and pendingValue are back to `[]`

So the solution in this PR is to remove `setPendingValue(value)` from `handleClick()`, since pendingValue is already at the expected state at step 2!

And then to make sure clicking on a pill will sync `value` and `pendingValue`, I added a `setPendingValue()` in `handleDelete()` callback

PTAL thank you!