### PR TITLE
feat(inputtoggle): add an inputtoggle

### DIFF
--- a/src/common/styles-dictionary/style-dictionary.json
+++ b/src/common/styles-dictionary/style-dictionary.json
@@ -248,6 +248,7 @@
         "solid": { "value": "1px solid" }
       },
       "primary": {
+        "300": { "value": "1px solid {sds.color.primary.300.value}" },
         "400": { "value": "1px solid {sds.color.primary.400.value}" },
         "500": { "value": "1px solid {sds.color.primary.500.value}" },
         "600": { "value": "1px solid {sds.color.primary.600.value}" },

--- a/src/core/InputToggle/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputToggle/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<InputToggle /> Test story renders snapshot 1`] = `
+<span
+  class="MuiSwitch-root css-ujw0lf"
+>
+  <span
+    aria-disabled="false"
+    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiSwitch-switchBase MuiSwitch-colorPrimary"
+    data-testid="test-toggle"
+  >
+    <span
+      class="MuiIconButton-label"
+    >
+      <input
+        class="PrivateSwitchBase-input-4 MuiSwitch-input"
+        type="checkbox"
+        value="Off"
+      />
+      <span
+        class="MuiSwitch-thumb"
+      />
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </span>
+  <span
+    class="MuiSwitch-track"
+  />
+</span>
+`;

--- a/src/core/InputToggle/index.stories.tsx
+++ b/src/core/InputToggle/index.stories.tsx
@@ -1,0 +1,54 @@
+import { Args, Story } from "@storybook/react";
+import React from "react";
+import InputToggle from "./index";
+
+const Demo = (props: Args): JSX.Element => {
+  return <InputToggle {...props} />;
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Default = Template.bind({});
+
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+export default {
+  argTypes: {
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
+  component: Demo,
+  title: "InputToggle",
+};
+
+// const LivePreviewDemo = (props: Args): JSX.Element => {
+//   return <InputToggle {...props} id="togglePreview" sdsStage="off" />;
+// };
+
+// const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+// export const LivePreview = LivePreviewTemplate.bind({});
+
+// LivePreview.parameters = {
+//   snapshot: {
+//     skip: true,
+//   },
+// };
+
+// const TestDemo = (props: Args): JSX.Element => {
+//   return (
+//     <InputToggle
+//       {...props}
+//       id="test-toggle"
+//     />
+//   );
+// };
+
+// const TestTemplate: Story = (args) => <TestDemo {...args} />;
+
+// export const Test = TestTemplate.bind({});

--- a/src/core/InputToggle/index.stories.tsx
+++ b/src/core/InputToggle/index.stories.tsx
@@ -26,29 +26,24 @@ export default {
   title: "InputToggle",
 };
 
-// const LivePreviewDemo = (props: Args): JSX.Element => {
-//   return <InputToggle {...props} id="togglePreview" sdsStage="off" />;
-// };
+const LivePreviewDemo = (props: Args): JSX.Element => {
+  return <InputToggle {...props} id="togglePreview" />;
+};
 
-// const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
 
-// export const LivePreview = LivePreviewTemplate.bind({});
+export const LivePreview = LivePreviewTemplate.bind({});
 
-// LivePreview.parameters = {
-//   snapshot: {
-//     skip: true,
-//   },
-// };
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 
-// const TestDemo = (props: Args): JSX.Element => {
-//   return (
-//     <InputToggle
-//       {...props}
-//       id="test-toggle"
-//     />
-//   );
-// };
+const TestDemo = (props: Args): JSX.Element => {
+  return <InputToggle {...props} data-testid="test-toggle" />;
+};
 
-// const TestTemplate: Story = (args) => <TestDemo {...args} />;
+const TestTemplate: Story = (args) => <TestDemo {...args} />;
 
-// export const Test = TestTemplate.bind({});
+export const Test = TestTemplate.bind({});

--- a/src/core/InputToggle/index.test.tsx
+++ b/src/core/InputToggle/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<InputToggle />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders", () => {
+    render(<Test {...Test.args} />);
+    const InputToggleElement = screen.getByTestId("test-toggle");
+    expect(InputToggleElement).not.toBeNull();
+  });
+});

--- a/src/core/InputToggle/index.tsx
+++ b/src/core/InputToggle/index.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { ExtraProps, Toggle } from "./style";
+
+const InputToggle = (props: ExtraProps) => {
+  const [checked, setChecked] = useState<boolean>(false);
+
+  const { offLabel = "Off", onChange, onLabel = "On", ...rest } = props;
+  const labelValue = checked ? onLabel : offLabel;
+
+  const handleChange = (e: React.ChangeEvent) => {
+    setChecked(!checked);
+    if (onChange) onChange(e);
+  };
+
+  return (
+    <Toggle
+      checked={checked}
+      color="primary"
+      onChange={handleChange}
+      value={labelValue}
+      {...rest}
+    >
+      {labelValue}
+    </Toggle>
+  );
+};
+
+export default InputToggle;

--- a/src/core/InputToggle/style.ts
+++ b/src/core/InputToggle/style.ts
@@ -1,0 +1,154 @@
+import styled from "@emotion/styled";
+import { Switch, SwitchProps } from "@material-ui/core";
+import {
+  CommonThemeProps,
+  fontBodyXs,
+  getBorders,
+  getColors,
+  getCorners,
+  getSpaces,
+} from "../styles";
+
+export interface ExtraProps extends SwitchProps, CommonThemeProps {
+  offLabel?: string;
+  onChange?(e: React.ChangeEvent): void;
+  onLabel?: string;
+}
+
+const toggle = (props: ExtraProps) => {
+  const { disabled } = props;
+  const corners = getCorners(props);
+  const spaces = getSpaces(props);
+  const TOGGLE_HEIGHT = 18;
+
+  return `
+    cursor: ${disabled ? "default" : "pointer"};
+    border-radius: ${corners?.l}px;
+    height: 26px;
+    width: 62px;
+    line-height: 18px;
+    margin-bottom: ${spaces?.m}px;
+    padding: 0;
+
+    .MuiSwitch-switchBase {
+      font: inherit;
+      margin: ${spaces?.xxs}px;
+      padding: 0;
+
+      &:hover {
+        background-color: white;
+      }
+    }
+
+    .MuiSwitch-thumb {
+      height: ${TOGGLE_HEIGHT}px;
+      width: ${TOGGLE_HEIGHT}px;
+      box-shadow: none;
+    }
+
+    && .MuiSwitch-track {
+      background-color: white;
+      width: unset;
+    }
+  `;
+};
+
+const toggleOn = (props: ExtraProps) => {
+  const { disabled, value } = props;
+  const borders = getBorders(props);
+  const colors = getColors(props);
+  const spaces = getSpaces(props);
+
+  return `
+    outline: ${disabled ? borders?.primary[300] : borders?.primary[400]};
+
+    .MuiSwitch-thumb {
+      color: ${disabled ? colors?.primary[300] : colors?.primary[400]};
+    }
+
+    .MuiSwitch-switchBase {
+      left: unset;
+      right: 0;
+      transform: unset;
+
+      .MuiIconButton-label {
+        margin-left: ${spaces?.s}px;
+      }
+
+      &:before {
+        color: ${disabled ? colors?.gray[300] : "black"};
+        content: "${value}";
+        font: inherit;
+        font-family: 'Open sans';
+      }
+    }
+
+    ${
+      !disabled &&
+      `&:hover {
+        outline: ${borders?.primary[500]};
+
+        .MuiSwitch-thumb {
+          color: ${colors?.primary[500]};
+        }
+      }`
+    }
+  `;
+};
+
+const toggleOff = (props: ExtraProps) => {
+  const { disabled, value } = props;
+  const borders = getBorders(props);
+  const colors = getColors(props);
+  const spaces = getSpaces(props);
+
+  return `
+    & {
+      outline: ${disabled ? borders?.gray[300] : borders?.gray[400]};
+    }
+
+    .MuiSwitch-thumb {
+      color: ${disabled ? colors?.gray[300] : colors?.gray[400]};
+    }
+
+    .MuiSwitch-switchBase {
+      right: unset;
+      left: 0;
+      transform: unset;
+
+      .MuiIconButton-label {
+        margin-right: ${spaces?.s}px;
+      }
+
+      &:after {
+        color: ${disabled ? colors?.gray[300] : colors?.gray[500]};
+        content: "${value}";
+        font: inherit;
+        font-family: 'Open sans';
+      }
+    }
+
+    ${
+      !disabled &&
+      `&:hover {
+        outline: ${borders?.gray[500]};
+
+        .MuiSwitch-thumb {
+          color: ${colors?.gray[500]};
+        }
+      }`
+    }
+  `;
+};
+
+export const Toggle = styled(Switch)`
+  ${fontBodyXs}
+  ${(props: ExtraProps) => {
+    const { checked } = props;
+
+    return `
+      ${toggle(props)}
+      ${checked ? toggleOn(props) : toggleOff(props)}
+    `;
+  }}
+`;

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -87,6 +87,7 @@ const borders = {
     solid: `1px solid`,
   },
   primary: {
+    "300": `1px solid ${defaultThemeColors.primary["300"]}`,
     "400": `1px solid ${defaultThemeColors.primary["400"]}`,
     "500": `1px solid ${defaultThemeColors.primary["500"]}`,
     "600": `1px solid${defaultThemeColors.primary["600"]}`,


### PR DESCRIPTION
### Summary
- **What:** Add `InputToggle` component
- **Ticket:** [[sc-157940]](https://app.shortcut.com/sci-design-system/story/157940)
- **Design:** https://www.figma.com/proto/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=1876%3A21139&scaling=min-zoom&page-id=642%3A1

### Demos
![after](https://user-images.githubusercontent.com/7562933/163504197-f533d643-4601-4dd7-936c-a9fe5126decc.gif)

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [x] I added relevant unit tests
- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design