### PR TITLE
feat(dropdown component): add multiselect with buttons dropdown variant

### DIFF
--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -8,7 +8,7 @@ import {
   StyledButton,
 } from "./style";
 
-interface SdsProps {
+export interface SdsProps {
   isAllCaps?: boolean;
   isRounded?: boolean;
   sdsStyle?: "minimal" | "rounded" | "square";

--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -65,6 +65,18 @@ MultipleSelectWithSearch.args = {
   search: true,
 };
 
+export const MultipleSelectWithButtons = Template.bind({});
+
+MultipleSelectWithButtons.args = {
+  buttons: true,
+  buttonPosition: "right",
+  closeOnBlur: false,
+  label: LABEL,
+  multiple: true,
+  onChange: noop,
+  search: true,
+};
+
 const useStyles = makeStyles(() => ({
   /* stylelint-disable-next-line */
   paper: {

--- a/src/core/Dropdown/style.ts
+++ b/src/core/Dropdown/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Paper } from "@material-ui/core";
 import Popper from "@material-ui/core/Popper";
+import Button from "../Button";
 import {
   fontHeaderXs,
   getColors,
@@ -33,7 +34,7 @@ export const StyledPopper = styled(Popper)`
       border-radius: ${corners?.m}px;
       box-shadow: ${shadows?.m};
       color: ${colors?.gray[500]};
-      padding: ${spacings?.s}px;
+      padding: ${spacings?.xs}px;
       min-width: 244px;
       z-index: 1400; // allows the dropdown to be used in modals
     `;
@@ -65,4 +66,25 @@ export const StyledPaper = styled(Paper)`
       `;
     }}
   }
+`;
+
+export const StyledButton = styled(Button)`
+  ${(props) => {
+    const spacings = getSpaces(props);
+
+    return `
+      margin-top: ${spacings?.l}px;
+      margin-bottom: ${spacings?.s}px;
+
+      &:first-child {
+        margin-left: ${spacings?.s}px;
+        margin-right: ${spacings?.m}px;
+      }
+      
+      &:last-child {
+        margin-left: 0;
+        margin-right: ${spacings?.s}px;
+      }
+    `;
+  }}
 `;


### PR DESCRIPTION


## Summary

**Structural Element (DNA)**
Shortcut ticket: [sh-184293](https://app.shortcut.com/sci-design-system/story/184293/implement-manual-apply-multiselect-dropdown)
Create a variant of the multiselect dropdown where the user can manually apply all their selections at once by pressing the "Apply" button.

### Acceptance Criteria:
- Do not support buttons for single select.
- Option for left or right button position. Primary button defaults to the right with option to position it left

**buttonPosition === "right"**
![Screen Shot 2022-03-03 at 4 59 06 PM](https://user-images.githubusercontent.com/53838890/156678916-1df6422e-f69b-4ac2-9946-8464b89ddce3.png)

**buttonPosition === "left"**
![Screen Shot 2022-03-03 at 4 59 15 PM](https://user-images.githubusercontent.com/53838890/156678902-a0058bfd-5aab-4774-8245-d0baae715a38.png)


### Behavior:
- Click “apply” to apply selections, clicking apply also closes the dropdownMenu
- Click “cancel” to exit the dropdownMenu
- If the user clicks outside the dropdownMenu, the dropdownMenu stays open, until the user clicks cancel 
- Buttons are sticky to the bottom and stay when scrolling

![ezgif com-gif-maker (22)](https://user-images.githubusercontent.com/53838890/156679393-ef09355e-df2a-4e2b-a6ca-7bde59a29747.gif)

### Figma link:
https://www.figma.com/proto/35JMdsMEL252zYWthRG1ui/Dropdown-Variation---Apply-butto[…]8&node-id=15%3A66531&viewport=241%2C48%2C0.13&scaling=min-zoom

Example of usage in the CZ ID heatmap:
https://www.figma.com/proto/b9Y14C0IM6k31kgNNmzGKD/Heatmap-small-tickets-(current-sprint)?page-id=186%3A64018&node-id=186%3A64471&viewport=501%2C48%2C0.12&scaling=min-zoom&starting-point-node-id=186%3A64435
## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
