### PR TITLE
chore(package.json): update ip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
+  "resolutions": {
+    "ip": "1.1.6"
+  },
   "scripts": {
     "build": "yarn sd-build && rollup -c",
     "build-watch": "rollup -c -w",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9016,10 +9016,10 @@ ip-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+ip@1.1.6, ip@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.6.tgz#5a651a37644586e18b6ba3b48ca122bf56495f67"
+  integrity sha512-/dAvCivFs/VexXAtiAoMIqyhkhStNC9CPD0h1noonimOgB1xrCkexF2c5CjlqQ72GgMPjN6tiV+oreoPv3Ft1g==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
`yarn start` was erroring out in the `ip` package, as shown below.  If this is a broader issue that others are experiencing, forcing `yarn` to use a newer `ip` package via the `resolutions` config seems to solve the issue.

```
❯ yarn && yarn start
yarn install v1.22.17
[1/4] 🔍  Resolving packages...
success Already up-to-date.
$ husky install
husky - Git hooks installed
✨  Done in 0.62s.
yarn run v1.22.17
$ start-storybook -p 6006
info @storybook/react v6.4.22
info
info => Loading presets
Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
ERR! TypeError: details.family.toLowerCase is not a function
ERR!     at /Users/jfu/sci-components/node_modules/ip/lib/ip.js:385:39
ERR!     at Array.filter (<anonymous>)
```

## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](link)
Copy ticket descirption here

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
