### PR TITLE
feat(link): add dashed styles and prop, update defaultTheme and styles-dictionary

### DIFF
--- a/src/common/styles-dictionary/css/variables.css
+++ b/src/common/styles-dictionary/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 24 Feb 2022 00:16:20 GMT
+ * Generated on Fri, 18 Mar 2022 19:32:28 GMT
  */
 
 :root {
@@ -86,6 +86,8 @@
   --sds-borders-gray-400: 1px solid #999999;
   --sds-borders-gray-500: 1px solid #767676;
   --sds-borders-gray-dashed: 2px dashed #999999;
+  --sds-borders-link-dashed: 1px dashed;
+  --sds-borders-link-solid: 1px solid;
   --sds-borders-primary-400: 1px solid #3867fa;
   --sds-borders-primary-500: 1px solid #2b52cd;
   --sds-borders-primary-600: 1px solid #223f9c;

--- a/src/common/styles-dictionary/scss/_variables.scss
+++ b/src/common/styles-dictionary/scss/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 24 Feb 2022 00:16:20 GMT
+// Generated on Fri, 18 Mar 2022 19:32:28 GMT
 
 $sds-font-letter-spacing-default: 0.3px;
 $sds-font-letter-spacing-caps: 1px;
@@ -82,6 +82,8 @@ $sds-borders-gray-300: 1px solid #cccccc;
 $sds-borders-gray-400: 1px solid #999999;
 $sds-borders-gray-500: 1px solid #767676;
 $sds-borders-gray-dashed: 2px dashed #999999;
+$sds-borders-link-dashed: 1px dashed;
+$sds-borders-link-solid: 1px solid;
 $sds-borders-primary-400: 1px solid #3867fa;
 $sds-borders-primary-500: 1px solid #2b52cd;
 $sds-borders-primary-600: 1px solid #223f9c;

--- a/src/common/styles-dictionary/style-dictionary.json
+++ b/src/common/styles-dictionary/style-dictionary.json
@@ -244,6 +244,10 @@
         "500": { "value": "1px solid {sds.color.gray.500.value}" },
         "dashed": { "value": "2px dashed {sds.color.gray.400.value}" }
       },
+      "link": {
+        "dashed": { "value": "1px dashed" },
+        "solid": { "value": "1px solid" }
+      },
       "primary": {
         "400": { "value": "1px solid {sds.color.primary.400.value}" },
         "500": { "value": "1px solid {sds.color.primary.500.value}" },

--- a/src/core/Link/index.stories.tsx
+++ b/src/core/Link/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from "@storybook/react";
+import { Args, Story } from "@storybook/react";
 import React from "react";
 import Link, { LinkProps } from "./index";
 
@@ -11,6 +11,12 @@ const Demo = (props: LinkProps): JSX.Element => {
 };
 
 export default {
+  argTypes: {
+    sdsStyle: {
+      control: { type: "select" },
+      options: ["default", "dashed"],
+    },
+  },
   component: Demo,
   title: "Link",
 };
@@ -21,4 +27,41 @@ export const Default = Template.bind({});
 
 Default.args = {
   sdsStyle: "default",
+};
+
+const livePreviewStyles = {
+  display: "grid",
+  fontFamily: "Open Sans",
+  gridColumnGap: "24px",
+  gridTemplateColumns: "repeat(2, 250px)",
+};
+
+const LivePreviewDemo = (props: Args): JSX.Element => {
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <div>
+        <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit.</p>
+        <Link href="/" sdsStyle="default" {...props}>
+          Learn More
+        </Link>
+      </div>
+      <p style={{ backgroundColor: "#EFF2FC", padding: "10px" }}>
+        Lorem ipsum{" "}
+        <Link href="/" sdsStyle="dashed" {...props}>
+          dolor sit apsidy
+        </Link>{" "}
+        consectetur, adipisicing elit.
+      </p>
+    </div>
+  );
+};
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const LivePreview = LivePreviewTemplate.bind({});
+
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
 };

--- a/src/core/Link/index.stories.tsx
+++ b/src/core/Link/index.stories.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import Link, { LinkProps } from "./index";
 
 const Demo = (props: LinkProps): JSX.Element => {
+  const { sdsStyle } = props;
   return (
-    <Link href="/" {...props}>
+    <Link href="/" sdsStyle={sdsStyle} {...props}>
       Test Link
     </Link>
   );

--- a/src/core/Link/style.ts
+++ b/src/core/Link/style.ts
@@ -5,7 +5,7 @@ import { CommonThemeProps as StyleProps } from "../styles";
 
 export type LinkProps = RawLinkProps &
   StyleProps & {
-    sdsStyle?: "default";
+    sdsStyle?: "default" | "dashed";
   };
 
 const defaultStyle = (props: LinkProps) => {
@@ -21,12 +21,26 @@ const defaultStyle = (props: LinkProps) => {
   `;
 };
 
+const dashedStyle = (_props: LinkProps) => {
+  return css`
+    color: inherit;
+    border-bottom: 1px dashed;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      border-bottom: 1px solid;
+    }
+  `;
+};
+
 export const StyledLink = styled(Link)`
   ${(props: LinkProps) => {
     const { sdsStyle } = props;
 
     return css`
       ${sdsStyle === "default" && defaultStyle(props)}
+      ${sdsStyle === "dashed" && dashedStyle(props)}
     `;
   }}
 `;

--- a/src/core/Link/style.ts
+++ b/src/core/Link/style.ts
@@ -1,12 +1,14 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Link, LinkProps as RawLinkProps } from "@material-ui/core";
-import { CommonThemeProps as StyleProps } from "../styles";
+import { CommonThemeProps as StyleProps, getBorders } from "../styles";
 
 export type LinkProps = RawLinkProps &
   StyleProps & {
     sdsStyle?: "default" | "dashed";
   };
+
+const sdsPropNames = ["sdsStyle"];
 
 const defaultStyle = (props: LinkProps) => {
   const { theme } = props;
@@ -21,20 +23,26 @@ const defaultStyle = (props: LinkProps) => {
   `;
 };
 
-const dashedStyle = (_props: LinkProps) => {
+const dashedStyle = (props: LinkProps) => {
+  const border = getBorders(props);
+
   return css`
     color: inherit;
-    border-bottom: 1px dashed;
+    border-bottom: ${border?.link.dashed};
 
     &:hover,
     &:focus {
       text-decoration: none;
-      border-bottom: 1px solid;
+      border-bottom: ${border?.link.solid};
     }
   `;
 };
 
-export const StyledLink = styled(Link)`
+export const StyledLink = styled(Link, {
+  shouldForwardProp: (prop) => {
+    return !sdsPropNames.includes(prop.toString());
+  },
+})`
   ${(props: LinkProps) => {
     const { sdsStyle } = props;
 

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -82,6 +82,10 @@ const borders = {
     "500": `1px solid ${defaultThemeColors.gray["500"]}`,
     dashed: `2px dashed ${defaultThemeColors.gray["400"]}`,
   },
+  link: {
+    dashed: `1px dashed`,
+    solid: `1px solid`,
+  },
   primary: {
     "400": `1px solid ${defaultThemeColors.primary["400"]}`,
     "500": `1px solid ${defaultThemeColors.primary["500"]}`,
@@ -509,16 +513,18 @@ export interface IconSizes {
 export interface Border {
   600?: string;
   500?: string;
-  400: string;
+  400?: string;
   300?: string;
   200?: string;
   100?: string;
   dashed?: string;
+  solid?: string;
 }
 
 export interface Borders {
   error: Border;
   gray: Border;
+  link: Border;
   primary: Border;
   success: Border;
   warning: Border;


### PR DESCRIPTION
## Summary

**Structural Element (Gene)**
Shortcut ticket: [sh-154874](https://app.shortcut.com/sci-design-system/story/154874/implement-dashed-link-component)
- Add link border style variables to the repo and storybook
- borderLinkDashed
- borderLinkSolid
- Add sdsStyle: Dashed to the Link component
- Dashed Link has states for default, hover, and click
- follow specs in Ref doc
- Dashed Link and bottom border both inherit color from parent text color

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- ~~[ ] Test Story in Storybook~~
- ~~[ ] Tests written~~
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
