### PR TITLE
fix: Update README alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ yarn add @emotion/css @emotion/react @emotion/styled @material-ui/core @material
 1. Run: `yarn && yarn start`
 1. A new browser tab will be automatically opened with the storybook!
 
-![image](https://user-images.githubusercontent.com/6309723/124010513-c09f0900-d993-11eb-8fc7-f66a0b4ec16e.png)
+![ ](https://user-images.githubusercontent.com/6309723/124010513-c09f0900-d993-11eb-8fc7-f66a0b4ec16e.png)
 
 #### Tips
 
@@ -136,7 +136,7 @@ To use the default theme, please do the following:
 
 `czifui` implements the Science Initiative Design System as documented in [Figma](https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference). As a result, it's very useful to get familiar with the available **theme variables**, such as `colors`, `spacings`, `typography`, etc., so you can leverage the theme properly in your application.
 
-![image](https://user-images.githubusercontent.com/6309723/123888574-a53aec00-d908-11eb-96b3-e32381e30c9a.png)
+![Science Design System Reference file in Figma with Pages outlined in the left panel](https://user-images.githubusercontent.com/6309723/123888574-a53aec00-d908-11eb-96b3-e32381e30c9a.png)
 (NOTE: Please use the left panel to find different types of components (Bases, Genes, DNA, and Chromosomes))
 
 ## How to Use


### PR DESCRIPTION
---
title: "type_of_change(scope_of_work): ticket title"
reviewers: "sds-eng, sds-design"
---

## Summary

The repo's readme has two images with some alt text. I'm proposing some more descriptive alt text because I like to contribute alt text for fun! 

Fixes #107

Shortcut ticket: none

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @sds-design

^I don't think any of this checklist applies to this change, but please let me know if there is something I should account for.

I know reviewing alt text isn't something everyone has experience with, so if you'd like to know my thought process I'd be happy to discuss and link resources on this PR. Thanks in advance for reviewing my work! 🌻 