### PR TITLE
feat(menuitem): add disabled menuitem styles

### DIFF
--- a/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<InputDropdown /> Test story renders snapshot 1`] = `
     class="MuiButton-label"
   >
     <span
-      class="css-ebsz01"
+      class="css-1sjvubj"
     >
       Label
     </span>

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -225,7 +225,7 @@ export const StyledInputDropdown = styled(Button, {
 `;
 
 export const StyledDetail = styled("span")`
-  ${labelFontBodyXs};
+  ${labelFontBodyXs}
   ${(props) => {
     const colors = getColors(props);
 
@@ -241,7 +241,7 @@ interface DetailsAndCounter extends CommonThemeProps {
 }
 
 export const StyledLabel = styled("span")`
-  ${labelFontBodyXs};
+  ${labelFontBodyXs}
   ${(props: DetailsAndCounter) => {
     const { details, counter } = props;
     const colors = getColors(props);
@@ -257,7 +257,7 @@ export const StyledLabel = styled("span")`
 `;
 
 export const StyledCounter = styled("span")`
-  ${labelFontBodyXs};
+  ${labelFontBodyXs}
   ${(props) => {
     const colors = getColors(props);
     const corners = getCorners(props);

--- a/src/core/MenuItem/index.stories.tsx
+++ b/src/core/MenuItem/index.stories.tsx
@@ -59,6 +59,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+export const MultipleSelect = MultipleSelectDemo.bind({});
+
 function MultipleSelectDemo() {
   const classes = useStyles();
   const [personName, setPersonName] = React.useState<string[]>([]);
@@ -171,4 +173,22 @@ WithMultiSelectSelected.args = {
   selected: true,
 };
 
-export const MultipleSelect = MultipleSelectDemo.bind({});
+export const Disabled = DisabledMenuItem.bind({});
+
+function DisabledMenuItem() {
+  return (
+    <>
+      <div>Single Select</div>
+      <Demo {...Default.args} disabled isMultiSelect={false} />
+      <Demo {...Default.args} disabled isMultiSelect={false} selected />
+      <br />
+      <div>Multi Select</div>
+      <Demo {...Default.args} disabled isMultiSelect />
+      <Demo {...Default.args} disabled isMultiSelect selected />
+      <br />
+      <div>With Column</div>
+      <Demo {...Default.args} disabled column="column value" />
+      <Demo {...Default.args} disabled column="column value" selected />
+    </>
+  );
+}

--- a/src/core/MenuItem/index.tsx
+++ b/src/core/MenuItem/index.tsx
@@ -19,23 +19,28 @@ const MenuItem = forwardRef((props: MenuItemProps, _) => {
   const {
     children,
     column = null,
+    disabled,
     isMultiSelect = false,
     ...originalMenuItemProps
   } = props;
   const { selected = false } = originalMenuItemProps as MenuItemProps;
 
   return (
-    <StyledMenuItem {...(originalMenuItemProps as unknown)}>
+    <StyledMenuItem {...(originalMenuItemProps as unknown)} disabled={disabled}>
       {isMultiSelect && (
         // TODO (mlila): replace with sds InputCheckbox class once complete
         <StyledCheck selected={selected} color="primary" />
       )}
 
       <ContentWrapper>
-        <TextWrapper selected={selected} className="primary-text">
+        <TextWrapper
+          selected={selected}
+          className="primary-text"
+          disabled={disabled}
+        >
           {children}
         </TextWrapper>
-        {column && <ColumnWrapper>{column}</ColumnWrapper>}
+        {column && <ColumnWrapper disabled={disabled}>{column}</ColumnWrapper>}
       </ContentWrapper>
     </StyledMenuItem>
   );

--- a/src/core/MenuItem/style.ts
+++ b/src/core/MenuItem/style.ts
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { MenuItem } from "@material-ui/core";
 import { Check } from "@material-ui/icons";
+import { CommonThemeProps } from "../styles";
 import { fontBody } from "../styles/common/mixins/fonts";
 import {
   getColors,
@@ -64,7 +65,24 @@ export const ContentWrapper = styled.span`
   width: 100%;
 `;
 
+interface DisabledType extends CommonThemeProps {
+  disabled?: boolean;
+}
+
+const disabledStyles = (props: DisabledType) => {
+  const { disabled } = props;
+  if (!disabled) return ``;
+
+  const colors = getColors(props);
+
+  return `
+    color: ${colors?.gray[300]};
+    cursor: default;
+  `;
+};
+
 interface TextWrapperProps {
+  disabled?: boolean;
   selected: boolean;
 }
 
@@ -78,9 +96,15 @@ export const TextWrapper = styled.span<TextWrapperProps>`
       color: ${palette?.text?.primary};
     `;
   }}
+
+  ${disabledStyles}
 `;
 
-export const ColumnWrapper = styled.span`
+interface ColumnWrapperProps {
+  disabled?: boolean;
+}
+
+export const ColumnWrapper = styled.span<ColumnWrapperProps>`
   ${fontBodyXs}
 
   ${(props) => {
@@ -90,6 +114,8 @@ export const ColumnWrapper = styled.span`
       color: ${colors?.gray[500]};
     `;
   }}
+
+  ${disabledStyles}
 `;
 
 export const DemoWrapper = styled.div`


### PR DESCRIPTION
### Summary
- **What:** Add disabled MenuItem styles
- **Ticket:** [[sc-168693]](https://app.shortcut.com/genepi/story/168693)

### Demos
<img width="299" alt="Screen Shot 2022-03-18 at 12 50 20 PM" src="https://user-images.githubusercontent.com/7562933/159047061-8333fceb-5de6-4a9a-a83a-8e9eba2ba3a5.png">

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I tested in multiple browsers
- [x] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design