### PR TITLE
fix: allow consuming apps to override colors in borders

### DIFF
--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -70,39 +70,7 @@ const defaultThemeColors = {
   },
 };
 
-const borders = {
-  error: {
-    "400": `1px solid ${defaultThemeColors.error["400"]}`,
-  },
-  gray: {
-    "100": `1px solid ${defaultThemeColors.gray["100"]}`,
-    "200": `1px solid ${defaultThemeColors.gray["200"]}`,
-    "300": `1px solid ${defaultThemeColors.gray["300"]}`,
-    "400": `1px solid ${defaultThemeColors.gray["400"]}`,
-    "500": `1px solid ${defaultThemeColors.gray["500"]}`,
-    dashed: `2px dashed ${defaultThemeColors.gray["400"]}`,
-  },
-  link: {
-    dashed: `1px dashed`,
-    solid: `1px solid`,
-  },
-  primary: {
-    "300": `1px solid ${defaultThemeColors.primary["300"]}`,
-    "400": `1px solid ${defaultThemeColors.primary["400"]}`,
-    "500": `1px solid ${defaultThemeColors.primary["500"]}`,
-    "600": `1px solid${defaultThemeColors.primary["600"]}`,
-    dashed: `2px dashed ${defaultThemeColors.primary["400"]}`,
-  },
-  success: {
-    "400": `1px solid ${defaultThemeColors.success["400"]}`,
-  },
-  warning: {
-    "400": `1px solid ${defaultThemeColors.warning["400"]}`,
-  },
-};
-
-export const defaultAppTheme: AppTheme = {
-  borders,
+const defaultAppTheme: AppTheme = {
   colors: defaultThemeColors,
   corners: {
     l: 20,
@@ -266,6 +234,45 @@ export const defaultAppTheme: AppTheme = {
   },
 };
 
+// (mlila) whenever our theme uses colors, we need to make sure we allow consuming
+// applications to override those colors using their own custom theme.
+// By defining borders using defaultAppTheme.colors instead of defaultThemeColors,
+// we allow other apps to specify their colors once, and have them apply
+// throughtout the application, such as in borders, etc without having to manually
+// override every theme property that makes use of colors.
+defaultAppTheme.borders = {
+  error: {
+    "400": `1px solid ${defaultAppTheme.colors.error[400]}`,
+  },
+  gray: {
+    "100": `1px solid ${defaultAppTheme.colors.gray[100]}`,
+    "200": `1px solid ${defaultAppTheme.colors.gray[200]}`,
+    "300": `1px solid ${defaultAppTheme.colors.gray[300]}`,
+    "400": `1px solid ${defaultAppTheme.colors.gray[400]}`,
+    "500": `1px solid ${defaultAppTheme.colors.gray[500]}`,
+    dashed: `2px dashed ${defaultAppTheme.colors.gray[400]}`,
+  },
+  link: {
+    dashed: `1px dashed`,
+    solid: `1px solid`,
+  },
+  primary: {
+    "300": `1px solid ${defaultAppTheme.colors.primary[300]}`,
+    "400": `1px solid ${defaultAppTheme.colors.primary[400]}`,
+    "500": `1px solid ${defaultAppTheme.colors.primary[500]}`,
+    "600": `1px solid${defaultAppTheme.colors.primary[600]}`,
+    dashed: `2px dashed ${defaultAppTheme.colors.primary[400]}`,
+  },
+  success: {
+    "400": `1px solid ${defaultAppTheme.colors.success[400]}`,
+  },
+  warning: {
+    "400": `1px solid ${defaultAppTheme.colors.warning[400]}`,
+  },
+};
+
+export { defaultAppTheme };
+
 export function makeThemeOptions(appTheme: AppTheme): AppThemeOptions {
   return {
     app: appTheme,
@@ -403,7 +410,7 @@ export interface AppThemeOptions extends ThemeOptions {
 }
 
 interface AppTheme {
-  borders: Borders;
+  borders?: Borders;
   colors: Colors;
   corners: Corners;
   fontWeights: FontWeights;

--- a/src/core/styles/common/defaultTheme.ts
+++ b/src/core/styles/common/defaultTheme.ts
@@ -18,7 +18,7 @@ enum FontWeight {
   semibold = 600,
 }
 
-const defaultThemeColors = {
+export const defaultThemeColors = {
   beta: {
     "100": "#F4F0F9",
     "200": "#F0EBF6",
@@ -270,8 +270,6 @@ defaultAppTheme.borders = {
     "400": `1px solid ${defaultAppTheme.colors.warning[400]}`,
   },
 };
-
-export { defaultAppTheme };
 
 export function makeThemeOptions(appTheme: AppTheme): AppThemeOptions {
   return {


### PR DESCRIPTION
## Summary
https://app.shortcut.com/sci-design-system/story/194499/update-defaulttheme-ts-to-avoid-using-defaultthemecolors

## Checklist
- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design