### PR TITLE
fix(tooltip): even when we don't render tooltip, show children

### DIFF
--- a/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/tooltip.test.tsx.snap
@@ -4,5 +4,7 @@ exports[`<Tooltip /> Test story renders snapshot 1`] = `
 <div
   class=""
   data-testid="tooltip"
-/>
+>
+  I am a tooltip child element
+</div>
 `;

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -112,6 +112,21 @@ LightWide.args = {
   width: "wide",
 };
 
+export const NoTooltipTitle = Template.bind({});
+
+NoTooltipTitle.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+NoTooltipTitle.args = {
+  arrow: true,
+  placement: "top",
+  sdsStyle: "light",
+  width: "wide",
+};
+
 export const StyledArrow = Template.bind({});
 StyledArrow.parameters = {
   snapshot: {
@@ -204,7 +219,7 @@ const TestDemo = (props: Args): JSX.Element => {
   const { title, ...rest } = props;
   return (
     <Tooltip title={title} {...rest} data-testid="tooltip">
-      <div />
+      <div>I am a tooltip child element</div>
     </Tooltip>
   );
 };

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -32,6 +32,8 @@ const Tooltip = forwardRef(function Tooltip(
     ...rest
   } = props;
 
+  const { children } = rest;
+
   if (inverted) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -72,8 +74,8 @@ const Tooltip = forwardRef(function Tooltip(
   });
 
   // (mlila) if no content is passed into the tooltip, don't render
-  // anything. this matches with the native MUI behavior.
-  if (!title && !subtitle) return null;
+  // a tooltip. this matches with the native MUI behavior.
+  if (!title && !subtitle) return <>{children}</>;
 
   const content = (
     <>

--- a/src/core/Tooltip/tooltip.test.tsx
+++ b/src/core/Tooltip/tooltip.test.tsx
@@ -17,9 +17,15 @@ describe("<Tooltip />", () => {
     expect(tooltipElement).not.toBeNull();
   });
 
-  it("does not render when no content provided", () => {
+  it("does not render when no title content provided", () => {
     render(<Test {...Test.args} title="" />);
     const tooltipElement = screen.queryByTestId("tooltip");
     expect(tooltipElement).toBeNull();
+  });
+
+  it("renders children even when it does not render a tooltip", () => {
+    render(<Test {...Test.args} title="" />);
+    const child = screen.getByText("I am a tooltip child element");
+    expect(child).not.toBeNull();
   });
 });


### PR DESCRIPTION
### Summary
- **What:** Even when we don't show a tooltip, still render the children
- **Why:** Oops! Otherwise even the components that are wrapped up by the tooltip won't be rendered

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [x] I added relevant unit tests