### PR TITLE
fix(menuselect): remove onInputChange API

### DIFF
--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -5,7 +5,6 @@ import {
   AutocompleteRenderOptionState,
 } from "@material-ui/lab";
 import React from "react";
-import { noop } from "src/common/utils";
 import Icon from "../Icon";
 import IconButton from "../IconButton";
 import { InputSearchProps } from "../InputSearch";
@@ -24,7 +23,6 @@ export interface DefaultMenuSelectOption {
 
 interface ExtraProps extends StyleProps {
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode;
-  onInputChange?: (event: React.SyntheticEvent) => void;
   InputBaseProps?: Partial<InputSearchProps>;
 }
 
@@ -62,7 +60,6 @@ export default function MenuSelect<
     disableCloseOnSelect = multiple,
     noOptionsText = "No options",
     search = false,
-    onInputChange = noop,
     InputBaseProps = {},
   } = props;
 
@@ -84,7 +81,6 @@ export default function MenuSelect<
             placeholder="Search"
             ref={params.InputProps.ref}
             search={search}
-            onChange={onInputChange}
             autoFocus
             InputProps={{
               /**


### PR DESCRIPTION
onInputChange API actually collapses with MUI Autocomplete's onInputChange, so let's remove it

BREAKING CHANGE: Removes onInputChange API. A code search shows that no product uses this API
anymore

## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](link)
Copy ticket descirption here

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
