### PR TITLE
feat(menuselect): add InputBaseProps

### DIFF
--- a/src/core/MenuSelect/index.stories.tsx
+++ b/src/core/MenuSelect/index.stories.tsx
@@ -180,6 +180,7 @@ MultiSelect.args = {
 export const MultiSelectWithSearch = Template.bind({});
 
 MultiSelectWithSearch.args = {
+  InputBaseProps: { placeholder: "Custom placeholder..." },
   multiple: true,
   search: true,
 };

--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -1,4 +1,7 @@
-import { InputAdornment } from "@material-ui/core";
+import {
+  InputAdornment,
+  InputBaseProps as RawInputBaseProps,
+} from "@material-ui/core";
 import {
   AutocompleteProps,
   AutocompleteRenderInputParams,
@@ -23,6 +26,7 @@ export interface DefaultMenuSelectOption {
 interface ExtraProps extends StyleProps {
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode;
   onInputChange?: (event: React.SyntheticEvent) => void;
+  InputBaseProps?: RawInputBaseProps;
 }
 
 type CustomAutocompleteProps<
@@ -60,6 +64,7 @@ export default function MenuSelect<
     noOptionsText = "No options",
     search = false,
     onInputChange = noop,
+    InputBaseProps = {},
   } = props;
 
   return (
@@ -92,6 +97,7 @@ export default function MenuSelect<
                 <StyledSearchIcon />
               </InputAdornment>
             }
+            {...InputBaseProps}
           />
         </InputBaseWrapper>
       )}


### PR DESCRIPTION
Expose InputBaseProps as an API

fix #121

---
title: feat(menuselect): add InputBaseProps
reviewers: sds-eng
---

## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**

https://github.com/chanzuckerberg/sci-components/issues/121

As seen below, we can now pass props (e.g., placeholder) to `InputBase` as expected! 

<img width="369" alt="Screen Shot 2022-02-22 at 10 10 51 AM" src="https://user-images.githubusercontent.com/6309723/155193838-f6cc2290-8153-4f8a-9d94-a3e58e773eee.png">


## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @sds-design
