### PR TITLE
feat(tabs): Add count and small variant

### DIFF
--- a/src/core/Tabs/__snapshots__/index.test.tsx.snap
+++ b/src/core/Tabs/__snapshots__/index.test.tsx.snap
@@ -2,54 +2,217 @@
 
 exports[`<Tabs /> Test story renders snapshot 1`] = `
 <div
-  class="MuiTabs-root css-m4aju7"
-  data-testid="tabs"
+  style="align-items: center; display: flex; gap: 40px; width: 100%;"
 >
-  <div
-    class="MuiTabs-scroller MuiTabs-fixed"
-    style="overflow: hidden;"
-  >
+  <div>
+    <h4>
+      Default
+    </h4>
     <div
-      class="MuiTabs-flexContainer"
-      role="tablist"
+      class="MuiTabs-root css-7c5evh"
+      data-testid="tabs"
+      style="width: 400px;"
     >
-      <button
-        aria-selected="true"
-        class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-17gm9np Mui-selected"
-        role="tab"
-        tabindex="0"
-        type="button"
+      <div
+        class="MuiTabs-scroller MuiTabs-fixed"
+        style="overflow: hidden;"
       >
-        <span
-          class="MuiTab-wrapper"
+        <div
+          class="MuiTabs-flexContainer"
+          role="tablist"
         >
-          Tab One
-        </span>
+          <button
+            aria-selected="true"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds Mui-selected"
+            role="tab"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              <span
+                class="css-1wj4pv3"
+              >
+                <span
+                  class="css-1szlfza"
+                >
+                  Tab One
+                </span>
+                <span
+                  class="css-1mg4zid"
+                >
+                  123
+                </span>
+              </span>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-selected="false"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              Tab Two
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
         <span
-          class="MuiTouchRipple-root"
+          class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorSecondary-3 css-1r8eawc"
+          style="left: 0px; width: 0px;"
         />
-      </button>
-      <button
-        aria-selected="false"
-        class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-17gm9np"
-        role="tab"
-        tabindex="-1"
-        type="button"
-      >
-        <span
-          class="MuiTab-wrapper"
-        >
-          Tab Two
-        </span>
-        <span
-          class="MuiTouchRipple-root"
-        />
-      </button>
+      </div>
     </div>
-    <span
-      class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorSecondary-3 css-1r8eawc"
-      style="left: 0px; width: 0px;"
-    />
+  </div>
+  <div>
+    <h4>
+      Small
+    </h4>
+    <div
+      class="MuiTabs-root css-7c5evh"
+      data-testid="tabs"
+      style="width: 400px;"
+    >
+      <div
+        class="MuiTabs-scroller MuiTabs-fixed"
+        style="overflow: hidden;"
+      >
+        <div
+          class="MuiTabs-flexContainer"
+          role="tablist"
+        >
+          <button
+            aria-selected="true"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-csy3xc Mui-selected"
+            role="tab"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              <span
+                class="css-1wj4pv3"
+              >
+                <span
+                  class="css-1szlfza"
+                >
+                  Tab One
+                </span>
+                <span
+                  class="css-1mg4zid"
+                >
+                  123
+                </span>
+              </span>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-selected="false"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-csy3xc"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              Tab Two
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <span
+          class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorSecondary-3 css-1r8eawc"
+          style="left: 0px; width: 0px;"
+        />
+      </div>
+    </div>
+  </div>
+  <div>
+    <h4>
+      Underlined
+    </h4>
+    <div
+      class="MuiTabs-root css-3mytyp"
+      data-testid="tabs"
+      style="width: 400px;"
+    >
+      <div
+        class="MuiTabs-scroller MuiTabs-fixed"
+        style="overflow: hidden;"
+      >
+        <div
+          class="MuiTabs-flexContainer"
+          role="tablist"
+        >
+          <button
+            aria-selected="true"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds Mui-selected"
+            role="tab"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              <span
+                class="css-1wj4pv3"
+              >
+                <span
+                  class="css-1szlfza"
+                >
+                  Tab One
+                </span>
+                <span
+                  class="css-1mg4zid"
+                >
+                  123
+                </span>
+              </span>
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            aria-selected="false"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds"
+            role="tab"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              Tab Two
+            </span>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <span
+          class="PrivateTabIndicator-root-1 PrivateTabIndicator-colorSecondary-3 css-1r8eawc"
+          style="left: 0px; width: 0px;"
+        />
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/core/Tabs/__snapshots__/index.test.tsx.snap
+++ b/src/core/Tabs/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds Mui-selected"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-rizdpq Mui-selected"
             role="tab"
             tabindex="0"
             type="button"
@@ -32,7 +32,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
               class="MuiTab-wrapper"
             >
               <span
-                class="css-1wj4pv3"
+                class="css-1d9n0h0"
               >
                 <span
                   class="css-1szlfza"
@@ -52,7 +52,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-rizdpq"
             role="tab"
             tabindex="-1"
             type="button"
@@ -93,7 +93,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-csy3xc Mui-selected"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1a0z6ji Mui-selected"
             role="tab"
             tabindex="0"
             type="button"
@@ -102,7 +102,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
               class="MuiTab-wrapper"
             >
               <span
-                class="css-1wj4pv3"
+                class="css-1d9n0h0"
               >
                 <span
                   class="css-1szlfza"
@@ -122,7 +122,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-csy3xc"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1a0z6ji"
             role="tab"
             tabindex="-1"
             type="button"
@@ -163,7 +163,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds Mui-selected"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-rizdpq Mui-selected"
             role="tab"
             tabindex="0"
             type="button"
@@ -172,7 +172,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
               class="MuiTab-wrapper"
             >
               <span
-                class="css-1wj4pv3"
+                class="css-1d9n0h0"
               >
                 <span
                   class="css-1szlfza"
@@ -192,7 +192,7 @@ exports[`<Tabs /> Test story renders snapshot 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-1e93pds"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit css-rizdpq"
             role="tab"
             tabindex="-1"
             type="button"

--- a/src/core/Tabs/components/LabelWithCount/index.tsx
+++ b/src/core/Tabs/components/LabelWithCount/index.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef, useContext } from "react";
+import { TabsContext } from "../common";
+import { Count, Label, Wrapper } from "./style";
+
+interface Props {
+  label: React.ReactNode;
+  count: number;
+}
+
+export default forwardRef<HTMLSpanElement, Props>(function LabelWithCount(
+  props,
+  ref
+): JSX.Element {
+  const { sdsSize = "large" } = useContext(TabsContext);
+  const { label, count } = props;
+
+  return (
+    <Wrapper ref={ref}>
+      <Label sdsSize={sdsSize}>{label}</Label>
+      <Count sdsSize={sdsSize}>{count}</Count>
+    </Wrapper>
+  );
+});

--- a/src/core/Tabs/components/LabelWithCount/style.ts
+++ b/src/core/Tabs/components/LabelWithCount/style.ts
@@ -1,0 +1,79 @@
+import styled from "@emotion/styled";
+import {
+  fontBodyS,
+  fontBodyXs,
+  fontBodyXxs,
+  getColors,
+  getFontWeights,
+  getPalette,
+  getSpaces,
+  Props as StyleProps,
+} from "src/core/styles";
+import { SdsSize } from "../common";
+
+export const Wrapper = styled.span`
+  ${(props) => {
+    const colors = getColors(props);
+    const palette = getPalette(props);
+
+    return `
+      &:hover {
+        color: ${colors?.gray[600]};
+      }
+
+      &:active {
+        color: ${palette?.text?.primary};
+      }
+
+      &:disabled {
+        color: ${colors?.gray[200]};
+      }
+    `;
+  }}
+`;
+
+interface Props extends StyleProps {
+  sdsSize: SdsSize;
+}
+
+export const Label = styled.span`
+  ${(props: Props) => {
+    const { sdsSize } = props;
+
+    const isLarge = sdsSize === "large";
+
+    return isLarge ? fontBodyS(props) : fontBodyXs(props);
+  }}
+
+  ${(props: Props) => {
+    const fontWeights = getFontWeights(props);
+    const spaces = getSpaces(props);
+
+    const { sdsSize } = props;
+
+    const isLarge = sdsSize === "large";
+
+    return `
+      margin-right: ${isLarge ? spaces?.l : spaces?.m}px;
+      font-weight: ${fontWeights?.semibold};
+  `;
+  }}
+`;
+
+export const Count = styled.span`
+  ${(props: Props) => {
+    const { sdsSize } = props;
+
+    const isLarge = sdsSize === "large";
+
+    return isLarge ? fontBodyXs(props) : fontBodyXxs(props);
+  }}
+
+  ${(props: Props) => {
+    const colors = getColors(props);
+
+    return `
+      color: ${colors?.gray[500]};
+    `;
+  }}
+`;

--- a/src/core/Tabs/components/LabelWithCount/style.ts
+++ b/src/core/Tabs/components/LabelWithCount/style.ts
@@ -1,28 +1,22 @@
 import styled from "@emotion/styled";
 import {
+  CommonThemeProps as StyleProps,
   fontBodyS,
   fontBodyXs,
   fontBodyXxs,
   getColors,
   getFontWeights,
-  getPalette,
   getSpaces,
-  Props as StyleProps,
 } from "src/core/styles";
 import { SdsSize } from "../common";
 
 export const Wrapper = styled.span`
   ${(props) => {
     const colors = getColors(props);
-    const palette = getPalette(props);
 
     return `
-      &:hover {
-        color: ${colors?.gray[600]};
-      }
-
       &:active {
-        color: ${palette?.text?.primary};
+        color: black;
       }
 
       &:disabled {

--- a/src/core/Tabs/components/common.ts
+++ b/src/core/Tabs/components/common.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+export type SdsSize = "small" | "large";
+
+export const TabsContext = createContext({ sdsSize: "large" as SdsSize });

--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -5,6 +5,10 @@ import Tabs, { Tab, TabsProps } from "./index";
 
 export default {
   argTypes: {
+    sdsSize: {
+      control: { type: "select" },
+      options: ["large", "small"],
+    },
     tabOneLabel: {
       control: {
         type: "text",
@@ -28,10 +32,12 @@ export default {
 interface TabsArgs extends TabsProps {
   tabOneLabel: string;
   tabTwoLabel: string;
+  tabOneCount?: number;
+  tabTwoCount?: number;
 }
 
 const Template: Story<TabsArgs> = (props: TabsArgs) => {
-  const { tabOneLabel, tabTwoLabel, ...args } = props;
+  const { tabOneLabel, tabTwoLabel, tabOneCount, tabTwoCount, ...args } = props;
 
   const [value, setValue] = useState(0);
 
@@ -44,8 +50,8 @@ const Template: Story<TabsArgs> = (props: TabsArgs) => {
 
   return (
     <Tabs {...args} value={value} onChange={handleTabsChange}>
-      <Tab label={tabOneLabel} />
-      <Tab label={tabTwoLabel} />
+      <Tab label={tabOneLabel} count={tabOneCount} />
+      <Tab label={tabTwoLabel} count={tabTwoCount} />
     </Tabs>
   );
 };
@@ -54,6 +60,7 @@ const Template: Story<TabsArgs> = (props: TabsArgs) => {
 export const Default = Template.bind({});
 
 Default.args = {
+  sdsSize: "large",
   tabOneLabel: "Upload from Your Computer",
   tabTwoLabel: "Upload from Basespace",
   underlined: true,
@@ -73,32 +80,59 @@ Default.parameters = {
 const livePreviewWrapperStyle: React.CSSProperties = {
   alignItems: "center",
   display: "flex",
-  flexDirection: "column",
-  gap: "20px",
+  gap: "40px",
   width: "100%",
 };
 
 function LivePreviewDemo(props: Args): JSX.Element {
   const finalProps = {
     ...props,
-    style: { width: "400px" },
+    style: { width: "200px" },
   };
 
   return (
     <div style={livePreviewWrapperStyle}>
-      <Template
-        tabOneLabel="Tab One"
-        tabTwoLabel="Tab Two"
-        onChange={noop}
-        {...finalProps}
-      />
-      <Template
-        {...finalProps}
-        onChange={noop}
-        tabOneLabel="Tab One"
-        tabTwoLabel="Tab Two"
-        underlined
-      />
+      <div>
+        <Template
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          onChange={noop}
+          underlined
+          {...finalProps}
+        />
+      </div>
+      <div>
+        <Template
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          tabOneCount={123}
+          onChange={noop}
+          underlined
+          {...finalProps}
+        />
+      </div>
+      <div />
+      <div>
+        <Template
+          onChange={noop}
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          sdsSize="small"
+          underlined
+          {...finalProps}
+        />
+      </div>
+      <div>
+        <Template
+          onChange={noop}
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          tabOneCount={123}
+          sdsSize="small"
+          underlined
+          {...finalProps}
+        />
+      </div>
     </div>
   );
 }
@@ -107,10 +141,7 @@ const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
 
 export const LivePreview = LivePreviewTemplate.bind({});
 
-LivePreview.args = {
-  tabOneLabel: "Upload from Your Computer",
-  tabTwoLabel: "Upload from Basespace",
-};
+LivePreview.args = {};
 
 LivePreview.parameters = {
   snapshot: {
@@ -120,15 +151,47 @@ LivePreview.parameters = {
 
 // Test
 function TestDemo(props: Args): JSX.Element {
+  const finalProps = {
+    ...props,
+    "data-testid": "tabs",
+    style: { width: "400px" },
+  };
+
   return (
-    <Template
-      {...props}
-      onChange={noop}
-      tabOneLabel="Tab One"
-      tabTwoLabel="Tab Two"
-      data-testid="tabs"
-      underlined
-    />
+    <div style={livePreviewWrapperStyle}>
+      <div>
+        <h4>Default</h4>
+        <Template
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          tabOneCount={123}
+          onChange={noop}
+          {...finalProps}
+        />
+      </div>
+      <div>
+        <h4>Small</h4>
+        <Template
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          tabOneCount={123}
+          onChange={noop}
+          sdsSize="small"
+          {...finalProps}
+        />
+      </div>
+      <div>
+        <h4>Underlined</h4>
+        <Template
+          onChange={noop}
+          tabOneLabel="Tab One"
+          tabTwoLabel="Tab Two"
+          tabOneCount={123}
+          underlined
+          {...finalProps}
+        />
+      </div>
+    </div>
   );
 }
 

--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -87,7 +87,7 @@ const livePreviewWrapperStyle: React.CSSProperties = {
 function LivePreviewDemo(props: Args): JSX.Element {
   const finalProps = {
     ...props,
-    style: { width: "200px" },
+    style: { width: "250px" },
   };
 
   return (
@@ -106,6 +106,7 @@ function LivePreviewDemo(props: Args): JSX.Element {
           tabOneLabel="Tab One"
           tabTwoLabel="Tab Two"
           tabOneCount={123}
+          tabTwoCount={456}
           onChange={noop}
           underlined
           {...finalProps}
@@ -128,6 +129,7 @@ function LivePreviewDemo(props: Args): JSX.Element {
           tabOneLabel="Tab One"
           tabTwoLabel="Tab Two"
           tabOneCount={123}
+          tabTwoCount={456}
           sdsSize="small"
           underlined
           {...finalProps}

--- a/src/core/Tabs/index.test.tsx
+++ b/src/core/Tabs/index.test.tsx
@@ -17,18 +17,18 @@ describe("<Tabs />", () => {
   it("renders Tabs component", () => {
     render(<Test />);
 
-    const element = screen.getByTestId("tabs");
+    const elements = screen.getAllByTestId("tabs");
 
-    expect(element).not.toBeNull();
+    expect(elements.length).toBeTruthy();
   });
 
   it("renders tab texts", () => {
     render(<Test />);
 
-    const Label1 = screen.getByText(/Tab One/i);
-    const Label2 = screen.getByText(/Tab Two/i);
+    const Label1 = screen.getAllByText(/Tab One/i);
+    const Label2 = screen.getAllByText(/Tab Two/i);
 
-    expect(Label1).toBeTruthy();
-    expect(Label2).toBeTruthy();
+    expect(Label1.length).toBeTruthy();
+    expect(Label2.length).toBeTruthy();
   });
 });

--- a/src/core/Tabs/index.tsx
+++ b/src/core/Tabs/index.tsx
@@ -7,7 +7,7 @@ import { TabsContext } from "./components/common";
 import LabelWithCount from "./components/LabelWithCount";
 import { StyledTab, StyledTabs, TabsProps } from "./style";
 
-export { TabsProps };
+export type { TabsProps };
 
 const TabIndicator = (theme: AppThemeOptions) => {
   const colors = getColors({ theme });

--- a/src/core/Tabs/index.tsx
+++ b/src/core/Tabs/index.tsx
@@ -1,61 +1,13 @@
 import { css } from "@emotion/css";
-import styled from "@emotion/styled";
-import {
-  Tab as RawTab,
-  Tabs as RawTabs,
-  TabsProps as RawTabsProps,
-  useTheme,
-} from "@material-ui/core";
-import React, { ChangeEvent, FormEvent } from "react";
+import { TabProps as RawTabProps, useTheme } from "@material-ui/core";
+import React, { forwardRef, useContext, useMemo } from "react";
 import { AppThemeOptions } from "../styles/common/defaultTheme";
-import {
-  getColors,
-  getPalette,
-  getSpaces,
-} from "../styles/common/selectors/theme";
+import { getColors } from "../styles/common/selectors/theme";
+import { TabsContext } from "./components/common";
+import LabelWithCount from "./components/LabelWithCount";
+import { StyledTab, StyledTabs, TabsProps } from "./style";
 
-// (thuang): https://github.com/mui-org/material-ui/issues/17454#issuecomment-647132303
-// Will be fixed in v5.x
-interface TabsPropsFixed extends Omit<RawTabsProps, "onChange"> {
-  onChange:
-    | ((event: ChangeEvent<Record<string, unknown>>, value: never) => void)
-    | ((event: FormEvent<HTMLButtonElement>) => void);
-}
-
-// (thuang): Use this instead of MUI's raw Tabs. `onChange` type will be fixed
-// in v5.x
-// https://github.com/mui-org/material-ui/issues/17454#issuecomment-647132303
-const TempTabs = (props: TabsPropsFixed) => <RawTabs {...(props as never)} />;
-
-export type TabsProps = TabsPropsFixed & {
-  underlined?: boolean;
-};
-
-const StyledTabs = styled(TempTabs, {
-  shouldForwardProp: (prop) => prop !== "underlined",
-})<TabsProps>`
-  ${(props) => {
-    const { underlined } = props;
-    const colors = getColors(props);
-    const spaces = getSpaces(props);
-
-    return `
-      box-sizing: border-box;
-      padding-bottom: 0px;
-      margin-top: ${spaces?.l}px;
-      margin-bottom: ${spaces?.xl}px;
-      min-height: unset;
-      border-bottom: ${underlined ? `2px solid ${colors?.gray[200]};` : "none"};
-      position: relative;
-      z-index: 1;
-      overflow: inherit;
-
-      & .MuiTabs-scroller {
-        overflow: inherit !important;
-      }
-    `;
-  }}
-`;
+export { TabsProps };
 
 const TabIndicator = (theme: AppThemeOptions) => {
   const colors = getColors({ theme });
@@ -68,47 +20,45 @@ const TabIndicator = (theme: AppThemeOptions) => {
   `;
 };
 
-const Tabs = (props: TabsProps): React.ReactElement => {
+const Tabs = forwardRef<HTMLButtonElement, TabsProps>(function Tabs(
+  props,
+  ref
+): React.ReactElement {
+  const { sdsSize = "large", ...rest } = props;
   const theme = useTheme();
 
+  const contextValue = React.useMemo(() => ({ sdsSize }), [sdsSize]);
+
+  const indicatorProps = useMemo(() => {
+    return { className: TabIndicator(theme) };
+  }, [theme]);
+
   return (
-    <StyledTabs
-      {...props}
-      TabIndicatorProps={{ className: TabIndicator(theme) }}
-    />
+    <TabsContext.Provider value={contextValue}>
+      <StyledTabs TabIndicatorProps={indicatorProps} ref={ref} {...rest} />
+    </TabsContext.Provider>
   );
-};
+});
 
 export default Tabs;
 
-export const Tab = styled(RawTab)`
-  ${(props) => {
-    const colors = getColors(props);
-    const spaces = getSpaces(props);
-    const palette = getPalette(props);
+export interface TabProps extends RawTabProps {
+  count?: number;
+}
 
-    return `
-      color: black;
-      text-transform: none;
-      min-height: unset;
-      // (thuang): Large Tab height is 30px, the offset is 4px
-      height: 26px;
-      font-style: normal;
-      font-weight: 600;
-      font-size: 14px;
-      line-height: 20px;
-      padding: 0;
-      margin: 0 ${spaces?.xl}px ${spaces?.xxs}px 0;
-      min-width: 32px;
-      &:hover {
-        color: ${colors?.gray[600]};
-      }
-      &:active {
-        color: ${palette?.text?.primary};
-      }
-      &:disabled {
-        color: ${colors?.gray[200]};
-      }
-    `;
-  }}
-`;
+export const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
+  props,
+  ref
+) {
+  const { count, label, ...rest } = props;
+  const context = useContext(TabsContext);
+  const Label =
+    // (thuang): `count` can be 0, which is a valid count value.
+    count === undefined ? (
+      label
+    ) : (
+      <LabelWithCount label={label} count={count} />
+    );
+
+  return <StyledTab label={Label} ref={ref} {...rest} {...context} />;
+});

--- a/src/core/Tabs/style.tsx
+++ b/src/core/Tabs/style.tsx
@@ -8,11 +8,10 @@ import {
 import React, { ChangeEvent, FormEvent } from "react";
 import { fontBodyS, fontBodyXs } from "../styles";
 import {
+  CommonThemeProps,
   getColors,
   getFontWeights,
-  getPalette,
   getSpaces,
-  Props,
 } from "../styles/common/selectors/theme";
 import { SdsSize } from "./components/common";
 
@@ -65,24 +64,23 @@ export const StyledTabs = styled(TempTabs, {
 
 const TAB_DO_NOT_FORWARD_PROPS = ["sdsSize"];
 
-interface TabProps extends Props {
+interface TabProps extends CommonThemeProps {
   sdsSize: SdsSize;
 }
 
 export const StyledTab = styled(RawTab, {
   shouldForwardProp: (prop) => !TAB_DO_NOT_FORWARD_PROPS.includes(String(prop)),
 })<TabProps>`
-  color: black;
   min-height: unset;
   padding: 0;
   min-width: 32px;
+  opacity: 1 !important;
 
   ${tabFontMixin}
 
   ${(props) => {
     const colors = getColors(props);
     const spaces = getSpaces(props);
-    const palette = getPalette(props);
     const fontWeights = getFontWeights(props);
 
     const { sdsSize } = props;
@@ -96,12 +94,24 @@ export const StyledTab = styled(RawTab, {
       // (thuang): Large Tab height is 30px, the offset is 4px
       height: ${isLarge ? 26 : 22}px;
 
-      &:hover {
-        color: ${colors?.gray[600]};
+      color: ${colors?.gray[500]};
+
+      &:hover, :focus {
+        color: black;
       }
+
+      &.Mui-selected {
+        color: black;
+
+        &:hover {
+          color: black;
+        }
+      }
+
       &:active {
-        color: ${palette?.text?.primary};
+        color: black;
       }
+
       &:disabled {
         color: ${colors?.gray[200]};
       }

--- a/src/core/Tabs/style.tsx
+++ b/src/core/Tabs/style.tsx
@@ -1,0 +1,117 @@
+import { SerializedStyles } from "@emotion/react";
+import styled from "@emotion/styled";
+import {
+  Tab as RawTab,
+  Tabs as RawTabs,
+  TabsProps as RawTabsProps,
+} from "@material-ui/core";
+import React, { ChangeEvent, FormEvent } from "react";
+import { fontBodyS, fontBodyXs } from "../styles";
+import {
+  getColors,
+  getFontWeights,
+  getPalette,
+  getSpaces,
+  Props,
+} from "../styles/common/selectors/theme";
+import { SdsSize } from "./components/common";
+
+// TODO(185930): https://github.com/mui-org/material-ui/issues/17454#issuecomment-647132303
+// Will be fixed in v5.x
+interface TabsPropsFixed extends Omit<RawTabsProps, "onChange"> {
+  onChange:
+    | ((event: ChangeEvent<Record<string, unknown>>, value: never) => void)
+    | ((event: FormEvent<HTMLButtonElement>) => void);
+}
+
+export type TabsProps = TabsPropsFixed & {
+  underlined?: boolean;
+  sdsSize?: "small" | "large";
+};
+
+// TODO(185930): Use this instead of MUI's raw Tabs. `onChange` type will be fixed
+// in v5.x
+// https://github.com/mui-org/material-ui/issues/17454#issuecomment-647132303
+const TempTabs = (props: TabsPropsFixed) => <RawTabs {...(props as never)} />;
+
+export const StyledTabs = styled(TempTabs, {
+  shouldForwardProp: (prop) => prop !== "underlined",
+})<TabsProps>`
+  box-sizing: border-box;
+  padding-bottom: 0px;
+  min-height: unset;
+  position: relative;
+  z-index: 1;
+  overflow: inherit;
+
+  & .MuiTabs-scroller {
+    overflow: inherit !important;
+  }
+
+  ${(props) => {
+    const { underlined, sdsSize = "large" } = props;
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    const isLarge = sdsSize === "large";
+
+    return `
+      margin-top: ${isLarge ? spaces?.l : spaces?.m}px;
+      margin-bottom: ${isLarge ? spaces?.xl : spaces?.m}px;
+      border-bottom: ${underlined ? `2px solid ${colors?.gray[200]};` : "none"};
+    `;
+  }}
+`;
+
+const TAB_DO_NOT_FORWARD_PROPS = ["sdsSize"];
+
+interface TabProps extends Props {
+  sdsSize: SdsSize;
+}
+
+export const StyledTab = styled(RawTab, {
+  shouldForwardProp: (prop) => !TAB_DO_NOT_FORWARD_PROPS.includes(String(prop)),
+})<TabProps>`
+  color: black;
+  min-height: unset;
+  padding: 0;
+  min-width: 32px;
+
+  ${tabFontMixin}
+
+  ${(props) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+    const palette = getPalette(props);
+    const fontWeights = getFontWeights(props);
+
+    const { sdsSize } = props;
+
+    const isLarge = sdsSize === "large";
+
+    return `
+      font-weight: ${fontWeights?.semibold};
+      margin: 0 ${spaces?.xl}px ${spaces?.xxs}px 0;
+
+      // (thuang): Large Tab height is 30px, the offset is 4px
+      height: ${isLarge ? 26 : 22}px;
+
+      &:hover {
+        color: ${colors?.gray[600]};
+      }
+      &:active {
+        color: ${palette?.text?.primary};
+      }
+      &:disabled {
+        color: ${colors?.gray[200]};
+      }
+    `;
+  }}
+`;
+
+function tabFontMixin(props: TabProps): SerializedStyles | null {
+  const { sdsSize } = props;
+  const isLarge = sdsSize === "large";
+
+  return isLarge ? fontBodyS(props) : fontBodyXs(props);
+}


### PR DESCRIPTION
## Summary

**Structural Element (Gene)**
Shortcut ticket: [161558](https://app.shortcut.com/sci-design-system/story/161558/complete-tabs-component)
Copy ticket description here:

**Add Small variant to Tabs component:**
1. Label font should be `fontBodyXs`
2. Label font weight should be `fontWeightSemibold`

**Prop to remove persistent underline:**
1. Add prop option to enable or disable persistent underline from Tabs component (both Large and Small variants)

**Add counter to Large variant:**
1. Add prop option to add a Counter to Tabs component
2. For `Large` variant, counter should be `fontBodyXs`
3. For `Large` variant, there should be `spaceL` between Label and Counter
4. Counter should be color `gray500`
5. Counter should be center aligned to Label

**Add counter to Small variant:**
1. Add prop option to add a Counter to Tabs component
2. For `Small` variant, counter should be `fontBodyXxs`
3.  For `Large` variant, there should be `spaceM` between Label and Counter
4. Counter should be color `gray500`
5. Counter should be center aligned to Label

<img width="1021" alt="Screen Shot 2022-02-25 at 12 08 07 PM" src="https://user-images.githubusercontent.com/6309723/155804248-a9e1d4c0-2c96-411b-8369-00ffa5733b66.png">

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
