### PR TITLE
Bethbertozzi/sc 167623/update stories for inputcheckbox to csf format

### DIFF
--- a/src/core/Checkbox/__snapshots__/index.test.tsx.snap
+++ b/src/core/Checkbox/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Checkbox /> Test story renders snapshot 1`] = `
+<label
+  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+>
+  <span
+    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-1x95i3r-MuiButtonBase-root-MuiCheckbox-root"
+    data-testid="checkbox"
+  >
+    <input
+      class="PrivateSwitchBase-input css-1m9pwf3"
+      data-indeterminate="false"
+      type="checkbox"
+    />
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      data-jest-file-name="IconCheckboxUnchecked.svg"
+      data-jest-svg-name="IconCheckboxUnchecked"
+      data-testid="IconCheckboxUnchecked"
+      fillcontrast="white"
+      focusable="false"
+      viewBox="0 0 16 16"
+    />
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </span>
+  <span
+    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+  >
+    Label
+  </span>
+</label>
+`;

--- a/src/core/Checkbox/__snapshots__/index.test.tsx.snap
+++ b/src/core/Checkbox/__snapshots__/index.test.tsx.snap
@@ -1,36 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Checkbox /> Test story renders snapshot 1`] = `
-<label
-  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+<div
+  style="display: grid; grid-template-columns: repeat(2, 1fr); grid-template-rows: 1fr;"
 >
-  <span
-    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-1x95i3r-MuiButtonBase-root-MuiCheckbox-root"
-    data-testid="checkbox"
+  <div
+    style="grid-area: 1 / 1 / 1 / 2;"
   >
-    <input
-      class="PrivateSwitchBase-input css-1m9pwf3"
-      data-indeterminate="false"
-      type="checkbox"
-    />
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-      data-jest-file-name="IconCheckboxUnchecked.svg"
-      data-jest-svg-name="IconCheckboxUnchecked"
-      data-testid="IconCheckboxUnchecked"
-      fillcontrast="white"
-      focusable="false"
-      viewBox="0 0 16 16"
-    />
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
-  </span>
-  <span
-    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
-  >
-    Label
-  </span>
-</label>
+    <label
+      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+    >
+      <span
+        class="MuiCheckbox-root MuiCheckbox-colorDefault MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root css-1ptfvrq-MuiButtonBase-root-MuiCheckbox-root"
+        data-testid="checkbox"
+        stage="unchecked"
+      >
+        <input
+          class="PrivateSwitchBase-input css-1m9pwf3"
+          data-indeterminate="false"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-jest-file-name="IconCheckboxUnchecked.svg"
+          data-jest-svg-name="IconCheckboxUnchecked"
+          data-testid="IconCheckboxUnchecked"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 16 16"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+      >
+        Label
+      </span>
+    </label>
+  </div>
+</div>
 `;

--- a/src/core/Checkbox/index.stories.tsx
+++ b/src/core/Checkbox/index.stories.tsx
@@ -1,27 +1,47 @@
-import { FormControlLabel } from "@mui/material";
-import { action } from "@storybook/addon-actions";
+import { Box, FormControlLabel } from "@mui/material";
 import { Args, Story } from "@storybook/react";
 import React from "react";
 import Checkbox from "./index";
 
-const actions = {
-  onChange: action("onChange"),
+const CheckboxDemo = (props: Args): JSX.Element => {
+  const { disabled } = props;
+  const [checked, setChecked] = React.useState(true);
+
+  const handleCheck = () => setChecked(true);
+  const handleUncheck = () => setChecked(false);
+
+  const livePreviewStyles = {
+    display: "grid",
+    gridColumnGap: "24px",
+    gridRowGap: "0px",
+    gridTemplateColumns: "repeat(2, 1fr)",
+    gridTemplateRows: "1fr",
+  };
+
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <div style={{ gridArea: "1 / 1 / 1 / 2" }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              disabled={disabled}
+              onChange={checked ? handleUncheck : handleCheck}
+              stage={checked ? "unchecked" : "checked"}
+            />
+          }
+          label="Label"
+        />
+      </div>
+    </div>
+  );
 };
 
 export default {
-  component: Checkbox,
+  component: CheckboxDemo,
   title: "Checkbox",
 };
 
-const Template: Story = (props: Args) => {
-  const { stage } = props;
-  return (
-    <FormControlLabel
-      control={<Checkbox onChange={actions.onChange} stage={stage} />}
-      label="Label"
-    />
-  );
-};
+const Template: Story = (args) => <CheckboxDemo {...args} />;
 
 export const Default = Template.bind({});
 
@@ -33,7 +53,6 @@ Default.parameters = {
 
 Default.args = {
   id: "test-story",
-  stage: "checked",
 };
 
 export const Test = Template.bind({});
@@ -43,23 +62,97 @@ Test.args = {
   togglePosition: "right",
 };
 
-const livePreviewStyles = {
-  display: "grid",
-  gridColumnGap: "24px",
-  gridRowGap: "0px",
-  gridTemplateColumns: "repeat(2, 1fr)",
-  gridTemplateRows: "1fr",
-};
+/*
+ * Live Preview
+ */
 
-// LivePreview
-function LivePreviewDemo(props: Args): JSX.Element {
+const IndeterminateDemo = (): JSX.Element => {
+  const [checked, setChecked] = React.useState([true, false]);
+
+  const handleChange1 = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked([event.target.checked, event.target.checked]);
+  };
+
+  const handleChange2 = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked([event.target.checked, checked[1]]);
+  };
+
+  const handleChange3 = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked([checked[0], event.target.checked]);
+  };
+
+  const children = (
+    <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
+      <FormControlLabel
+        label="Child 1"
+        control={
+          <Checkbox
+            onChange={handleChange2}
+            stage={checked[0] ? "checked" : "unchecked"}
+          />
+        }
+      />
+      <FormControlLabel
+        label="Child 2"
+        control={
+          <Checkbox
+            onChange={handleChange3}
+            stage={checked[1] ? "checked" : "unchecked"}
+          />
+        }
+      />
+    </Box>
+  );
+
+  function getParentStage() {
+    if (checked[0] && checked[1]) {
+      return "checked";
+    }
+    if (checked[0] !== checked[1]) {
+      return "indeterminate";
+    }
+    return "unchecked";
+  }
   return (
-    <div style={livePreviewStyles as React.CSSProperties}>
-      <Template id="checkbox-1" stage="unchecked" {...props} />
-      <Template id="checkbox-2" stage="unchecked" {...props} />
+    <div>
+      <FormControlLabel
+        label="Parent"
+        control={
+          <Checkbox
+            checked={checked[0] && checked[1]}
+            stage={getParentStage()}
+            onChange={handleChange1}
+          />
+        }
+      />
+      {children}
     </div>
   );
-}
+};
+
+const LivePreviewDemo = (): JSX.Element => {
+  const livePreviewStyles = {
+    display: "grid",
+    gridColumnGap: "24px",
+    gridRowGap: "0px",
+    gridTemplateColumns: "repeat(3, 1fr)",
+    gridTemplateRows: "1fr",
+  };
+
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <div style={{ gridArea: "1 / 1 / 1 / 2" }}>
+        <CheckboxDemo disabled={false} />
+      </div>
+      <div style={{ gridArea: "1 / 2 / 1 / 2" }}>
+        <CheckboxDemo disabled />
+      </div>
+      <div style={{ gridArea: "1 / 3 / 1 / 3" }}>
+        <IndeterminateDemo />
+      </div>
+    </div>
+  );
+};
 
 const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
 

--- a/src/core/Checkbox/index.stories.tsx
+++ b/src/core/Checkbox/index.stories.tsx
@@ -1,6 +1,6 @@
 import { FormControlLabel } from "@mui/material";
 import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/react";
+import { Args, Story } from "@storybook/react";
 import React from "react";
 import Checkbox from "./index";
 
@@ -8,97 +8,65 @@ const actions = {
   onChange: action("onChange"),
 };
 
-const storyColumn = {
-  alignItems: "flex-start",
-  display: "flex",
-  flexDirection: "column",
+export default {
+  component: Checkbox,
+  title: "Checkbox",
 };
 
-storiesOf("Checkbox", module).add("unchecked", () => (
-  <div style={storyColumn as React.CSSProperties}>
-    <p>
-      <strong>Accessibility</strong>: All checkboxes should have a label. This
-      can be done with a visible form label or with the aria-label attribute.
-      Note aria labels should be meaningful based on your content. <br /> Good:
-      &ldquo;XYZ Gene&ldquo;
-      <br /> Bad: &ldquo;Unchecked&ldquo; <br />{" "}
-      https://material-ui.com/components/checkboxes/#accessibility
-    </p>
+const Template: Story = (props: Args) => {
+  const { stage } = props;
+  return (
     <FormControlLabel
-      control={<Checkbox onChange={actions.onChange} stage="unchecked" />}
-      label="Unchecked"
+      control={<Checkbox onChange={actions.onChange} stage={stage} />}
+      label="Label"
     />
-    <FormControlLabel
-      control={
-        <Checkbox disabled onChange={actions.onChange} stage="unchecked" />
-      }
-      label="Unchecked & disabled"
-    />
-    With aria labels:
-    <Checkbox
-      inputProps={{ "aria-label": "checkbox unchecked" }}
-      onChange={actions.onChange}
-      stage="unchecked"
-    />
-    <Checkbox
-      disabled
-      inputProps={{ "aria-label": "checkbox unchecked and disabled" }}
-      onChange={actions.onChange}
-      stage="unchecked"
-    />
-  </div>
-));
+  );
+};
 
-storiesOf("Checkbox", module).add("checked", () => (
-  <div style={storyColumn as React.CSSProperties}>
-    <FormControlLabel
-      control={<Checkbox onChange={actions.onChange} stage="checked" />}
-      label="Checked"
-    />
-    <FormControlLabel
-      control={
-        <Checkbox disabled onChange={actions.onChange} stage="checked" />
-      }
-      label="Checked & disabled"
-    />
-    With aria labels:
-    <Checkbox
-      inputProps={{ "aria-label": "checked" }}
-      onChange={actions.onChange}
-      stage="checked"
-    />
-    <Checkbox
-      disabled
-      inputProps={{ "aria-label": "checked and disabled" }}
-      onChange={actions.onChange}
-      stage="checked"
-    />
-  </div>
-));
+export const Default = Template.bind({});
 
-storiesOf("Checkbox", module).add("indeterminate", () => (
-  <div style={storyColumn as React.CSSProperties}>
-    <FormControlLabel
-      control={<Checkbox onChange={actions.onChange} stage="indeterminate" />}
-      label="Checked"
-    />
-    <FormControlLabel
-      control={
-        <Checkbox disabled onChange={actions.onChange} stage="indeterminate" />
-      }
-      label="Checked & disabled"
-    />
-    With aria labels:
-    <Checkbox
-      inputProps={{ "aria-label": "indeterminate" }}
-      onChange={actions.onChange}
-      stage="indeterminate"
-    />
-    <Checkbox
-      disabled
-      inputProps={{ "aria-label": "indeterminate and disabled" }}
-      onChange={actions.onChange}
-      stage="indeterminate"
-    />
-  </div>
-));
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+Default.args = {
+  id: "test-story",
+  stage: "checked",
+};
+
+export const Test = Template.bind({});
+
+Test.args = {
+  id: "test-story",
+  togglePosition: "right",
+};
+
+const livePreviewStyles = {
+  display: "grid",
+  gridColumnGap: "24px",
+  gridRowGap: "0px",
+  gridTemplateColumns: "repeat(2, 1fr)",
+  gridTemplateRows: "1fr",
+};
+
+// LivePreview
+function LivePreviewDemo(props: Args): JSX.Element {
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <Template id="checkbox-1" stage="unchecked" {...props} />
+      <Template id="checkbox-2" stage="unchecked" {...props} />
+    </div>
+  );
+}
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const LivePreview = LivePreviewTemplate.bind({});
+
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};

--- a/src/core/Checkbox/index.test.tsx
+++ b/src/core/Checkbox/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<Checkbox />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders checkbox component", () => {
+    render(<Test {...Test.args} />);
+    const checkboxElement = screen.getByTestId("checkbox");
+    expect(checkboxElement).not.toBeNull();
+  });
+});

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -44,6 +44,7 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
 
   return (
     <StyledCheckbox
+      data-testid="checkbox"
       {...newProps}
       checkedIcon={
         <SvgIcon


### PR DESCRIPTION
## Summary
The checkbox does not currently have the 'caption' (text under label) functionality so I have created a follow up ticket to add it: https://app.shortcut.com/sci-design-system/story/204074/add-caption-to-checkbox-component. I have also made the stories intractable, and added a story to Live preview to demonstrate the functionality of the indeterminate stage

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](https://app.shortcut.com/sci-design-system/story/167623/update-stories-for-inputcheckbox-to-csf-format)
In order to support testing and ZeroHeight, we are moving away from the StoriesOf() syntax and are adopting the [CSF Format](https://storybook.js.org/docs/react/api/csf).

In addition, there should be 3 stories per component: Default (all props are interactable via storybook controls, will occasionally include some external components to trigger effects and states), LivePreview (a number of components as defined by our ZeroHeight implementation—see below for which components to include in each LivePreview view), and Test (a single component).

New components will be created with this format, but already published components will need to be updated.

Default and LivePreview should have the following parameters set so a snapshot is only taken of the single component:

Default.parameters = {
  snapshot: {
    skip: true,
  },
};

LivePreview.parameters = {
  snapshot: {
    skip: true,
  },
};
 Wrap
Most props should auto populate

Live Preview

See directions and attached screenshots below for guidance of how the Live Preview should be laid out:

Checkbox
Two variants: InputCheckbox + Label, InputCheckbox + Label + Caption
Spacing as follows: 24px between each variant

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
