### PR TITLE
feat(corner styles): add Corners to styles-dictionary

### DIFF
--- a/src/common/styles-dictionary/css/variables.css
+++ b/src/common/styles-dictionary/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 10 Dec 2021 16:31:54 GMT
+ * Generated on Thu, 24 Feb 2022 00:16:20 GMT
  */
 
 :root {
@@ -111,4 +111,8 @@
   --sds-icon-sizes-l-width: 22px;
   --sds-icon-sizes-xl-height: 32px;
   --sds-icon-sizes-xl-width: 32px;
+  --sds-corners-corner-l: 20px;
+  --sds-corners-corner-m: 4px;
+  --sds-corners-corner-s: 2px;
+  --sds-corners-corner-none: 0px;
 }

--- a/src/common/styles-dictionary/scss/_variables.scss
+++ b/src/common/styles-dictionary/scss/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 10 Dec 2021 16:31:54 GMT
+// Generated on Thu, 24 Feb 2022 00:16:20 GMT
 
 $sds-font-letter-spacing-default: 0.3px;
 $sds-font-letter-spacing-caps: 1px;
@@ -107,3 +107,7 @@ $sds-icon-sizes-l-height: 22px;
 $sds-icon-sizes-l-width: 22px;
 $sds-icon-sizes-xl-height: 32px;
 $sds-icon-sizes-xl-width: 32px;
+$sds-corners-corner-l: 20px;
+$sds-corners-corner-m: 4px;
+$sds-corners-corner-s: 2px;
+$sds-corners-corner-none: 0px;

--- a/src/common/styles-dictionary/style-dictionary.json
+++ b/src/common/styles-dictionary/style-dictionary.json
@@ -295,6 +295,12 @@
         "height": { "value": "32px" },
         "width": { "value": "32px" }
       }
+    },
+    "corners": {
+      "cornerL": { "value": "20px" },
+      "cornerM": { "value": "4px" },
+      "cornerS": { "value": "2px" },
+      "cornerNone": { "value": "0px" }
     }
   }
 }


### PR DESCRIPTION
## Summary

**Structural Element (Base)**
Shortcut ticket: [sh-171869](https://app.shortcut.com/sci-design-system/story/171869/replace-corners-in-idseq)
Adds corners to styles-dictionary so we can use them to refactor bases in the CZ ID codebase (corner are already defined in `defaultTheme.ts`.
Based off the values defined in ZeroHeight here: https://sds.czi.design/009eaf17b/p/313aae-corners

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @sds-design
