### PR TITLE
feat(button): add v5 color support

### DIFF
--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -1,146 +1,181 @@
 import DeleteIcon from "@material-ui/icons/Delete";
-import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/react";
+import { Meta, Story } from "@storybook/react";
 import React from "react";
 import Button from "./index";
 
-export const text = "Click me!";
+export default {
+  argTypes: {
+    color: {
+      control: {
+        type: "radio",
+      },
+      options: ["primary", "secondary", "error", "info", "warning"],
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
+  component: Button,
+  title: "Button",
+} as Meta;
 
-export const actions = {
-  onClick: action("onClick"),
+const TEXT = "Click me!";
+
+const Template: Story = (props) => {
+  return <Button {...props}>{TEXT}</Button>;
 };
 
-storiesOf("Button", module).add("Rounded Primary", () => (
-  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
-    {text}
-  </Button>
-));
+// RoundedPrimary
+export const RoundedPrimary = Template.bind({});
 
-storiesOf("Button", module).add("Rounded Primary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="rounded"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+RoundedPrimary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "rounded",
+  sdsType: "primary",
+};
 
-storiesOf("Button", module).add("Rounded Secondary", () => (
-  <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="secondary">
-    {text}
-  </Button>
-));
+RoundedPrimary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
-storiesOf("Button", module).add("Rounded Secondary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="rounded"
-    sdsType="secondary"
-  >
-    {text}
-  </Button>
-));
+// RoundedSecondary
+export const RoundedSecondary = Template.bind({});
 
-storiesOf("Button", module).add("Square Primary", () => (
-  <Button onClick={actions.onClick} sdsStyle="square" sdsType="primary">
-    {text}
-  </Button>
-));
+RoundedSecondary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "rounded",
+  sdsType: "secondary",
+  variant: "outlined",
+};
 
-storiesOf("Button", module).add("Square Primary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="square"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+RoundedSecondary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
-storiesOf("Button", module).add("Square Secondary", () => (
-  <Button onClick={actions.onClick} sdsStyle="square" sdsType="secondary">
-    {text}
-  </Button>
-));
+// SquarePrimary
+export const SquarePrimary = Template.bind({});
 
-storiesOf("Button", module).add("Square Secondary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="square"
-    sdsType="secondary"
-  >
-    {text}
-  </Button>
-));
+SquarePrimary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "square",
+  sdsType: "primary",
+};
 
-storiesOf("Button", module).add("Minimal Primary", () => (
-  <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="primary">
-    {text}
-  </Button>
-));
+SquarePrimary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
-storiesOf("Button", module).add("Minimal Primary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="minimal"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+// SquareSecondary
+export const SquareSecondary = Template.bind({});
 
-storiesOf("Button", module).add("Minimal Secondary", () => (
-  <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="secondary">
-    {text}
-  </Button>
-));
+SquareSecondary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "square",
+  sdsType: "secondary",
+  variant: "outlined",
+};
 
-storiesOf("Button", module).add("Minimal Secondary Disabled", () => (
-  <Button
-    disabled
-    onClick={actions.onClick}
-    sdsStyle="minimal"
-    sdsType="secondary"
-  >
-    {text}
-  </Button>
-));
+SquareSecondary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
-storiesOf("Button", module).add("Minimal No Caps - use sparingly", () => (
-  <Button
-    isAllCaps={false}
-    onClick={actions.onClick}
-    sdsStyle="minimal"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+// MinimalPrimary
+export const MinimalPrimary = Template.bind({});
 
-storiesOf("Button", module).add("With Icon", () => (
-  <Button
-    startIcon={<DeleteIcon />}
-    onClick={actions.onClick}
-    sdsStyle="rounded"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+MinimalPrimary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "minimal",
+  sdsType: "primary",
+  variant: "text",
+};
 
-storiesOf("Button", module).add("Minimal With Icon", () => (
-  <Button
-    startIcon={<DeleteIcon />}
-    onClick={actions.onClick}
-    sdsStyle="minimal"
-    sdsType="primary"
-  >
-    {text}
-  </Button>
-));
+MinimalPrimary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+// MinimalSecondary
+export const MinimalSecondary = Template.bind({});
+
+MinimalSecondary.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "minimal",
+  sdsType: "secondary",
+  variant: "text",
+};
+
+MinimalSecondary.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+// MinimalSecondaryNoCapsUseSparingly
+export const MinimalSecondaryNoCapsUseSparingly: Story = (props) => (
+  <Template {...props} />
+);
+
+MinimalSecondaryNoCapsUseSparingly.args = {
+  color: "primary",
+  disabled: false,
+  isAllCaps: false,
+  sdsStyle: "minimal",
+  sdsType: "secondary",
+  variant: "text",
+};
+
+MinimalSecondaryNoCapsUseSparingly.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+// RoundedPrimaryWithIcon
+export const RoundedPrimaryWithIcon = Template.bind({});
+
+RoundedPrimaryWithIcon.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "rounded",
+  sdsType: "primary",
+  startIcon: <DeleteIcon />,
+};
+
+RoundedPrimaryWithIcon.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+// MinimalPrimaryWithIcon
+export const MinimalPrimaryWithIcon = Template.bind({});
+
+MinimalPrimaryWithIcon.args = {
+  color: "primary",
+  disabled: false,
+  sdsStyle: "minimal",
+  sdsType: "primary",
+  startIcon: <DeleteIcon />,
+  variant: "text",
+};
+
+MinimalPrimaryWithIcon.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -4,20 +4,25 @@ import {
   ExtraProps,
   MinimalButton,
   RoundedButton,
+  SecondaryMinimalButton,
   SquareButton,
   StyledButton,
 } from "./style";
 
-export type ButtonProps = Omit<RawButtonProps, "color"> & ExtraProps;
+export interface ButtonProps extends Omit<RawButtonProps, "color">, ExtraProps {
+  sdsStyle?: "minimal" | "rounded" | "square";
+  sdsType?: "primary" | "secondary";
+}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (props: ButtonProps, ref): JSX.Element | null => {
     const {
       // TEMP(thuang): Set as any to get around the type error.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      color = "" as any,
+      color = undefined as any,
       sdsStyle,
       sdsType,
+      ...rest
     } = props;
 
     if (!sdsStyle || !sdsType) {
@@ -38,56 +43,37 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isAllCaps =
       typeof props?.isAllCaps === "boolean" ? props?.isAllCaps : true;
 
-    const propsWithDefault = { ...props, isAllCaps };
+    const propsWithDefault = { ...rest, color, isAllCaps };
 
     switch (true) {
       case sdsStyle === "rounded" && sdsType === "primary":
         return (
-          <RoundedButton
-            color={color || "primary"}
-            ref={ref}
-            variant="contained"
-            {...propsWithDefault}
-          />
+          <RoundedButton ref={ref} variant="contained" {...propsWithDefault} />
         );
       case sdsStyle === "rounded" && sdsType === "secondary":
         return (
-          <RoundedButton
-            color={color || "primary"}
-            ref={ref}
-            variant="outlined"
-            {...propsWithDefault}
-          />
+          <RoundedButton ref={ref} variant="outlined" {...propsWithDefault} />
         );
       case sdsStyle === "square" && sdsType === "primary":
         return (
-          <SquareButton
-            color={color || "primary"}
-            ref={ref}
-            variant="contained"
-            {...propsWithDefault}
-          />
+          <SquareButton ref={ref} variant="contained" {...propsWithDefault} />
         );
       case sdsStyle === "square" && sdsType === "secondary":
         return (
-          <SquareButton
-            color={color || "primary"}
-            ref={ref}
-            variant="outlined"
-            {...propsWithDefault}
-          />
+          <SquareButton ref={ref} variant="outlined" {...propsWithDefault} />
         );
-      case sdsStyle === "minimal":
+      case sdsStyle === "minimal" && sdsType === "primary":
+        return <MinimalButton ref={ref} variant="text" {...propsWithDefault} />;
+      case sdsStyle === "minimal" && sdsType === "secondary":
         return (
-          <MinimalButton
-            color={color || "primary"}
+          <SecondaryMinimalButton
             ref={ref}
             variant="text"
             {...propsWithDefault}
           />
         );
       default:
-        return <StyledButton color={color} {...propsWithDefault} ref={ref} />;
+        return <StyledButton {...propsWithDefault} ref={ref} />;
     }
   }
 );

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -1,25 +1,24 @@
 import { ButtonProps as RawButtonProps } from "@material-ui/core";
 import React from "react";
 import {
-  PrimaryMinimalButton,
+  ExtraProps,
+  MinimalButton,
   RoundedButton,
-  SecondaryMinimalButton,
   SquareButton,
   StyledButton,
 } from "./style";
 
-interface SdsProps {
-  isAllCaps?: boolean;
-  isRounded?: boolean;
-  sdsStyle?: "minimal" | "rounded" | "square";
-  sdsType?: "primary" | "secondary";
-}
-export type ButtonProps = RawButtonProps & SdsProps;
+export type ButtonProps = Omit<RawButtonProps, "color"> & ExtraProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (props: ButtonProps, ref): JSX.Element | null => {
-    const sdsStyle = props?.sdsStyle;
-    const sdsType = props?.sdsType;
+    const {
+      // TEMP(thuang): Set as any to get around the type error.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      color = "" as any,
+      sdsStyle,
+      sdsType,
+    } = props;
 
     if (!sdsStyle || !sdsType) {
       // eslint-disable-next-line no-console
@@ -38,13 +37,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     // isAllCaps is only used for the Minimal Button.  It defaults to true.
     const isAllCaps =
       typeof props?.isAllCaps === "boolean" ? props?.isAllCaps : true;
+
     const propsWithDefault = { ...props, isAllCaps };
 
     switch (true) {
       case sdsStyle === "rounded" && sdsType === "primary":
         return (
           <RoundedButton
-            color="primary"
+            color={color || "primary"}
             ref={ref}
             variant="contained"
             {...propsWithDefault}
@@ -53,7 +53,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       case sdsStyle === "rounded" && sdsType === "secondary":
         return (
           <RoundedButton
-            color="primary"
+            color={color || "primary"}
             ref={ref}
             variant="outlined"
             {...propsWithDefault}
@@ -62,7 +62,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       case sdsStyle === "square" && sdsType === "primary":
         return (
           <SquareButton
-            color="primary"
+            color={color || "primary"}
             ref={ref}
             variant="contained"
             {...propsWithDefault}
@@ -71,32 +71,23 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       case sdsStyle === "square" && sdsType === "secondary":
         return (
           <SquareButton
-            color="primary"
+            color={color || "primary"}
             ref={ref}
             variant="outlined"
             {...propsWithDefault}
           />
         );
-      case sdsStyle === "minimal" && sdsType === "primary":
+      case sdsStyle === "minimal":
         return (
-          <PrimaryMinimalButton
-            color="primary"
-            ref={ref}
-            variant="text"
-            {...propsWithDefault}
-          />
-        );
-      case sdsStyle === "minimal" && sdsType === "secondary":
-        return (
-          <SecondaryMinimalButton
-            color="default"
+          <MinimalButton
+            color={color || "primary"}
             ref={ref}
             variant="text"
             {...propsWithDefault}
           />
         );
       default:
-        return <StyledButton {...propsWithDefault} ref={ref} />;
+        return <StyledButton color={color} {...propsWithDefault} ref={ref} />;
     }
   }
 );

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -12,7 +12,7 @@ export interface ExtraProps {
   isAllCaps?: boolean;
   isRounded?: boolean;
   /**
-   * TODO(thuang): Remove custom `color` prop when we upgrade to MUIv5.
+   * TODO(185930): Remove custom `color` prop when we upgrade to MUIv5.
    * Currently we're extending MUIv4 Button's `color` props from "primary" and
    * "secondary" to the following ones.
    */

--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -11,8 +11,6 @@ import {
 export interface ExtraProps {
   isAllCaps?: boolean;
   isRounded?: boolean;
-  sdsStyle?: "minimal" | "rounded" | "square";
-  sdsType?: "primary" | "secondary";
   /**
    * TODO(thuang): Remove custom `color` prop when we upgrade to MUIv5.
    * Currently we're extending MUIv4 Button's `color` props from "primary" and
@@ -23,21 +21,12 @@ export interface ExtraProps {
 
 type V5ButtonProps = Props & ExtraProps & Omit<ButtonProps, "color">;
 
-// Please keep this in sync with the props used in `ExtraProps`
-const doNotForwardProps = [
-  "isAllCaps",
-  "isRounded",
-  "sdsStyle",
-  "sdsType",
-  /**
-   * TODO(thuang): Exception. This is a native MUI prop.
-   */
-  // "color",
-];
+// Please add non MUI props from `ExtraProps` here
+const NON_MUI_PROPS = ["isAllCaps", "isRounded"];
 
 const ButtonBase = styled(Button, {
   shouldForwardProp: (prop) => {
-    return !doNotForwardProps.includes(String(prop));
+    return !NON_MUI_PROPS.includes(String(prop));
   },
 })`
   box-shadow: none;
@@ -100,10 +89,25 @@ interface IsAllCaps extends V5ButtonProps {
 
 export const MinimalButton = styled(Button, {
   shouldForwardProp: (prop) => {
-    return !doNotForwardProps.includes(String(prop));
+    return !NON_MUI_PROPS.includes(String(prop));
   },
 })`
-  ${v5ColorSupport}
+  ${(props) => {
+    const colors = getColors(props);
+    const { color: colorProp = "primary" } = props;
+
+    const color = colors?.[colorProp];
+
+    return `
+      color: ${color?.[400]};
+      &:hover, &:focus {
+        color: ${color?.[500]};
+      }
+      &:active {
+        color: ${color?.[600]};
+      }
+    `;
+  }}
 
   ${(props: IsAllCaps) => {
     const spacings = getSpaces(props);
@@ -128,6 +132,20 @@ export const MinimalButton = styled(Button, {
   }
 `;
 
+export const SecondaryMinimalButton = styled(MinimalButton)`
+  ${() => {
+    return `
+      color: black;
+      &:hover, &:focus {
+        color: black;
+      }
+      &:active {
+        color: black;
+      }
+    `;
+  }}
+`;
+
 // Legacy support for backwards-compatible props
 interface IsRounded extends V5ButtonProps {
   isRounded?: boolean;
@@ -135,7 +153,7 @@ interface IsRounded extends V5ButtonProps {
 
 export const StyledButton = styled(Button, {
   shouldForwardProp: (prop) => {
-    return !doNotForwardProps.includes(String(prop));
+    return !NON_MUI_PROPS.includes(String(prop));
   },
 })`
   &:focus {
@@ -159,11 +177,7 @@ export const StyledButton = styled(Button, {
 
 function v5ColorSupport(props: V5ButtonProps) {
   const colors = getColors(props);
-  const {
-    variant = "contained",
-    color: colorProp = "primary",
-    sdsType,
-  } = props;
+  const { variant = "contained", color: colorProp = "primary" } = props;
 
   const color = colors?.[colorProp];
 
@@ -186,15 +200,7 @@ function v5ColorSupport(props: V5ButtonProps) {
         background-color: ${color?.[500]};
       }
     `,
-    text: `
-      color: ${sdsType === "primary" ? color?.[400] : "black"};
-      &:hover, &:focus {
-        color: ${sdsType === "primary" ? color?.[500] : "black"};
-      }
-      &:active {
-        color: ${sdsType === "primary" ? color?.[600] : "black"};
-      }
-    `,
+    text: ``,
   };
 
   return result[variant];

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 3`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-i2916s MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >
@@ -74,7 +74,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 3`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1rnfyys MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
     tabindex="0"
     type="button"
   >
@@ -150,7 +150,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 6`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-i2916s MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >
@@ -164,7 +164,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 6`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1rnfyys MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
     tabindex="0"
     type="button"
   >
@@ -240,7 +240,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 9`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-i2916s MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >
@@ -254,7 +254,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 9`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1rnfyys MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
     tabindex="0"
     type="button"
   >
@@ -330,7 +330,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 12`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-i2916s MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >
@@ -344,7 +344,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 12`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1rnfyys MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
     tabindex="0"
     type="button"
   >
@@ -366,7 +366,7 @@ exports[`<Dialog /> renders Dialog left positioned buttons 1`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1rnfyys MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
     tabindex="0"
     type="button"
   >
@@ -380,7 +380,7 @@ exports[`<Dialog /> renders Dialog left positioned buttons 1`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-i2916s MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
     tabindex="0"
     type="button"
   >

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 3`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa"
     tabindex="0"
     type="button"
   >
@@ -74,7 +74,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 3`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3"
     tabindex="0"
     type="button"
   >
@@ -150,7 +150,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 6`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa"
     tabindex="0"
     type="button"
   >
@@ -164,7 +164,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 6`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3"
     tabindex="0"
     type="button"
   >
@@ -240,7 +240,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 9`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa"
     tabindex="0"
     type="button"
   >
@@ -254,7 +254,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 9`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3"
     tabindex="0"
     type="button"
   >
@@ -330,7 +330,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 12`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa"
     tabindex="0"
     type="button"
   >
@@ -344,7 +344,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 12`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3"
     tabindex="0"
     type="button"
   >
@@ -366,7 +366,7 @@ exports[`<Dialog /> renders Dialog left positioned buttons 1`] = `
   data-testid="dialog-actions"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3 MuiButton-containedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-contained css-1yomru3"
     tabindex="0"
     type="button"
   >
@@ -380,7 +380,7 @@ exports[`<Dialog /> renders Dialog left positioned buttons 1`] = `
     />
   </button>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa MuiButton-outlinedPrimary"
+    class="MuiButtonBase-root MuiButton-root MuiButton-outlined css-matdoa"
     tabindex="0"
     type="button"
   >

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -29,6 +29,7 @@ const defaultThemeColors = {
     "100": "#FEF2F2",
     "200": "#FBE8E8",
     "400": "#DC132C",
+    "500": "#C61128",
     "600": "#B70016",
   },
   gray: {


### PR DESCRIPTION
---
title: "type_of_change(scope_of_work): ticket title"
reviewers: "sds-eng, sds-design"
---

## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](link)

This ticket adds MUI button v5 color support, which expands v4's options "primary", "secondary", to `color?: "primary" | "secondary" | "success" | "error" | "warning" | "info";`

Implementation inspiration from: https://github.com/mui-org/material-ui/issues/13875#issuecomment-841869537

![demo](https://user-images.githubusercontent.com/6309723/152639276-722e65f7-e5b3-4eb4-9c79-fec57a09e026.gif)


## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @sds-design
