### PR TITLE
style(alert): fix colors on alerts

### DIFF
--- a/src/core/Alert/style.ts
+++ b/src/core/Alert/style.ts
@@ -10,16 +10,24 @@ export const StyledAlert = styled(Alert)`
     const shadows = getShadows(props);
     const { severity = "primary" } = props;
     const borderColor = (colors && colors[severity][400]) || "black";
+    const alertColor = (colors && colors[severity][100]) || "white";
+    const iconColor = (colors && colors[severity][400]) || "black";
     return `
       margin: ${spacings?.m}px 0;
       border-radius: ${spacings?.default};
       color: ${defaultTheme.palette.text.primary};
       padding: ${spacings?.l}px ${spacings?.l}px
         ${spacings?.l}px 9px;
+      background-color: ${alertColor};
       &.elevated {
         border-left: 5px solid;
         box-shadow: ${shadows?.s};
         border-color: ${borderColor};
+      }
+      .MuiAlert-icon {
+        path {
+          fill: ${iconColor};
+        }
       }
     `;
   }}

--- a/src/core/Callout/style.ts
+++ b/src/core/Callout/style.ts
@@ -20,6 +20,7 @@ export const StyledCallout = styled(Alert)`
     const corners = getCorners(props);
     const iconSizes = getIconSizes(props);
     const iconColor = (colors && colors[severity][400]) || "black";
+    const calloutColor = (colors && colors[severity][200]) || "white";
 
     return `
       width: 360px;
@@ -27,6 +28,7 @@ export const StyledCallout = styled(Alert)`
       border-radius: ${corners?.m}px;
       color: ${defaultTheme.palette.text.primary};
       padding: ${spacings?.m}px;
+      background-color: ${calloutColor};
 
       .MuiAlert-icon {
         height: ${iconSizes?.l.height}px;

--- a/src/core/Callout/style.ts
+++ b/src/core/Callout/style.ts
@@ -20,7 +20,7 @@ export const StyledCallout = styled(Alert)`
     const corners = getCorners(props);
     const iconSizes = getIconSizes(props);
     const iconColor = (colors && colors[severity][400]) || "black";
-    const calloutColor = (colors && colors[severity][200]) || "white";
+    const calloutColor = (colors && colors[severity][100]) || "white";
 
     return `
       width: 360px;

--- a/src/core/Notification/__snapshots__/notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/notification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Notification /> Test story renders snapshot 1`] = `
 <div
-  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardInfo MuiAlert-standard elevated css-7go2cd-MuiPaper-root-MuiAlert-root"
+  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardInfo MuiAlert-standard elevated css-1xj0a98-MuiPaper-root-MuiAlert-root"
   data-testid="notification"
   role="alert"
   style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"

--- a/src/core/Notification/style.ts
+++ b/src/core/Notification/style.ts
@@ -23,6 +23,7 @@ export const StyledNotification = styled(Alert)`
     const corners = getCorners(props);
     const iconSizes = getIconSizes(props);
     const iconColor = (colors && colors[severity][400]) || "black";
+    const notificationColor = (colors && colors[severity][100]) || "white";
 
     return `
       width: 360px;
@@ -31,6 +32,7 @@ export const StyledNotification = styled(Alert)`
       color: ${defaultTheme.palette.text.primary};
       padding: ${spacings?.l}px;
       align-items: flex-start;
+      background-color: ${notificationColor};
 
       &.elevated {
         border-left: 5px solid;


### PR DESCRIPTION
We need to explicitly set the background colors now.

The colors defined in our theme seem to be slightly different from what the background color of Alert previously defaulted to, so this should be reviewed by a designer to determine what color we actually want to use. I set them all to 100 for now.