### PR TITLE
refactor(tag): updates the hover and active logic for custom colored tags 

### DIFF
--- a/src/core/FilterTag/__snapshots__/index.test.tsx.snap
+++ b/src/core/FilterTag/__snapshots__/index.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<FilterTag /> Default story renders snapshot 1`] = `
     style="grid-area: 2 / 1 / 2 / 2;"
   >
     <div
-      class="MuiButtonBase-root MuiChip-root css-jkv6tl MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-deletableColorPrimary MuiChip-clickable MuiChip-deletable"
+      class="MuiButtonBase-root MuiChip-root css-ipf0dd MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-deletableColorPrimary MuiChip-clickable MuiChip-deletable"
       role="button"
       tabindex="0"
     >

--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -70,7 +70,7 @@ Default.parameters = {
   // tab indicator bug known by MUI where width for indicator updates once font is loaded in.
   // delay allows for font to load and prevents chromatic from constantly creating new baselines
   // https://github.com/mui/material-ui/blob/v4.x/packages/material-ui/src/Tabs/Tabs.js#L194
-  chromatic: { delay: 500 },
+  chromatic: { delay: 5000 },
   snapshot: {
     skip: true,
   },
@@ -146,6 +146,7 @@ export const LivePreview = LivePreviewTemplate.bind({});
 LivePreview.args = {};
 
 LivePreview.parameters = {
+  chromatic: { delay: 5000 },
   snapshot: {
     skip: true,
   },
@@ -200,3 +201,7 @@ function TestDemo(props: Args): JSX.Element {
 const TestTemplate: Story = (args) => <TestDemo {...args} />;
 
 export const Test = TestTemplate.bind({});
+
+Test.parameters = {
+  chromatic: { delay: 5000 },
+};

--- a/src/core/Tag/__snapshots__/index.test.tsx.snap
+++ b/src/core/Tag/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Tag /> Default story renders snapshot 1`] = `
 <div
-  class="MuiButtonBase-root MuiChip-root css-1fpabxj MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
+  class="MuiButtonBase-root MuiChip-root css-1b7rsrz MuiChip-colorPrimary MuiChip-clickableColorPrimary MuiChip-clickable"
   role="button"
   tabindex="0"
 >

--- a/src/core/Tag/index.stories.tsx
+++ b/src/core/Tag/index.stories.tsx
@@ -20,8 +20,8 @@ const Demo = (props: Args): JSX.Element => {
 };
 
 const customColorTuples = {
-  labelAndBack: ["brown", "lightsalmon"],
-  labelAndBackAndIcon: ["brown", "lightsalmon", "crimson"],
+  labelAndBack: ["#A52A2A", "#ffa07a"],
+  labelAndBackAndIcon: ["#A52A2A", "#ffa07a", "#ffe74a"],
 };
 
 const availableColorOptions = [
@@ -56,8 +56,8 @@ export default {
           "error",
           "gray",
           "beta",
-          "Label + Background",
-          "Label + Background + Icon",
+          "Custom colors for Label, Background",
+          "Custom colors for Label, Background, Icon",
         ],
         type: "select",
       },

--- a/src/core/Tag/style.ts
+++ b/src/core/Tag/style.ts
@@ -1,6 +1,6 @@
 import { css, SerializedStyles } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Chip } from "@material-ui/core";
+import { Chip, darken } from "@material-ui/core";
 import {
   CommonThemeProps,
   fontBodyXs,
@@ -158,37 +158,30 @@ function createTypeCss(
     typeof props.tagColor === "string" ? props.tagColor : "primary";
   const colors = Array.isArray(props.tagColor) ? [...props.tagColor] : [];
 
-  let cssFilters: {
-    activeFilter?: string;
-    hoverFilter?: string;
-  } = {
-    activeFilter: "brightness(1) saturate(1)",
-    hoverFilter: "brightness(1) saturate(1)",
-  };
-
-  if (colors.length >= 2) {
-    cssFilters = {
-      activeFilter: "brightness(0.7) saturate(1.3)",
-      hoverFilter: "brightness(0.85) saturate(1.15)",
-    };
-  }
-
   const typeToColors = {
     primary: {
       background: colors.length >= 2 ? colors[1] : themeColors?.[intent][400],
       backgroundClicked:
-        colors.length >= 2 ? colors[1] : themeColors?.[intent][600],
+        colors.length >= 2
+          ? darken(colors[1], 0.3)
+          : themeColors?.[intent][600],
       backgroundHover:
-        colors.length >= 2 ? colors[1] : themeColors?.[intent][500],
+        colors.length >= 2
+          ? darken(colors[1], 0.15)
+          : themeColors?.[intent][500],
       iconColor: colors.length > 2 ? colors[2] : "white",
       label: colors.length ? colors[0] : "white",
     },
     secondary: {
       background: colors.length >= 2 ? colors[1] : themeColors?.[intent][200],
       backgroundClicked:
-        colors.length >= 2 ? colors[1] : themeColors?.[intent][600],
+        colors.length >= 2
+          ? darken(colors[1], 0.3)
+          : themeColors?.[intent][600],
       backgroundHover:
-        colors.length >= 2 ? colors[1] : themeColors?.[intent][500],
+        colors.length >= 2
+          ? darken(colors[1], 0.15)
+          : themeColors?.[intent][500],
       iconColor: colors.length > 2 ? colors[2] : themeColors?.[intent][400],
       label: colors.length ? colors[0] : themeColors?.[intent][600],
     },
@@ -210,17 +203,11 @@ function createTypeCss(
 
     &:hover {
       background-color: ${typeColors.backgroundHover};
-      &:after {
-        backdrop-filter: ${cssFilters.hoverFilter};
-      }
     }
 
     &:active,
     &:focus {
       background-color: ${typeColors.backgroundClicked};
-      &:after {
-        backdrop-filter: ${cssFilters.activeFilter};
-      }
     }
 
     &:hover,
@@ -248,22 +235,6 @@ export const StyledTag = styled(Chip, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   border: none;
-
-  &:after {
-    content: "";
-    width: 100%;
-    height: 100%;
-    left: 0;
-    top: 0;
-    position: absolute;
-    background-color: transparent;
-    z-index: 0;
-  }
-
-  .MuiChip-label,
-  svg {
-    z-index: 1;
-  }
 
   ${(props: ExtraProps) => {
     const { sdsType, sdsStyle, icon } = props;


### PR DESCRIPTION
## Summary

**Tag**
Using MUI's `darken()` function to replace the `::after` pseudo-element previously used to change the `:hover` and `:active` background-colors for custom colored tags. 

