### PR TITLE
feat(tooltipcondensed): add component, stories and tests

### DIFF
--- a/src/core/TooltipCondensed/index.stories.tsx
+++ b/src/core/TooltipCondensed/index.stories.tsx
@@ -55,3 +55,37 @@ export const Test = TestTemplate.bind({});
 Test.args = {
   title: "Test",
 };
+
+const livePreviewStyles = {
+  display: "grid",
+  gridTemplateColumns: "repeat(2, 80px)",
+};
+
+// LivePreview
+function LivePreviewDemo(props: Args): JSX.Element {
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <TooltipCondensed title="Label" {...props}>
+        <InfoOutlinedIcon />
+      </TooltipCondensed>
+      <TooltipCondensed
+        indicator
+        indicatorColor="#223F9C"
+        title="Label"
+        {...props}
+      >
+        <InfoOutlinedIcon />
+      </TooltipCondensed>
+    </div>
+  );
+}
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const LivePreview = LivePreviewTemplate.bind({});
+
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};

--- a/src/core/TooltipCondensed/index.stories.tsx
+++ b/src/core/TooltipCondensed/index.stories.tsx
@@ -1,0 +1,57 @@
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import TooltipCondensed from "./index";
+
+const Demo = (props: Args): JSX.Element => {
+  const { title, indicator } = props;
+  return (
+    <div>
+      Hover over the info icon to view the tooltip.
+      <div
+        style={{
+          margin: "135px 300px",
+        }}
+      >
+        <TooltipCondensed indicator={indicator} title={title} {...props}>
+          <InfoOutlinedIcon data-testid="tooltip-hover" />
+        </TooltipCondensed>
+      </div>
+    </div>
+  );
+};
+
+export default {
+  argTypes: {
+    indicator: {
+      control: { type: "boolean" },
+    },
+    indicatorColor: {
+      control: { type: "color" },
+    },
+  },
+  component: Demo,
+  title: "TooltipCondensed",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Default = Template.bind({});
+
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+Default.args = {
+  title: "Label",
+};
+
+const TestTemplate: Story = (args) => <Demo {...args} />;
+
+export const Test = TestTemplate.bind({});
+
+Test.args = {
+  title: "Test",
+};

--- a/src/core/TooltipCondensed/index.test.tsx
+++ b/src/core/TooltipCondensed/index.test.tsx
@@ -1,0 +1,18 @@
+import { composeStory } from "@storybook/testing-react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<TooltipCondensed />", () => {
+  // (mmoore): no snapshot of this component. The tooltip can be shown by default, but MUI appends it to the page outside the scope of what `generateSnapshots` captures.
+
+  it("renders components", async () => {
+    render(<Test />);
+    const tooltipHoverElement = screen.getByTestId("tooltip-hover");
+    fireEvent.mouseOver(tooltipHoverElement);
+    await screen.findByText("Test");
+  });
+});

--- a/src/core/TooltipCondensed/index.tsx
+++ b/src/core/TooltipCondensed/index.tsx
@@ -29,7 +29,14 @@ const TooltipCondensed = forwardRef(function TooltipCondensed(
   });
 
   return (
-    <Tooltip followCursor title={title} ref={ref} classes={{ tooltip }}>
+    <Tooltip
+      followCursor
+      enterDelay={50}
+      leaveDelay={50}
+      title={title}
+      ref={ref}
+      classes={{ tooltip }}
+    >
       {children}
     </Tooltip>
   );

--- a/src/core/TooltipCondensed/index.tsx
+++ b/src/core/TooltipCondensed/index.tsx
@@ -1,0 +1,56 @@
+import { useTheme } from "@emotion/react";
+import { TooltipClassKey } from "@material-ui/core";
+import React, { forwardRef } from "react";
+import Tooltip, { TooltipProps } from "../Tooltip";
+import { condensedCSS, ExtraProps } from "./style";
+
+export type TooltipCondesnedProps = TooltipProps & ExtraProps;
+
+const TooltipCondensed = forwardRef(function TooltipCondensed(
+  props: TooltipCondesnedProps,
+  ref
+): JSX.Element {
+  const { children, title, indicator, indicatorColor } = props;
+
+  const theme = useTheme();
+
+  const extraProps = {
+    /* stylelint-disable property-no-unknown -- false positive */
+    indicator,
+    indicatorColor,
+    theme,
+    /* stylelint-enable property-no-unknown -- false positive */
+  };
+
+  const tooltip = mergeClass({
+    className: condensedCSS(extraProps),
+    key: "tooltip",
+    props,
+  });
+
+  return (
+    <Tooltip followCursor title={title} ref={ref} classes={{ tooltip }}>
+      {children}
+    </Tooltip>
+  );
+});
+
+function mergeClass({
+  props,
+  className,
+  key,
+}: {
+  props: TooltipProps;
+  className: string;
+  key: TooltipClassKey;
+}) {
+  const { classes } = props;
+
+  if (!classes) return className;
+
+  const propClassName = classes[key];
+
+  return propClassName ? `${propClassName} ${className}` : className;
+}
+
+export default TooltipCondensed;

--- a/src/core/TooltipCondensed/style.ts
+++ b/src/core/TooltipCondensed/style.ts
@@ -28,7 +28,7 @@ export const condensedCSS = (props: ExtraProps): string => {
   const spaces = getSpaces(props);
 
   return css`
-    &.MuiTooltip-tooltip {
+    && {
       padding-top: ${spaces?.xxs}px;
       padding-bottom: ${spaces?.xxs}px;
       padding-left: ${spaces?.m}px;

--- a/src/core/TooltipCondensed/style.ts
+++ b/src/core/TooltipCondensed/style.ts
@@ -1,0 +1,43 @@
+import { css } from "@emotion/css";
+import { CommonThemeProps, getCorners, getSpaces } from "../styles";
+
+export interface ExtraProps extends CommonThemeProps {
+  indicator?: boolean;
+  indicatorColor?: string;
+}
+
+const indicatorCSS = (props: ExtraProps): string => {
+  const { indicatorColor } = props;
+  const spaces = getSpaces(props);
+  const corners = getCorners(props);
+  return css`
+    &::before {
+      content: "";
+      width: ${spaces?.m}px;
+      height: ${spaces?.m}px;
+      display: block;
+      background-color: ${indicatorColor};
+      border-radius: ${corners?.l}px;
+      margin-right: ${spaces?.m}px;
+    }
+  `;
+};
+
+export const condensedCSS = (props: ExtraProps): string => {
+  const { indicator } = props;
+  const spaces = getSpaces(props);
+
+  return css`
+    &.MuiTooltip-tooltip {
+      padding-top: ${spaces?.xxs}px;
+      padding-bottom: ${spaces?.xxs}px;
+      padding-left: ${spaces?.m}px;
+      padding-right: ${spaces?.m}px;
+      max-width: 250px;
+      display: flex;
+      align-items: center;
+
+      ${indicator === true && indicatorCSS(props)};
+    }
+  `;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,5 +61,7 @@ export * from "./core/Tabs";
 export { default as Tabs } from "./core/Tabs";
 export * from "./core/Tooltip";
 export { default as Tooltip } from "./core/Tooltip";
+export * from "./core/TooltipCondensed";
+export { default as TooltipCondensed } from "./core/TooltipCondensed";
 export * from "./core/TooltipTable";
 export { default as TooltipTable } from "./core/TooltipTable";


### PR DESCRIPTION
## Summary

**Structural Element (Gene)**
Shortcut ticket: [sh-152183](https://app.shortcut.com/sci-design-system/story/152183/implement-tooltipcondensed-component-for-sds)
**Props**
- `indicator`: true | false;
- `indicatorColor`: string

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
