### PR TITLE
fix(alert, callout, notification): set appropriate bg color

### DIFF
--- a/src/core/Alert/style.ts
+++ b/src/core/Alert/style.ts
@@ -8,11 +8,13 @@ export const StyledAlert = styled(Alert)`
     const colors = getColors(props);
     const spacings = getSpaces(props);
     const shadows = getShadows(props);
-    const { severity = "primary" } = props;
+    const { severity = "success" } = props;
     const borderColor = (colors && colors[severity][400]) || "black";
+    const backgroundColor = colors && colors[severity][100];
+
     return `
+      background-color: ${backgroundColor};
       margin: ${spacings?.m}px 0;
-      border-radius: ${spacings?.default};
       color: ${defaultTheme.palette.text.primary};
       padding: ${spacings?.l}px ${spacings?.l}px
         ${spacings?.l}px 9px;

--- a/src/core/Callout/style.ts
+++ b/src/core/Callout/style.ts
@@ -20,8 +20,10 @@ export const StyledCallout = styled(Alert)`
     const corners = getCorners(props);
     const iconSizes = getIconSizes(props);
     const iconColor = (colors && colors[severity][400]) || "black";
+    const backgroundColor = colors && colors[severity][100];
 
     return `
+      background-color: ${backgroundColor};
       width: 360px;
       margin: ${spacings?.m}px 0;
       border-radius: ${corners?.m}px;

--- a/src/core/Notification/__snapshots__/notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/notification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Notification /> Test story renders snapshot 1`] = `
 <div
-  class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo elevated css-u3gjkj MuiPaper-elevation0"
+  class="MuiPaper-root MuiAlert-root MuiAlert-standardInfo elevated css-ge3qs3 MuiPaper-elevation0"
   data-testid="notification"
   role="alert"
   style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"

--- a/src/core/Notification/style.ts
+++ b/src/core/Notification/style.ts
@@ -23,8 +23,10 @@ export const StyledNotification = styled(Alert)`
     const corners = getCorners(props);
     const iconSizes = getIconSizes(props);
     const iconColor = (colors && colors[severity][400]) || "black";
+    const backgroundColor = colors && colors[severity][100];
 
     return `
+      background-color: ${backgroundColor};
       width: 360px;
       margin: ${spacings?.m}px 0;
       border-radius: ${corners?.m}px;


### PR DESCRIPTION
### Summary
- **What:** set appropriate bg color for alert, callout, notification, rather than using the mui default colors
- **Why:** To match design spec
- **Design:** https://www.figma.com/file/EaRifXLFs54XTjO1Mlszkg/Science-Design-System-Reference?node-id=5683%3A87200


### Demos
#### Before: 
![Screen Shot 2022-04-19 at 9 39 43 AM](https://user-images.githubusercontent.com/7562933/164053351-2404ea44-febe-42f3-b924-b430a2ed1078.png)

#### After: 
![Screen Shot 2022-04-19 at 9 39 34 AM](https://user-images.githubusercontent.com/7562933/164053366-3d78855a-7d07-464e-87ff-ecbb684d35ea.png)

### Notes
The visual change is very subtle, but more noticeable in callouts that have zebra tables. I only noticed this because I was trying to make a table in a callout in czge and the colors were wonky looking.

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)
- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [x] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design