### PR TITLE
fix(segmented control): fixed styling after migration to v5

### DIFF
--- a/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
 <div
-  class="MuiToggleButtonGroup-root css-686uuq"
+  class="MuiToggleButtonGroup-root css-xct8ce"
   color="primary"
   role="group"
 >
@@ -135,7 +135,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
 
 exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
 <div
-  class="MuiToggleButtonGroup-root css-686uuq"
+  class="MuiToggleButtonGroup-root css-xct8ce"
   color="primary"
   data-testid="segmentedControl"
   role="group"

--- a/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
 <div
-  class="MuiToggleButtonGroup-root css-xct8ce"
-  color="primary"
+  class="MuiToggleButtonGroup-root css-g1e6pw-MuiToggleButtonGroup-root"
   role="group"
 >
   <button
     aria-pressed="true"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal Mui-selected MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List A"
@@ -40,6 +40,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List B"
@@ -71,6 +72,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List C"
@@ -102,6 +104,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List D"
@@ -135,14 +138,14 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
 
 exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
 <div
-  class="MuiToggleButtonGroup-root css-xct8ce"
-  color="primary"
+  class="MuiToggleButtonGroup-root css-g1e6pw-MuiToggleButtonGroup-root"
   data-testid="segmentedControl"
   role="group"
 >
   <button
     aria-pressed="true"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal Mui-selected MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List A"
@@ -174,6 +177,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="List B"
@@ -205,6 +209,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="Table"
@@ -236,6 +241,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
   <button
     aria-pressed="false"
     class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-sizeSmall"
+    color="standard"
     tabindex="0"
     type="button"
     value="People"

--- a/src/core/SegmentedControl/index.tsx
+++ b/src/core/SegmentedControl/index.tsx
@@ -11,8 +11,18 @@ interface SingleButtonDefinition {
   tooltipText: string;
 }
 
-interface SegmentedControlExtraProps {
+interface SegmentedControlExtraProps
+  extends Omit<ToggleButtonGroupProps, "color"> {
   buttonDefinition: SingleButtonDefinition[];
+  color?:
+    | "primary"
+    | "secondary"
+    | "standard"
+    | "success"
+    | "error"
+    | "info"
+    | "warning"
+    | undefined;
 }
 
 /**
@@ -37,11 +47,11 @@ const SegmentedControl = (props: SegmentedControlProps) => {
 
   return (
     <StyledSegmentedControl
+      color="primary"
       size="small"
       value={active}
       exclusive
       onChange={handleActive}
-      color="primary"
       {...props}
     >
       {(buttonDefinition as SingleButtonDefinition[]).map((button) => {

--- a/src/core/SegmentedControl/style.ts
+++ b/src/core/SegmentedControl/style.ts
@@ -34,6 +34,7 @@ export const StyledSegmentedControl = styled(ToggleButtonGroup, {
       padding: 0;
 
       &:hover {
+        border-color: ${colors?.gray[300]};
         background-color: ${colors?.gray[100]};
       }
     }

--- a/src/core/SegmentedControl/style.ts
+++ b/src/core/SegmentedControl/style.ts
@@ -1,13 +1,11 @@
-import styled from "@emotion/styled";
-import ToggleButtonGroup from "@material-ui/lab/ToggleButtonGroup";
+import { styled } from "@mui/material/styles";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import { CommonThemeProps, getColors, getCorners, getSpaces } from "../styles";
 
-const sdsPropNames = ["buttonDefinition"];
+const doNotForwardProps = ["color", "buttonDefinition"];
 
 export const StyledSegmentedControl = styled(ToggleButtonGroup, {
-  shouldForwardProp: (prop) => {
-    return !sdsPropNames.includes(prop.toString());
-  },
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: CommonThemeProps) => {
     const colors = getColors(props);


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [[sh-XXXX](link)](https://app.shortcut.com/sci-design-system/story/199601/migrate-segmented-control)
migrate the segmented control component to use mui5

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
