### PR TITLE
feat(buttondropdown): implement ButtonDropdown component

### DIFF
--- a/src/core/ButtonDropdown/index.stories.tsx
+++ b/src/core/ButtonDropdown/index.stories.tsx
@@ -1,0 +1,55 @@
+import { action } from "@storybook/addon-actions";
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import Icon from "../Icon";
+import ButtonDropdown from "./index";
+
+const text = "Label";
+
+const actions = {
+  onClick: action("onClick"),
+};
+
+const Demo = (props: Args): JSX.Element => {
+  const { icon, sdsTypes, ...rest } = props;
+
+  return (
+    <>
+      <span style={{ marginRight: "10px" }}>
+        <ButtonDropdown icon={icon} sdsType={sdsTypes[0]} {...rest}>
+          {text}
+        </ButtonDropdown>
+      </span>
+      <ButtonDropdown icon={icon} sdsType={sdsTypes[1]} {...rest}>
+        {text}
+      </ButtonDropdown>
+    </>
+  );
+};
+
+export default {
+  comonent: Demo,
+  title: "ButtonDropdown",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const RoundedButtonDropdown = Template.bind({});
+
+RoundedButtonDropdown.args = {
+  disabled: false,
+  icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
+  onClick: actions.onClick,
+  sdsStyle: "rounded",
+  sdsTypes: ["primary", "secondary"],
+};
+
+export const SquareButtonDropdown = Template.bind({});
+
+SquareButtonDropdown.args = {
+  disabled: false,
+  icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
+  onClick: actions.onClick,
+  sdsStyle: "square",
+  sdsTypes: ["primary", "secondary"],
+};

--- a/src/core/ButtonDropdown/index.stories.tsx
+++ b/src/core/ButtonDropdown/index.stories.tsx
@@ -11,45 +11,102 @@ const actions = {
 };
 
 const Demo = (props: Args): JSX.Element => {
-  const { icon, sdsTypes, ...rest } = props;
-
-  return (
-    <>
-      <span style={{ marginRight: "10px" }}>
-        <ButtonDropdown icon={icon} sdsType={sdsTypes[0]} {...rest}>
-          {text}
-        </ButtonDropdown>
-      </span>
-      <ButtonDropdown icon={icon} sdsType={sdsTypes[1]} {...rest}>
-        {text}
-      </ButtonDropdown>
-    </>
-  );
+  return <ButtonDropdown {...props}>{text}</ButtonDropdown>;
 };
 
 export default {
-  comonent: Demo,
+  component: Demo,
   title: "ButtonDropdown",
 };
 
 const Template: Story = (args) => <Demo {...args} />;
 
-export const RoundedButtonDropdown = Template.bind({});
+export const RoundedPrimary = Template.bind({});
 
-RoundedButtonDropdown.args = {
+RoundedPrimary.args = {
   disabled: false,
   icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
   onClick: actions.onClick,
   sdsStyle: "rounded",
-  sdsTypes: ["primary", "secondary"],
+  sdsType: "primary",
 };
 
-export const SquareButtonDropdown = Template.bind({});
+export const RoundedSecondary = Template.bind({});
 
-SquareButtonDropdown.args = {
+RoundedSecondary.args = {
+  disabled: false,
+  icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
+  onClick: actions.onClick,
+  sdsStyle: "rounded",
+  sdsType: "secondary",
+};
+
+export const SquarePrimary = Template.bind({});
+
+SquarePrimary.args = {
   disabled: false,
   icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
   onClick: actions.onClick,
   sdsStyle: "square",
-  sdsTypes: ["primary", "secondary"],
+  sdsType: "primary",
+};
+
+export const SquareSecondary = Template.bind({});
+
+SquareSecondary.args = {
+  disabled: false,
+  icon: <Icon sdsIcon="download" sdsSize="l" sdsType="button" />,
+  onClick: actions.onClick,
+  sdsStyle: "square",
+  sdsType: "secondary",
+};
+
+// LivePreview
+function LivePreviewDemo(props: Args): JSX.Element {
+  return (
+    <>
+      <span style={{ marginRight: "10px" }}>
+        <ButtonDropdown
+          sdsType="primary"
+          icon={<Icon sdsIcon="download" sdsSize="l" sdsType="button" />}
+          {...props}
+        >
+          {text}
+        </ButtonDropdown>
+      </span>
+      <ButtonDropdown
+        sdsType="secondary"
+        icon={<Icon sdsIcon="download" sdsSize="l" sdsType="button" />}
+        {...props}
+      >
+        {text}
+      </ButtonDropdown>
+    </>
+  );
+}
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const LivePreviewRounded = LivePreviewTemplate.bind({});
+
+LivePreviewRounded.args = {
+  sdsStyle: "rounded",
+};
+
+LivePreviewRounded.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+export const LivePreviewSquare = LivePreviewTemplate.bind({});
+
+LivePreviewSquare.args = {
+  sdsStyle: "square",
+};
+
+LivePreviewSquare.parameters = {
+  snapshot: {
+    skip: true,
+  },
 };

--- a/src/core/ButtonDropdown/index.tsx
+++ b/src/core/ButtonDropdown/index.tsx
@@ -1,0 +1,38 @@
+import { ButtonProps as RawButtonProps } from "@material-ui/core";
+import React, { ForwardedRef } from "react";
+import Button from "../Button";
+import Icon from "../Icon";
+
+interface SdsProps {
+  icon?: JSX.Element;
+  isRounded?: boolean;
+  sdsStyle?: "rounded" | "square";
+  sdsType?: "primary" | "secondary";
+}
+
+export type ButtonDropdownProps<C extends React.ElementType = "button"> =
+  RawButtonProps<C, { component?: C }> & SdsProps;
+
+const ButtonDropdown = React.forwardRef(
+  <C extends React.ElementType>(
+    props: ButtonDropdownProps<C>,
+    ref: ForwardedRef<HTMLButtonElement>
+  ): JSX.Element | null => {
+    const icon = props?.icon;
+    const sdsStyle = props?.sdsStyle;
+    const sdsType = props?.sdsType;
+
+    return (
+      <Button
+        {...props}
+        endIcon={<Icon sdsIcon="chevronDown" sdsSize="s" sdsType="button" />}
+        sdsStyle={sdsStyle}
+        ref={ref}
+        sdsType={sdsType}
+        startIcon={icon}
+      />
+    );
+  }
+);
+
+export default ButtonDropdown;

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root css-11u5v9s"
+          class="MuiSvgIcon-root css-10tbi0i"
           data-jest-file-name="IconXMarkSmall.svg"
           data-jest-svg-name="IconXMarkSmall"
           data-testid="IconXMarkSmall"
@@ -108,7 +108,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 4`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root css-11u5v9s"
+          class="MuiSvgIcon-root css-10tbi0i"
           data-jest-file-name="IconXMarkLarge.svg"
           data-jest-svg-name="IconXMarkLarge"
           data-testid="IconXMarkLarge"
@@ -198,7 +198,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root css-11u5v9s"
+          class="MuiSvgIcon-root css-10tbi0i"
           data-jest-file-name="IconXMarkLarge.svg"
           data-jest-svg-name="IconXMarkLarge"
           data-testid="IconXMarkLarge"
@@ -288,7 +288,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root css-11u5v9s"
+          class="MuiSvgIcon-root css-10tbi0i"
           data-jest-file-name="IconXMarkLarge.svg"
           data-jest-svg-name="IconXMarkLarge"
           data-testid="IconXMarkLarge"

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -24,9 +24,7 @@ function iconSize<IconName extends keyof IconNameToSizes>(
   `;
 }
 
-function buttonStyle<IconName extends keyof IconNameToSizes>(
-  props: ExtraProps<IconName>
-): SerializedStyles {
+function buttonStyle(): SerializedStyles {
   return css`
     color: inherit;
   `;
@@ -83,7 +81,7 @@ export const StyledSvgIcon = styled(SvgIcon, {
       ${sdsType !== "iconButton" && iconSize(props)}
       ${sdsType === "static" && staticStyle(props)}
       ${sdsType === "interactive" && interactive(props)}
-      ${sdsType === "button" && buttonStyle(props)}
+      ${sdsType === "button" && buttonStyle()}
     `;
   }}
 `;

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -9,7 +9,7 @@ export interface ExtraProps<IconName extends keyof IconNameToSizes>
   extends CommonThemeProps {
   sdsIcon: IconName;
   sdsSize: IconNameToSizes[IconName];
-  sdsType: "iconButton" | "interactive" | "static";
+  sdsType: "button" | "iconButton" | "interactive" | "static";
 }
 
 function iconSize<IconName extends keyof IconNameToSizes>(
@@ -21,6 +21,14 @@ function iconSize<IconName extends keyof IconNameToSizes>(
   return css`
     height: ${iconSizes?.[sdsSize]?.height}px;
     width: ${iconSizes?.[sdsSize]?.width}px;
+  `;
+}
+
+function buttonStyle<IconName extends keyof IconNameToSizes>(
+  props: ExtraProps<IconName>
+): SerializedStyles {
+  return css`
+    color: inherit;
   `;
 }
 
@@ -75,6 +83,7 @@ export const StyledSvgIcon = styled(SvgIcon, {
       ${sdsType !== "iconButton" && iconSize(props)}
       ${sdsType === "static" && staticStyle(props)}
       ${sdsType === "interactive" && interactive(props)}
+      ${sdsType === "button" && buttonStyle(props)}
     `;
   }}
 `;

--- a/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<InputDropdown /> Test story renders snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root css-106974y"
+        class="MuiSvgIcon-root css-dkgei6"
         data-jest-file-name="IconChevronDownSmall.svg"
         data-jest-svg-name="IconChevronDownSmall"
         data-testid="IconChevronDownSmall"

--- a/src/core/Notification/__snapshots__/notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/notification.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<Notification /> Test story renders snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root css-m80vuh"
+        class="MuiSvgIcon-root css-henzh4"
         data-jest-file-name="IconInfoCircleLarge.svg"
         data-jest-svg-name="IconInfoCircleLarge"
         data-testid="IconInfoCircleLarge"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export * from "./core/Alert";
 export { default as Alert } from "./core/Alert";
 export * from "./core/Button";
 export { default as Button } from "./core/Button";
+export * from "./core/ButtonDropdown";
+export { default as ButtonDropdown } from "./core/ButtonDropdown";
 export * from "./core/Callout";
 export { default as Callout } from "./core/Callout";
 export * from "./core/Checkbox";


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-157948](https://app.shortcut.com/sci-design-system/story/157948/implement-buttondropdown)

**Acceptance Criteria:**
* `ButtonDropdown` is added to code repo and viewable in Storybook
* Has both rounded and square `sdsStyle` props
* Has primary and secondary `sdsType` props
* Has the same states as other Button components

**Designs:**
https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=1876%3A21349

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
