### PR TITLE
fix(iconbutton): iconButton now forwards ref

### DIFF
--- a/src/core/IconButton/index.tsx
+++ b/src/core/IconButton/index.tsx
@@ -1,13 +1,15 @@
 import { IconButtonProps as RawIconButtonProps } from "@material-ui/core";
-import React from "react";
+import React, { forwardRef } from "react";
 import { ExtraProps, StyledIconButton } from "./style";
 
 type IconButtonProps = ExtraProps & RawIconButtonProps;
 
 export { IconButtonProps };
 
-const IconButton = (props: IconButtonProps): JSX.Element => {
-  return <StyledIconButton {...props} />;
-};
+const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  (props, ref): JSX.Element => {
+    return <StyledIconButton {...props} ref={ref} />;
+  }
+);
 
 export default IconButton;


### PR DESCRIPTION
Since functional components don't have `ref` prop, we need to use `forwardRef` to pass `props.ref` to the target component manually!

Thanks again for spotting this, @codemonkey800 🙏 

Context: https://docs.google.com/document/d/1p7y8qptmw4rrURSEjV7ApAqAzBNMIhQKjn7Obz69dJo/edit#bookmark=id.kx5wxx9qmisj