### PR TITLE
fix(inputsearch): remove extra data-test-id from index file

### DIFF
--- a/src/core/InputSearch/index.tsx
+++ b/src/core/InputSearch/index.tsx
@@ -75,7 +75,6 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
               <InputAdornment position="end">
                 <IconButton
                   onClick={localHandleSubmit}
-                  data-testId="searchButton"
                   sdsType="secondary"
                   aria-label="search-button"
                 >


### PR DESCRIPTION
Removes Warning: React does not recognize the `data-testId` prop on a DOM element.