### PR TITLE
docs(all): add MUI links

### DIFF
--- a/src/core/Accordion/index.tsx
+++ b/src/core/Accordion/index.tsx
@@ -4,6 +4,9 @@ import { AccordionExtraProps, StyledAccordion } from "./style";
 
 export type AccordionProps = RawAccordionProps & AccordionExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/accordion/
+ */
 const Accordion = (props: AccordionProps) => {
   const { children, useDivider, togglePosition = "right", id } = props;
   const [expanded, setExpanded] = React.useState<string | false>(false);

--- a/src/core/Alert/index.tsx
+++ b/src/core/Alert/index.tsx
@@ -4,6 +4,9 @@ import { StyledAlert } from "./style";
 
 export type { AlertProps };
 
+/**
+ * @see https://v4.mui.com/components/alert/
+ */
 const Alert = (props: AlertProps): JSX.Element => {
   return <StyledAlert {...props} />;
 };

--- a/src/core/Button/index.tsx
+++ b/src/core/Button/index.tsx
@@ -20,6 +20,9 @@ export interface SdsProps {
 export type ButtonProps<C extends React.ElementType = "button"> =
   RawButtonProps<C, { component?: C }> & SdsProps;
 
+/**
+ * @see https://v4.mui.com/components/buttons/
+ */
 const Button = React.forwardRef(
   <C extends React.ElementType>(
     props: ButtonProps<C>,

--- a/src/core/ButtonDropdown/index.tsx
+++ b/src/core/ButtonDropdown/index.tsx
@@ -13,6 +13,9 @@ interface SdsProps {
 export type ButtonDropdownProps<C extends React.ElementType = "button"> =
   RawButtonProps<C, { component?: C }> & SdsProps;
 
+/**
+ * @see https://v4.mui.com/components/buttons/
+ */
 const ButtonDropdown = React.forwardRef(
   <C extends React.ElementType>(
     props: ButtonDropdownProps<C>,

--- a/src/core/Callout/index.tsx
+++ b/src/core/Callout/index.tsx
@@ -14,6 +14,9 @@ export interface CalloutProps {
 
 export type ExposedCalloutProps = AlertProps & CalloutProps;
 
+/**
+ * @see https://v4.mui.com/components/alert/
+ */
 const Callout = ({
   autoDismiss,
   children,

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -10,6 +10,9 @@ export interface CheckboxProps
   stage: "checked" | "unchecked" | "indeterminate";
 }
 
+/**
+ * @see https://v4.mui.com/components/checkboxes/
+ */
 const Checkbox = (props: CheckboxProps): JSX.Element => {
   let newProps: MUICheckboxProps;
   switch (props.stage) {

--- a/src/core/Chip/index.tsx
+++ b/src/core/Chip/index.tsx
@@ -7,6 +7,9 @@ type ChipProps = ChipExtraProps & RawChipProps;
 
 export type { ChipProps };
 
+/**
+ * @see https://v4.mui.com/components/chips/
+ */
 const Chip = (props: ChipProps): JSX.Element => {
   const { onDelete } = props;
   if (onDelete) {

--- a/src/core/Dialog/index.tsx
+++ b/src/core/Dialog/index.tsx
@@ -16,6 +16,9 @@ interface DialogExtraProps {
 
 export type DialogProps = RawDialogProps & DialogExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/dialogs/
+ */
 const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
   props,
   ref

--- a/src/core/DialogActions/index.tsx
+++ b/src/core/DialogActions/index.tsx
@@ -5,6 +5,9 @@ import { DialogActionsExtraProps, StyledDialogActions } from "./style";
 export type DialogActionsProps = DialogActionsExtraProps &
   RawDialogActionsProps;
 
+/**
+ * @see https://v4.mui.com/components/dialogs/
+ */
 const DialogActions = forwardRef<HTMLDivElement, DialogActionsProps>(
   function DialogActions(props, ref) {
     return <StyledDialogActions ref={ref} {...props} />;

--- a/src/core/DialogContent/index.tsx
+++ b/src/core/DialogContent/index.tsx
@@ -5,6 +5,9 @@ import { StyledDialogContent } from "./style";
 export type { DialogContentProps };
 
 export default forwardRef<HTMLDivElement, DialogContentProps>(
+  /**
+   * @see https://v4.mui.com/components/dialogs/
+   */
   function DialogContent(props, ref) {
     return <StyledDialogContent ref={ref} {...props} />;
   }

--- a/src/core/DialogPaper/index.tsx
+++ b/src/core/DialogPaper/index.tsx
@@ -5,6 +5,9 @@ import { StyledPaper } from "./style";
 
 export type { PaperProps as DialogPaperProps };
 
+/**
+ * @see https://v4.mui.com/components/paper/
+ */
 const DialogPaper = forwardRef<unknown, PaperProps>(function DialogPaper(
   props,
   ref

--- a/src/core/DialogTitle/index.tsx
+++ b/src/core/DialogTitle/index.tsx
@@ -18,6 +18,9 @@ export interface DialogTitleProps
   onClose?: () => void;
 }
 
+/**
+ * @see https://v4.mui.com/components/dialogs/
+ */
 const DialogTitle = forwardRef(function DialogTitle(
   props: DialogTitleProps,
   ref

--- a/src/core/Icon/index.tsx
+++ b/src/core/Icon/index.tsx
@@ -7,6 +7,9 @@ export type { IconNameToSizes };
 export type IconProps<IconName extends keyof IconNameToSizes> =
   IconExtraProps<IconName>;
 
+/**
+ * @see https://v4.mui.com/components/dialogs/
+ */
 const Icon = forwardRef(function Icon<IconName extends keyof IconNameToSizes>(
   { sdsIcon, sdsSize, sdsType }: IconProps<IconName>,
   ref: ForwardedRef<HTMLDivElement | null>

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -12,6 +12,9 @@ export interface IconExtraProps<IconName extends keyof IconNameToSizes>
   sdsType: "iconButton" | "interactive" | "static" | "button";
 }
 
+/**
+ * @see https://v4.mui.com/components/icons/#svgicon
+ */
 function iconSize<IconName extends keyof IconNameToSizes>(
   props: IconExtraProps<IconName>
 ): SerializedStyles {

--- a/src/core/IconButton/index.tsx
+++ b/src/core/IconButton/index.tsx
@@ -6,6 +6,9 @@ type IconButtonProps = IconButtonExtraProps & RawIconButtonProps;
 
 export type { IconButtonProps };
 
+/**
+ * @see https://v4.mui.com/components/buttons/#icon-buttons
+ */
 const IconButton = forwardRef<HTMLButtonElement | null, IconButtonProps>(
   (props, ref): JSX.Element => {
     return <StyledIconButton {...props} ref={ref} />;

--- a/src/core/InputDropdown/index.tsx
+++ b/src/core/InputDropdown/index.tsx
@@ -10,6 +10,9 @@ import {
 
 export type { InputDropdownProps };
 
+/**
+ * @see https://v4.mui.com/components/buttons/
+ */
 const InputDropdown = (props: InputDropdownProps): JSX.Element => {
   const { label, open, sdsType, details, counter } = props;
 

--- a/src/core/InputSearch/index.tsx
+++ b/src/core/InputSearch/index.tsx
@@ -18,6 +18,9 @@ export type InputSearchProps = RawTextFieldSearchProps &
   AccessibleInputSearchProps &
   InputSearchExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/text-fields/
+ */
 const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
   function InputSearch(props, ref): JSX.Element {
     const {

--- a/src/core/InputText/index.tsx
+++ b/src/core/InputText/index.tsx
@@ -12,6 +12,9 @@ export type InputTextProps = RawTextFieldProps &
   InputTextExtraProps &
   AccessibleInputTextProps;
 
+/**
+ * @see https://v4.mui.com/components/text-fields/
+ */
 const InputText = forwardRef<HTMLInputElement, InputTextProps>(
   function InputText(props, ref): JSX.Element {
     const {

--- a/src/core/InputToggle/index.tsx
+++ b/src/core/InputToggle/index.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
 import { InputToggleExtraProps, Toggle } from "./style";
 
+/**
+ * @see https://v4.mui.com/components/switches/
+ */
 const InputToggle = (props: InputToggleExtraProps) => {
   const [checked, setChecked] = useState<boolean>(false);
 

--- a/src/core/Link/index.tsx
+++ b/src/core/Link/index.tsx
@@ -1,6 +1,9 @@
 import React, { ForwardedRef, forwardRef } from "react";
 import { LinkProps, StyledLink } from "./style";
 
+/**
+ * @see https://v4.mui.com/components/links/
+ */
 const Link = forwardRef(
   (props: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
     const { sdsStyle } = props;

--- a/src/core/List/index.tsx
+++ b/src/core/List/index.tsx
@@ -4,6 +4,9 @@ import { ListExtraProps, StyledList } from "./style";
 
 type ListProps = ListExtraProps & RawListProps;
 
+/**
+ * @see https://v4.mui.com/components/lists/
+ */
 const List = (props: ListProps): JSX.Element => {
   const { ordered } = props;
 

--- a/src/core/ListItem/index.tsx
+++ b/src/core/ListItem/index.tsx
@@ -6,6 +6,9 @@ export { ListItemLabel };
 
 export type ListItemProps = RawListItemProps & ListItemExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/lists/
+ */
 const ListItem = (props: ListItemProps): JSX.Element => {
   return <StyledListItem disableGutters {...(props as never)} />;
 };

--- a/src/core/ListSubheader/index.tsx
+++ b/src/core/ListSubheader/index.tsx
@@ -4,6 +4,9 @@ import { StyledListSubheader } from "./style";
 
 export type { ListSubheaderProps };
 
+/**
+ * @see https://v4.mui.com/components/lists/
+ */
 const ListSubheader = (props: ListSubheaderProps): JSX.Element => {
   return <StyledListSubheader disableGutters {...props} />;
 };

--- a/src/core/Menu/index.tsx
+++ b/src/core/Menu/index.tsx
@@ -14,6 +14,9 @@ const TRANSFORM_ORIGIN: PopoverOrigin = {
 
 export type { MenuProps };
 
+/**
+ * @see https://v4.mui.com/components/menus/
+ */
 const Menu = (props: MenuProps): JSX.Element => {
   return (
     <StyledMenu

--- a/src/core/MenuItem/index.tsx
+++ b/src/core/MenuItem/index.tsx
@@ -15,6 +15,9 @@ export interface MenuItemExtraProps {
 
 export type MenuItemProps = MenuItemExtraProps & RawMenuItemProps;
 
+/**
+ * @see https://v4.mui.com/components/menus/
+ */
 const MenuItem = forwardRef((props: MenuItemProps, _) => {
   const {
     children,

--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -44,6 +44,9 @@ export type MenuSelectProps<
 > = CustomAutocompleteProps<T, Multiple, DisableClearable, FreeSolo> &
   MenuSelectExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/autocomplete/
+ */
 export default function MenuSelect<
   T extends DefaultMenuSelectOption,
   Multiple extends boolean | undefined = undefined,

--- a/src/core/Notification/index.tsx
+++ b/src/core/Notification/index.tsx
@@ -18,6 +18,9 @@ export interface NotificationProps {
 
 export type ExposedNotificationProps = AlertProps & NotificationProps;
 
+/**
+ * @see https://v4.mui.com/components/alert/
+ */
 const Notification = ({
   autoDismiss,
   children,

--- a/src/core/Radio/index.tsx
+++ b/src/core/Radio/index.tsx
@@ -9,6 +9,9 @@ export interface RadioProps
   stage: "checked" | "unchecked";
 }
 
+/**
+ * @see https://v4.mui.com/components/radio-buttons/
+ */
 const RadioButton = (props: RadioProps): JSX.Element => {
   let newProps: MUIRadioProps;
   switch (props.stage) {

--- a/src/core/SegmentedControl/index.tsx
+++ b/src/core/SegmentedControl/index.tsx
@@ -15,6 +15,9 @@ interface SegmentedControlExtraProps {
   buttonDefinition: SingleButtonDefinition[];
 }
 
+/**
+ * @see https://v4.mui.com/components/toggle-button/
+ */
 export type SegmentedControlProps = SegmentedControlExtraProps &
   ToggleButtonGroupProps;
 

--- a/src/core/Tabs/index.tsx
+++ b/src/core/Tabs/index.tsx
@@ -46,6 +46,9 @@ export interface TabProps extends RawTabProps {
   count?: number;
 }
 
+/**
+ * @see https://v4.mui.com/components/tabs/
+ */
 export const Tab = forwardRef<HTMLDivElement, TabProps>(function Tab(
   props,
   ref

--- a/src/core/Tag/index.tsx
+++ b/src/core/Tag/index.tsx
@@ -22,7 +22,7 @@ export interface SdsTagProps extends Omit<ChipProps, "color"> {
 export type TagProps = SdsTagProps;
 
 /**
- * @see: https://v4.mui.com/components/chips/
+ * @see https://v4.mui.com/components/chips/
  *
  * @props color: {string}                   - applies color for tag based on default theme color values
  *               [string, string]           - applies custom colors for [font, background]

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -12,6 +12,8 @@ type TooltipProps = TooltipExtraProps & RawTooltipProps;
 export type { TooltipProps };
 
 /**
+ * @see https://v4.mui.com/components/tooltips/
+ *
  * @warning If the tooltip wraps a disabled component, please make sure to
  * wrap the children in a `<span>` tag.
  * https://mui.com/components/tooltips/#disabled-elements

--- a/src/core/TooltipCondensed/index.tsx
+++ b/src/core/TooltipCondensed/index.tsx
@@ -6,6 +6,13 @@ import { condensedCSS, TooltipCondensedExtraProps } from "./style";
 
 export type TooltipCondensedProps = TooltipProps & TooltipCondensedExtraProps;
 
+/**
+ * @see https://v4.mui.com/components/tooltips/
+ *
+ * @warning If the tooltip wraps a disabled component, please make sure to
+ * wrap the children in a `<span>` tag.
+ * https://mui.com/components/tooltips/#disabled-elements
+ */
 const TooltipCondensed = forwardRef(function TooltipCondensed(
   props: TooltipCondensedProps,
   ref

--- a/src/core/TooltipTable/index.tsx
+++ b/src/core/TooltipTable/index.tsx
@@ -13,6 +13,9 @@ type TooltipTableContentProps = TooltipTableExtraProps;
 
 export type { TooltipTableContentProps };
 
+/**
+ * @see https://v4.mui.com/components/tables/
+ */
 const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
   const { contentAlert, data, itemAlign = "right", ...rest } = props;
 


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-191659](https://app.shortcut.com/sci-design-system/story/191659/add-links-to-underlying-mui-components-to-sds-components-in-the-codebase)

Add links to underlying MUI components to SDS components in the codebase

<img width="1150" alt="Screen Shot 2022-05-17 at 3 31 32 PM" src="https://user-images.githubusercontent.com/6309723/168923108-91f022bd-9087-424a-b80d-550b1528e54e.png">

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
