### PR TITLE
feat(menuselect, dropdownmenu): Add option to prevent Dropdown from clearing search bar on select

### DIFF
--- a/src/core/DropdownMenu/index.stories.tsx
+++ b/src/core/DropdownMenu/index.stories.tsx
@@ -202,6 +202,9 @@ export default {
     hasSections: {
       control: { type: "boolean" },
     },
+    keepSearchOnSelect: {
+      control: { type: "boolean" },
+    },
     multiple: {
       control: { type: "boolean" },
     },
@@ -222,6 +225,7 @@ export const Default = Template.bind({});
 
 Default.args = {
   hasSections: true,
+  keepSearchOnSelect: true,
   multiple: true,
   search: true,
   title: true,
@@ -546,6 +550,7 @@ export const LivePreview = LivePreviewTemplate.bind({});
 
 LivePreview.args = {
   hasSections: false,
+  keepSearchOnSelect: true,
   multiple: false,
   search: false,
   title: false,
@@ -678,6 +683,7 @@ export const Test = TestTemplate.bind({});
 
 Test.args = {
   hasSections: false,
+  keepSearchOnSelect: false,
   multiple: false,
   search: false,
   title: false,

--- a/src/core/DropdownMenu/index.tsx
+++ b/src/core/DropdownMenu/index.tsx
@@ -4,7 +4,7 @@ import {
   AutocompleteRenderInputParams,
   AutocompleteRenderOptionState,
 } from "@material-ui/lab";
-import React from "react";
+import React, { useState } from "react";
 import { noop } from "src/common/utils";
 import Icon from "../Icon";
 import IconButton from "../IconButton";
@@ -26,8 +26,8 @@ export interface DefaultDropdownMenuOption {
   details?: string;
   count?: string;
 }
-
 interface ExtraProps extends StyleProps {
+  keepSearchOnSelect?: boolean;
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode;
   onInputChange?: (event: React.SyntheticEvent) => void;
   InputBaseProps?: Partial<InputSearchProps>;
@@ -60,6 +60,7 @@ export default function DropdownMenu<
   props: DropdownMenuProps<T, Multiple, DisableClearable, FreeSolo>
 ): JSX.Element {
   const {
+    keepSearchOnSelect = true,
     multiple = false,
     getOptionLabel = defaultGetOptionLabel,
     getOptionSelected = defaultGetOptionSelected,
@@ -72,6 +73,8 @@ export default function DropdownMenu<
     InputBaseProps = {},
   } = props;
 
+  const [inputValue, setInputValue] = useState("");
+
   return (
     <StyledAutocomplete
       clearOnBlur={false}
@@ -82,6 +85,17 @@ export default function DropdownMenu<
       renderOption={renderOption}
       getOptionLabel={getOptionLabel}
       getOptionSelected={getOptionSelected}
+      inputValue={inputValue}
+      onInputChange={(event, value, reason) => {
+        if (event && event.type === "blur") {
+          setInputValue("");
+        } else if (
+          reason !== "reset" ||
+          (reason === "reset" && !keepSearchOnSelect)
+        ) {
+          setInputValue(value);
+        }
+      }}
       renderInput={(params) => (
         <InputBaseWrapper search={search}>
           <StyledMenuInputSearch

--- a/src/core/DropdownMenu/style.ts
+++ b/src/core/DropdownMenu/style.ts
@@ -67,6 +67,7 @@ export interface StyleProps extends CommonThemeProps {
 
 const doNotForwardProps = [
   "count",
+  "keepSearchOnSelect",
   "search",
   "InputBaseProps",
   "hasSections",

--- a/src/core/MenuSelect/index.stories.tsx
+++ b/src/core/MenuSelect/index.stories.tsx
@@ -155,6 +155,17 @@ function Chips({ value, multiple, onDelete }: ChipsProps): JSX.Element | null {
 }
 
 export default {
+  argTypes: {
+    keepSearchOnSelect: {
+      control: { type: "boolean" },
+    },
+    multiple: {
+      control: { type: "boolean" },
+    },
+    search: {
+      control: { type: "boolean" },
+    },
+  },
   component: Demo,
   title: "MenuSelect - To Be Depreciated",
 };
@@ -163,24 +174,33 @@ const Template: Story = (args) => <Demo {...args} />;
 
 export const Default = Template.bind({});
 
-Default.args = {};
+Default.args = {
+  keepSearchOnSelect: false,
+  multiple: false,
+  search: false,
+};
 
 export const SingleSelectWithSearch = Template.bind({});
 
 SingleSelectWithSearch.args = {
+  keepSearchOnSelect: false,
+  multiple: false,
   search: true,
 };
 
 export const MultiSelect = Template.bind({});
 
 MultiSelect.args = {
+  keepSearchOnSelect: false,
   multiple: true,
+  search: false,
 };
 
 export const MultiSelectWithSearch = Template.bind({});
 
 MultiSelectWithSearch.args = {
   InputBaseProps: { placeholder: "Custom placeholder..." },
+  keepSearchOnSelect: true,
   multiple: true,
   search: true,
 };
@@ -214,6 +234,10 @@ const useStyles = makeStyles((theme: AppThemeOptions) => {
       margin: 0,
     },
     popper: {
+      "& .MuiAutocomplete-option[aria-selected='true'], & .MuiAutocomplete-option[data-focus='true']":
+        {
+          backgroundColor: "transparent",
+        },
       backgroundColor: "white",
       border: `1px solid ${colors?.gray[100]}`,
       borderRadius: corners?.m,

--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -4,7 +4,7 @@ import {
   AutocompleteRenderInputParams,
   AutocompleteRenderOptionState,
 } from "@material-ui/lab";
-import React from "react";
+import React, { useState } from "react";
 import Icon from "../Icon";
 import IconButton from "../IconButton";
 import { InputSearchProps } from "../InputSearch";
@@ -23,6 +23,7 @@ export interface DefaultMenuSelectOption {
 }
 
 interface MenuSelectExtraProps extends StyleProps {
+  keepSearchOnSelect?: boolean;
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode;
   InputBaseProps?: Partial<InputSearchProps>;
 }
@@ -57,6 +58,7 @@ export default function MenuSelect<
   props: MenuSelectProps<T, Multiple, DisableClearable, FreeSolo>
 ): JSX.Element {
   const {
+    keepSearchOnSelect = true,
     multiple = false,
     getOptionLabel = defaultGetOptionLabel,
     renderTags = defaultRenderTags,
@@ -66,6 +68,8 @@ export default function MenuSelect<
     search = false,
     InputBaseProps = {},
   } = props;
+
+  const [inputValue, setInputValue] = useState("");
 
   if (!hasWarned) {
     // eslint-disable-next-line no-console
@@ -85,6 +89,17 @@ export default function MenuSelect<
       noOptionsText={noOptionsText}
       renderOption={renderOption}
       getOptionLabel={getOptionLabel}
+      inputValue={inputValue}
+      onInputChange={(event, value, reason) => {
+        if (event && event.type === "blur") {
+          setInputValue("");
+        } else if (
+          reason !== "reset" ||
+          (reason === "reset" && !keepSearchOnSelect)
+        ) {
+          setInputValue(value);
+        }
+      }}
       renderInput={(params) => (
         <InputBaseWrapper search={search}>
           <StyledMenuInputSearch

--- a/src/core/MenuSelect/style.ts
+++ b/src/core/MenuSelect/style.ts
@@ -12,7 +12,7 @@ export interface StyleProps extends CommonThemeProps {
   search?: boolean;
 }
 
-const doNotForwardProps = ["search", "InputBaseProps"];
+const doNotForwardProps = ["search", "InputBaseProps", "keepSearchOnSelect"];
 
 // (thuang): Casting the type to `Autocomplete`
 //  per https://github.com/mui-org/material-ui/issues/21727#issuecomment-880263271


### PR DESCRIPTION
## Summary

**MenuSelect, DropDownMenu**
Shortcut ticket: [sh-193551](https://app.shortcut.com/sci-design-system/story/193551/add-option-to-prevent-dropdown-from-clearing-search-bar-on-option-select)

"The search bar -- when search is true -- clears on selection of any item in the Dropdown. This isn't exactly a bug, but for the component we're working on in CZ GEN EPI we really need a way to change the behavior so that the search bar keeps its entered search term and the filtered options remain the same before and after selection of an item."

+ [Added] KeepSearchOnSelect option for menuSelect
+ [Added] KeepSearchOnSelect option for dropDownMenu
+ [Changed] Minor styling updates for MenuSelect component

If you set `keepSearchOnSelect` as `false`, after clicking on an option, the search box would be cleared too. This is how it was previously.

![KeepSearchOnSelect = False](https://user-images.githubusercontent.com/927990/171497602-4389032f-bf02-4a52-9337-5a359046a869.gif)

But setting `keepSearchOnSelect` as `true` would prevent clearing the search bar on option select.

![KeepSearchOnSelect = true](https://user-images.githubusercontent.com/927990/171497848-bea15899-e93f-4cd5-986e-736ad890189c.gif)
