### PR TITLE
fix(dropdown): allow custom renderer for Dropdown popper and paper

### DIFF
--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -21,6 +21,8 @@ export type Value<T, Multiple> = Multiple extends undefined | false
   ? T | null
   : Array<T> | null;
 
+type RenderFunctionType = (props: any) => JSX.Element;
+
 interface DropdownProps<Multiple> {
   label: string;
   options: DefaultMenuSelectOption[];
@@ -32,8 +34,8 @@ interface DropdownProps<Multiple> {
   value?: Value<DefaultMenuSelectOption, Multiple>;
   style?: React.CSSProperties;
   className?: string;
-  PopperComponent?: typeof StyledPopper;
-  PaperComponent?: typeof StyledPaper;
+  PopperComponent?: typeof StyledPopper | RenderFunctionType;
+  PaperComponent?: typeof StyledPaper | RenderFunctionType;
   InputDropdownComponent?: typeof InputDropdown;
 }
 


### PR DESCRIPTION
### Summary
- **What:** Allow Dropdown component to accept various Popper and Paper rendering functions, rather than only accepting a StyledComponent
- **Why:** 
  - To simplify the process of customizing a Dropdown
  - to bring these types in line with the other customizable prop, `InputComponent`
  - enables https://github.com/chanzuckerberg/czgenepi/pull/982/files

### Demos
No visual changes.

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)