### PR TITLE
fix(link): fix LinkProps export

### DIFF
--- a/src/core/Link/style.ts
+++ b/src/core/Link/style.ts
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Link, LinkProps as Props } from "@material-ui/core";
+import { Link, LinkProps as RawLinkProps } from "@material-ui/core";
 import { Props as StyleProps } from "../styles";
 
-export type LinkProps = Props &
+export type LinkProps = RawLinkProps &
   StyleProps & {
     sdsStyle?: "default";
   };


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**

It seems like somehow `import { LinkProps as Props }` confuses TS, so changing it to  `import { LinkProps as RawLinkProps }` to unblock Single Cell! Thank you!

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
