### PR TITLE
fix(menuselect): use new inputtext for menuselect search inputs

### DIFF
--- a/src/core/InputText/index.tsx
+++ b/src/core/InputText/index.tsx
@@ -53,7 +53,7 @@ const InputText = forwardRef<HTMLInputElement, InputTextProps>(
           ref={ref}
           inputProps={inputProps}
           type="text"
-          multiline={sdsType === "textArea" ? true : false}
+          multiline={sdsType === "textArea"}
           minRows={sdsType === "textArea" ? 4 : 2}
           id={id}
           intent={intent}

--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -12,7 +12,7 @@ import { noop } from "src/common/utils";
 import {
   InputBaseWrapper,
   StyledAutocomplete,
-  StyledInputBase,
+  StyledInputText,
   StyledMenuItem,
   StyledSearchIcon,
   StyleProps,
@@ -78,11 +78,22 @@ export default function MenuSelect<
       getOptionLabel={getOptionLabel}
       renderInput={(params) => (
         <InputBaseWrapper search={search}>
-          <StyledInputBase
-            search={search}
+          <StyledInputText
+            hideLabel
+            id="location-search"
+            label="Search for a location"
             placeholder="Search"
             ref={params.InputProps.ref}
-            inputProps={{
+            sdsType="textField"
+            search={search}
+            onChange={onInputChange}
+            autoFocus
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <StyledSearchIcon />
+                </InputAdornment>
+              ),
               ...params.inputProps,
               /**
                * (thuang): Works with css caret-color: "transparent" to hide
@@ -90,13 +101,6 @@ export default function MenuSelect<
                */
               inputMode: search ? "text" : "none",
             }}
-            onChange={onInputChange}
-            autoFocus
-            endAdornment={
-              <InputAdornment position="end">
-                <StyledSearchIcon />
-              </InputAdornment>
-            }
             {...InputBaseProps}
           />
         </InputBaseWrapper>

--- a/src/core/MenuSelect/style.ts
+++ b/src/core/MenuSelect/style.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
-import { InputBase } from "@material-ui/core";
 import { Search } from "@material-ui/icons";
 import { Autocomplete } from "@material-ui/lab";
+import InputText from "../InputText";
 import MenuItem from "../MenuItem";
-import { getColors, getCorners, getSpaces, Props } from "../styles";
+import { getColors, getSpaces, Props } from "../styles";
 
 export const StyledMenuItem = styled(MenuItem)`
   width: 100%;
@@ -37,22 +37,21 @@ export const InputBaseWrapper = styled.div`
     }
 
     const spacings = getSpaces(props);
-    const corners = getCorners(props);
-    const colors = getColors(props);
 
     return `
-      padding: ${spacings?.xxs}px ${spacings?.m}px;
       margin: ${spacings?.s}px;
-      border: ${colors?.gray["300"]} solid 1px;
-      border-radius: ${corners?.m}px;
     `;
   }}
 `;
 
-export const StyledInputBase = styled(InputBase, {
+export const StyledInputText = styled(InputText, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })<{ search: boolean }>`
-  width: 100%;
+  margin: 0;
+  .MuiInputBase-root {
+    width: 100%;
+  }
+
   /* (thuang): Works with attribute inputMode: "none" to hide mobile keyboard */
   caret-color: ${({ search }) => (search ? "auto" : "transparent")};
 `;
@@ -62,7 +61,7 @@ export const StyledSearchIcon = styled(Search)`
     const colors = getColors(props);
 
     return `
-      color: ${colors?.gray["500"]};
+      color: ${colors?.gray[500]};
     `;
   }}
 `;


### PR DESCRIPTION
### Summary
- **What:** Use an `InputText` component in `MenuSelect` instead of a custom input
- **Why:** So that future styling updates are automatically applied, and to bring the component more in line with the spec for styling in active states
- **Ticket:** https://app.shortcut.com/genepi/story/175880/design-review-feedback-location-normalization
- **Design:** https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=642%3A1

### Demo
<img width="314" alt="Screen Shot 2022-03-02 at 12 34 16 PM" src="https://user-images.githubusercontent.com/7562933/156416524-dae69dd2-a4da-42aa-9bb8-d88bde7b8e24.png">

### Notes
I also checked consumers of `MenuSelect` to ensure they weren't adversely impacted. (ComplexFilter and Dropdown)

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)