### PR TITLE
fix(input toggle): fixed styling

### DIFF
--- a/src/core/InputToggle/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputToggle/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<InputToggle /> Test story renders snapshot 1`] = `
 <span
-  class="MuiSwitch-root css-ujw0lf"
+  class="MuiSwitch-root css-14g4sls"
 >
   <span
     aria-disabled="false"
@@ -21,9 +21,6 @@ exports[`<InputToggle /> Test story renders snapshot 1`] = `
         class="MuiSwitch-thumb"
       />
     </span>
-    <span
-      class="MuiTouchRipple-root"
-    />
   </span>
   <span
     class="MuiSwitch-track"

--- a/src/core/InputToggle/index.tsx
+++ b/src/core/InputToggle/index.tsx
@@ -21,6 +21,7 @@ const InputToggle = (props: InputToggleExtraProps) => {
       color="primary"
       onChange={handleChange}
       value={labelValue}
+      disableRipple
       {...rest}
     >
       {labelValue}

--- a/src/core/InputToggle/style.ts
+++ b/src/core/InputToggle/style.ts
@@ -22,31 +22,33 @@ const toggle = (props: InputToggleExtraProps) => {
   const TOGGLE_HEIGHT = 18;
 
   return `
-    cursor: ${disabled ? "default" : "pointer"};
-    border-radius: ${corners?.l}px;
-    height: 26px;
-    width: 62px;
-    line-height: 18px;
-    margin-bottom: ${spaces?.m}px;
-    padding: 0;
-
-    .MuiSwitch-switchBase {
-      font: inherit;
-      margin: ${spaces?.xxs}px;
+    &&{
+      cursor: ${disabled ? "default" : "pointer"};
+      border-radius: ${corners?.l}px;
+      height: 26px;
+      width: 62px;
+      line-height: 18px;
+      margin-bottom: ${spaces?.m}px;
       padding: 0;
 
-      &:hover {
-        background-color: white;
+      .MuiSwitch-switchBase {
+        font: inherit;
+        margin: ${spaces?.xxs}px;
+        padding: 0;
+        transform: unset;
+
+        &:hover {
+          background-color: white;
+        }
       }
-    }
 
-    .MuiSwitch-thumb {
-      height: ${TOGGLE_HEIGHT}px;
-      width: ${TOGGLE_HEIGHT}px;
-      box-shadow: none;
-    }
+      .MuiSwitch-thumb {
+        height: ${TOGGLE_HEIGHT}px;
+        width: ${TOGGLE_HEIGHT}px;
+        box-shadow: none;
+      }
 
-    && .MuiSwitch-track {
+    .MuiSwitch-track {
       background-color: white;
       width: unset;
     }


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [[sh-XXXX](link)](https://app.shortcut.com/sci-design-system/story/199606/migrate-inputtoggle)
fix input toggle component so it works as expected on mui5
## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
