### PR TITLE
refactor(icon): refactor icon component to add type hinting

### DIFF
--- a/src/core/Icon/index.stories.tsx
+++ b/src/core/Icon/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Args, Story } from "@storybook/react";
 import React from "react";
 import Icon from "./index";
-import { iconMap } from "./map";
+import { iconMap, IconNameToSizes } from "./map";
 
 const Demo = (props: Args): JSX.Element => {
   const { px, sdsIcon, sdsSize, sdsType } = props;
@@ -76,11 +76,12 @@ export const IconBank = () => {
       }}
     >
       {icons.map(([sdsIcon, icon]) => {
-        const { availableSizes } = icon;
-        const sdsSize = availableSizes[availableSizes.length - 1];
+        const { largeIcon } = icon;
+        const sdsSize = largeIcon ? "l" : "s";
 
         return (
           <div
+            key={sdsIcon}
             style={{
               alignItems: "center",
               border: "1px solid black",
@@ -90,7 +91,11 @@ export const IconBank = () => {
               padding: "5px",
             }}
           >
-            <Icon sdsSize={sdsSize} sdsIcon={sdsIcon} sdsType="static" />
+            <Icon
+              sdsSize={sdsSize}
+              sdsIcon={sdsIcon as keyof IconNameToSizes}
+              sdsType="static"
+            />
             <span>{sdsIcon}</span>
             <span>(size {sdsSize})</span>
           </div>

--- a/src/core/Icon/index.tsx
+++ b/src/core/Icon/index.tsx
@@ -1,24 +1,16 @@
 import React from "react";
-import { iconMap } from "./map";
+import { iconMap, IconNameToSizes } from "./map";
 import { ExtraProps, StyledIcon, StyledSvgIcon } from "./style";
 
-interface Props extends ExtraProps {
-  sdsIcon: keyof typeof iconMap;
-}
+type Props<IconName extends keyof IconNameToSizes> = ExtraProps<IconName>;
 
-const Icon = ({ sdsIcon, sdsSize, sdsType }: Props): JSX.Element | null => {
+function Icon<IconName extends keyof IconNameToSizes>({
+  sdsIcon,
+  sdsSize,
+  sdsType,
+}: Props<IconName>): JSX.Element | null {
   const icon = iconMap[sdsIcon] ?? {};
-  const { availableSizes, largeIcon, smallIcon } = icon;
-
-  if (!availableSizes?.includes(sdsSize)) {
-    console.error(
-      `Error: Icon ${sdsIcon} not available in size ${sdsSize}.
-      Please choose from available sizes for this icon: ${availableSizes?.join(
-        ", "
-      )}.`
-    );
-    return null;
-  }
+  const { largeIcon, smallIcon } = icon;
 
   if ((sdsSize === "xs" || sdsSize === "s") && smallIcon) {
     return (
@@ -29,6 +21,7 @@ const Icon = ({ sdsIcon, sdsSize, sdsType }: Props): JSX.Element | null => {
           component={smallIcon}
           sdsSize={sdsSize}
           sdsType={sdsType}
+          sdsIcon={sdsIcon}
         />
       </StyledIcon>
     );
@@ -42,16 +35,18 @@ const Icon = ({ sdsIcon, sdsSize, sdsType }: Props): JSX.Element | null => {
           component={largeIcon}
           sdsSize={sdsSize}
           sdsType={sdsType}
+          sdsIcon={sdsIcon}
         />
       </StyledIcon>
     );
   }
 
+  // eslint-disable-next-line no-console
   console.error(
     `Error: Icon ${sdsIcon} not found for size ${sdsSize}. This is a czifui problem.`
   );
 
   return null;
-};
+}
 
 export default Icon;

--- a/src/core/Icon/map.ts
+++ b/src/core/Icon/map.ts
@@ -66,277 +66,276 @@ import { ReactComponent as IconXMarkCircleSmall } from "../../common/svgs/IconXM
 import { ReactComponent as IconXMarkLarge } from "../../common/svgs/IconXMarkLarge.svg";
 import { ReactComponent as IconXMarkSmall } from "../../common/svgs/IconXMarkSmall.svg";
 
-export type IconSizes = "xs" | "s" | "l" | "xl";
-
-interface Props {
-  [key: string]: {
-    availableSizes: IconSizes[];
-    largeIcon: FC<CustomSVGProps> | null;
-    smallIcon: FC<CustomSVGProps> | null;
-  };
+export interface IconNameToSizes {
+  barChartHorizontal3: "xs" | "s";
+  barChartVertical3: "xs" | "s";
+  barChartVertical4: "xs" | "s";
+  check: "xs" | "s";
+  checkCircle: "xs" | "s" | "l" | "xl";
+  chevronDown: "xs" | "s" | "l" | "xl";
+  chevronRight: "xs" | "s" | "l" | "xl";
+  chevronUp: "xs" | "s" | "l" | "xl";
+  copy: "xs" | "s" | "l" | "xl";
+  download: "xs" | "s" | "l" | "xl";
+  edit: "xs" | "s" | "l" | "xl";
+  exclamationMarkCircle: "xs" | "s" | "l" | "xl";
+  eyeOpen: "xs" | "s";
+  flask: "l" | "xl";
+  flaskPrivate: "xl";
+  flaskPublic: "xl";
+  globe: "xs" | "s";
+  grid: "l" | "xl";
+  gridPrivate: "xl";
+  gridPublic: "xl";
+  infoCircle: "xs" | "s" | "l" | "xl";
+  infoSpeechBubble: "l" | "xl";
+  lightBulb: "xs" | "s";
+  linesHorizontal: "xs" | "s";
+  link: "xs" | "s";
+  list: "xs" | "s";
+  loading: "xs" | "s" | "l" | "xl";
+  lock: "xs" | "s";
+  lockCircle: "xs" | "s";
+  minus: "xs" | "s";
+  open: "xs" | "s";
+  people: "xs" | "s" | "l" | "xl";
+  percentage: "xs" | "s";
+  plus: "xs" | "s";
+  plusCircle: "xs" | "s";
+  projectPrivate: "xl";
+  projectPublic: "xl";
+  puzzlePiece: "xs" | "s";
+  questionMark: "l" | "xl";
+  refresh: "xs" | "s" | "l" | "xl";
+  save: "l" | "xl";
+  search: "xs" | "s" | "l" | "xl";
+  share: "l" | "xl";
+  slidersHorizontal: "l" | "xl";
+  table: "xs" | "s";
+  treeDendogram: "l" | "xl";
+  treeHorizontal: "xs" | "s" | "l" | "xl";
+  treeHorizontalPrivate: "xl";
+  treeHorizontalPublic: "xl";
+  treeVertical: "xs" | "s";
+  xMark: "xs" | "s" | "l" | "xl";
+  xMarkCircle: "xs" | "s";
 }
 
-const iconMap: Props = {
+type Props = Record<
+  keyof IconNameToSizes,
+  {
+    largeIcon: FC<CustomSVGProps> | null;
+    smallIcon: FC<CustomSVGProps> | null;
+  }
+>;
+
+export const iconMap: Props = {
   barChartHorizontal3: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconBarChartHorizontal3Small,
   },
   barChartVertical3: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconBarChartVertical3Small,
   },
   barChartVertical4: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconBarChartVertical4Small,
   },
   check: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconCheckSmall,
   },
   checkCircle: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconCheckCircleLarge,
     smallIcon: IconCheckCircleSmall,
   },
   chevronDown: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconChevronDownLarge,
     smallIcon: IconChevronDownSmall,
   },
   chevronRight: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconChevronRightLarge,
     smallIcon: IconChevronRightSmall,
   },
   chevronUp: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconChevronUpLarge,
     smallIcon: IconChevronUpSmall,
   },
   copy: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconCopyLarge,
     smallIcon: IconCopySmall,
   },
   download: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconDownloadLarge,
     smallIcon: IconDownloadSmall,
   },
   edit: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconEditSmall,
   },
   exclamationMarkCircle: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconExclamationMarkCircleLarge,
     smallIcon: IconExclamationMarkCircleSmall,
   },
   eyeOpen: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconEyeOpenSmall,
   },
   flask: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconFlaskLarge,
     smallIcon: null,
   },
   flaskPrivate: {
-    availableSizes: ["xl"],
     largeIcon: IconFlaskPrivateLarge,
     smallIcon: null,
   },
   flaskPublic: {
-    availableSizes: ["xl"],
     largeIcon: IconFlaskPublicLarge,
     smallIcon: null,
   },
   globe: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconGlobeSmall,
   },
   grid: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconGridLarge,
     smallIcon: null,
   },
   gridPrivate: {
-    availableSizes: ["xl"],
     largeIcon: IconGridPrivateLarge,
     smallIcon: null,
   },
   gridPublic: {
-    availableSizes: ["xl"],
     largeIcon: IconGridPublicLarge,
     smallIcon: null,
   },
   infoCircle: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconInfoCircleLarge,
     smallIcon: IconInfoCircleSmall,
   },
   infoSpeechBubble: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconInfoSpeechBubbleLarge,
     smallIcon: null,
   },
   lightBulb: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconLightBulbSmall,
   },
   linesHorizontal: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconLinesHorizontalSmall,
   },
   link: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconLinkSmall,
   },
   list: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconListSmall,
   },
   loading: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconLoadingLarge,
     smallIcon: IconLoadingSmall,
   },
   lock: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconLockSmall,
   },
   lockCircle: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconLockCircleSmall,
   },
   minus: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconMinusSmall,
   },
   open: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconOpenSmall,
   },
   people: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconPeopleLarge,
     smallIcon: IconPeopleSmall,
   },
   percentage: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconPercentageSmall,
   },
   plus: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconPlusSmall,
   },
   plusCircle: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconPlusCircleSmall,
   },
   projectPrivate: {
-    availableSizes: ["xl"],
     largeIcon: IconProjectPrivateLarge,
     smallIcon: null,
   },
   projectPublic: {
-    availableSizes: ["xl"],
     largeIcon: IconProjectPublicLarge,
     smallIcon: null,
   },
   puzzlePiece: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconPuzzlePieceSmall,
   },
   questionMark: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconQuestionMarkLarge,
     smallIcon: null,
   },
   refresh: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconRefreshLarge,
     smallIcon: IconRefreshSmall,
   },
   save: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconSaveLarge,
     smallIcon: null,
   },
   search: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconSearchLarge,
     smallIcon: IconSearchSmall,
   },
   share: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconShareLarge,
     smallIcon: null,
   },
   slidersHorizontal: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconSlidersHorizontalLarge,
     smallIcon: null,
   },
   table: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconTableSmall,
   },
   treeDendogram: {
-    availableSizes: ["l", "xl"],
     largeIcon: IconTreeDendogramLarge,
     smallIcon: null,
   },
   treeHorizontal: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconTreeHorizontalLarge,
     smallIcon: IconTreeHorizontalSmall,
   },
   treeHorizontalPrivate: {
-    availableSizes: ["xl"],
     largeIcon: IconTreeHorizontalPrivateLarge,
     smallIcon: null,
   },
   treeHorizontalPublic: {
-    availableSizes: ["xl"],
     largeIcon: IconTreeHorizontalPublicLarge,
     smallIcon: null,
   },
   treeVertical: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconTreeVerticalSmall,
   },
   xMark: {
-    availableSizes: ["xs", "s", "l", "xl"],
     largeIcon: IconXMarkLarge,
     smallIcon: IconXMarkSmall,
   },
   xMarkCircle: {
-    availableSizes: ["xs", "s"],
     largeIcon: null,
     smallIcon: IconXMarkCircleSmall,
   },
 };
-
-export { iconMap };

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -3,14 +3,18 @@ import styled from "@emotion/styled";
 import { SvgIcon, SvgIconProps } from "@material-ui/core";
 import { FC } from "react";
 import { getColors, getIconSizes, Props } from "../styles";
-import { IconSizes } from "./map";
+import { IconNameToSizes } from "./map";
 
-export interface ExtraProps extends Props {
-  sdsSize: IconSizes;
+export interface ExtraProps<IconName extends keyof IconNameToSizes>
+  extends Props {
+  sdsIcon: IconName;
+  sdsSize: IconNameToSizes[IconName];
   sdsType: "iconButton" | "interactive" | "static";
 }
 
-const iconSize = (props: ExtraProps): SerializedStyles => {
+function iconSize<IconName extends keyof IconNameToSizes>(
+  props: ExtraProps<IconName>
+): SerializedStyles {
   const { sdsSize } = props;
   const iconSizes = getIconSizes(props);
 
@@ -18,17 +22,21 @@ const iconSize = (props: ExtraProps): SerializedStyles => {
     height: ${iconSizes?.[sdsSize]?.height}px;
     width: ${iconSizes?.[sdsSize]?.width}px;
   `;
-};
+}
 
-const staticStyle = (props: ExtraProps): SerializedStyles => {
+function staticStyle<IconName extends keyof IconNameToSizes>(
+  props: ExtraProps<IconName>
+): SerializedStyles {
   const colors = getColors(props);
 
   return css`
     color: ${colors?.primary[400]};
   `;
-};
+}
 
-const interactive = (props: ExtraProps): SerializedStyles => {
+function interactive<IconName extends keyof IconNameToSizes>(
+  props: ExtraProps<IconName>
+): SerializedStyles {
   const colors = getColors(props);
 
   return css`
@@ -46,18 +54,21 @@ const interactive = (props: ExtraProps): SerializedStyles => {
       color: ${colors?.gray[300]};
     }
   `;
-};
+}
 
-const doNotForwardProps = ["sdsSize", "sdsType"];
+const doNotForwardProps = ["sdsIcon", "sdsSize", "sdsType"];
 
-type StyledSvgIconProps = ExtraProps &
-  CustomSVGProps &
-  SvgIconProps<"svg", { component: FC<CustomSVGProps> }>;
+type StyledSvgIconProps<IconName extends keyof IconNameToSizes> =
+  ExtraProps<IconName> &
+    CustomSVGProps &
+    SvgIconProps<"svg", { component: FC<CustomSVGProps> }>;
 
 export const StyledSvgIcon = styled(SvgIcon, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
-  ${(props: StyledSvgIconProps) => {
+  ${<IconName extends keyof IconNameToSizes>(
+    props: StyledSvgIconProps<IconName>
+  ) => {
     const { sdsType } = props;
 
     return css`


### PR DESCRIPTION
Add type hinting that given a props.iconName, props.sdsSize is narrowed down to values available to
the props.iconName

Example:

`barChartHorizontal3` only accepts `"xs" | "s"`, so passing `sdsSize="l"` throws a TS error 🙆‍♂️ 

<img width="1326" alt="Screen Shot 2022-01-03 at 3 34 58 PM" src="https://user-images.githubusercontent.com/6309723/147991919-2746750d-0cdc-43a5-ac80-2de7c58a14ed.png">

[Slack context](https://czi-sci.slack.com/archives/C01TD8YUE86/p1636156524002000)