### PR TITLE
fix(tooltip): don't render tooltip that doesn't have content

### DIFF
--- a/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip /> Test story renders snapshot 1`] = `null`;
+exports[`<Tooltip /> Test story renders snapshot 1`] = `
+<div
+  class=""
+  data-testid="tooltip"
+/>
+`;

--- a/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tooltip /> Test story renders snapshot 1`] = `null`;

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -67,6 +67,11 @@ export default {
 const Template: Story = (args) => <Demo {...args} />;
 
 export const Dark = Template.bind({});
+Dark.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
 Dark.args = {
   arrow: true,
@@ -78,6 +83,11 @@ Dark.args = {
 };
 
 export const Light = Template.bind({});
+Light.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
 Light.args = {
   arrow: true,
@@ -88,6 +98,11 @@ Light.args = {
 };
 
 export const LightWide = Template.bind({});
+LightWide.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
 LightWide.args = {
   arrow: true,
@@ -98,6 +113,11 @@ LightWide.args = {
 };
 
 export const StyledArrow = Template.bind({});
+StyledArrow.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
 const arrow = css`
   left: 0 !important;
@@ -168,9 +188,25 @@ const PlacementDemo = (): JSX.Element => {
 const PlacementTemplate: Story = () => <PlacementDemo />;
 
 export const PlacementPreview = PlacementTemplate.bind({});
+PlacementPreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
 PlacementPreview.args = {
   // Chrome shifts elements when fonts load in
   // delay allows for font to load and prevents chromatic from constantly creating new baselines
   chromatic: { delay: 500 },
 };
+
+const TestDemo = (props: Args): JSX.Element => {
+  return (
+    <Tooltip {...props} data-testid="tooltip">
+      <div />
+    </Tooltip>
+  );
+};
+
+const TestTemplate: Story = (args) => <TestDemo {...args} />;
+export const Test = TestTemplate.bind({});

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -201,12 +201,13 @@ PlacementPreview.args = {
 };
 
 const TestDemo = (props: Args): JSX.Element => {
+  const { title, ...rest } = props;
   return (
-    <Tooltip {...props} data-testid="tooltip">
+    <Tooltip title={title} {...rest} data-testid="tooltip">
       <div />
     </Tooltip>
   );
 };
 
-const TestTemplate: Story = (args) => <TestDemo {...args} />;
+const TestTemplate: Story = (args) => <TestDemo title="test" {...args} />;
 export const Test = TestTemplate.bind({});

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -19,7 +19,7 @@ export type { TooltipProps };
 const Tooltip = forwardRef(function Tooltip(
   props: TooltipProps,
   ref
-): JSX.Element {
+): JSX.Element | null {
   const {
     classes,
     // TODO(185930): remove custom `followCursor` prop when we upgrade to MUIv5
@@ -70,6 +70,10 @@ const Tooltip = forwardRef(function Tooltip(
     key: "arrow",
     props,
   });
+
+  // (mlila) if no content is passed into the tooltip, don't render
+  // anything. this matches with the native MUI behavior.
+  if (!title && !subtitle) return null;
 
   const content = (
     <>

--- a/src/core/Tooltip/tooltip.test.tsx
+++ b/src/core/Tooltip/tooltip.test.tsx
@@ -1,0 +1,25 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<Tooltip />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders tooltip component", async () => {
+    render(<Test {...Test.args} title="I am a tooltip" />);
+    const tooltipElement = screen.getByTestId("tooltip");
+    expect(tooltipElement).not.toBeNull();
+  });
+
+  it("does not render when no content provided", () => {
+    render(<Test {...Test.args} title="" />);
+    const tooltipElement = screen.queryByTestId("tooltip");
+    expect(tooltipElement).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
**Structural Element (Genes)**
Shortcut ticket: [sh-176947](https://app.shortcut.com/sci-design-system/story/176947)
Don't render a tooltip that has no title or subtitle because an empty tooltip is awkward and doesn't align with MUI default behavior.

## Checklist
- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design