### PR TITLE
fix(input dropdown): forward sdsStyle to Button to silence Button warning

### DIFF
--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -202,7 +202,7 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const doNotForwardProps = ["intent", "open", "sdsStage", "sdsStyle"];
+const doNotForwardProps = ["intent", "open", "sdsStage"];
 
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),


### PR DESCRIPTION
## Summary
Silences warning that Button produces:`Warning: Buttons without sdsStyle or sdsType props will be deprecated.` by allowing InputDropdown to forward prop `sdsStyle` to Button

## Notes
My first contribution here I believe so I'm currently trying to read through the contribution guidelines and follow the steps there

Tested in CZ ID and verified that this indeed silenced the warning

Before:
https://user-images.githubusercontent.com/51972068/169142655-4c6f3eeb-f2fd-470b-9c67-af211d133807.mov


After:
https://user-images.githubusercontent.com/51972068/169142541-082793fb-8d72-49d1-9b70-ee5dbd74040f.mov

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
