### PR TITLE
feat(callout): allow consumer to conditionally override callout icon

### DIFF
--- a/src/core/Callout/index.tsx
+++ b/src/core/Callout/index.tsx
@@ -8,6 +8,7 @@ import { StyledCallout } from "./style";
 export interface CalloutProps {
   autoDismiss?: boolean | number;
   dismissed?: boolean;
+  icon?: React.ReactNode;
   intent: "info" | "error" | "success" | "warning";
 }
 
@@ -18,6 +19,7 @@ const Callout = ({
   children,
   dismissed,
   onClose,
+  icon,
   intent,
   ...rest
 }: ExposedCalloutProps): JSX.Element => {
@@ -40,6 +42,8 @@ const Callout = ({
   };
 
   const getIcon = () => {
+    if (icon) return icon;
+
     switch (intent) {
       case "success":
         return <Icon sdsSize="l" sdsIcon="checkCircle" sdsType="static" />;


### PR DESCRIPTION
### Summary
- **What:** Allow a consumer to conditionally assign a custom icon to callout
- **Why:** I have a component that is based on Callout, which wants to provide a custom icon _sometimes_. As is, if the component passes `icon={iconComponent}`, it works, but then if `iconComponent` is undefined, sds Callout reverts to using the mui default icon because `icon={undefined}` gets spread in sds Callout via `{...rest}`. With this change, if my component passes `icon={undefined}` (where undefined is determined programmatically), we still use the icon as dictated by sds style guidelines, rather than mui
- **Ticket:** [[sc-180631]](https://app.shortcut.com/genepi/story/180631)

### Demos
#### Before: 
<img width="322" alt="Screen Shot 2022-05-09 at 5 17 13 PM" src="https://user-images.githubusercontent.com/7562933/167518563-17a4ba10-b8bd-482b-8c34-9bc5807c4088.png">

#### After: 
<img width="320" alt="Screen Shot 2022-05-09 at 5 17 38 PM" src="https://user-images.githubusercontent.com/7562933/167518554-9581a239-8b68-48de-a7cd-64cb212c4543.png">

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)