### PR TITLE
feat(dropdown): allow consumers to pass onclose to dropdown

### DIFF
--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -88,6 +88,22 @@ MultipleSelectWithIsTriggerChangeOnOptionClick.args = {
   },
 };
 
+export const SearchWithOnClose = Template.bind({});
+
+SearchWithOnClose.args = {
+  buttonPosition: "right",
+  buttons: true,
+  closeOnBlur: false,
+  label: LABEL,
+  multiple: true,
+  onChange: noop,
+  onClose: () => {
+    // eslint-disable-next-line no-console
+    console.log(123);
+  },
+  search: true,
+};
+
 const useStyles = makeStyles(() => ({
   /* stylelint-disable-next-line */
   paper: {

--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -29,7 +29,7 @@ interface DropdownProps<Multiple> {
   label: string;
   options: DefaultDropdownMenuOption[];
   onChange: (options: Value<DefaultDropdownMenuOption, Multiple>) => void;
-  onClose: () => void;
+  onClose?: () => void;
   multiple?: Multiple;
   search?: boolean;
   MenuSelectProps?: Partial<typeof DropdownMenu>;
@@ -200,7 +200,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
-    onClose();
+    if (onClose) onClose();
     setAnchorEl(null);
   }
 
@@ -227,7 +227,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
-    onClose();
+    if (onClose) onClose();
     setAnchorEl(null);
   }
 

--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -29,6 +29,7 @@ interface DropdownProps<Multiple> {
   label: string;
   options: DefaultDropdownMenuOption[];
   onChange: (options: Value<DefaultDropdownMenuOption, Multiple>) => void;
+  onClose: () => void;
   multiple?: Multiple;
   search?: boolean;
   MenuSelectProps?: Partial<typeof DropdownMenu>;
@@ -56,6 +57,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
   // unapplied changes.
   closeOnBlur = !buttons,
   onChange,
+  onClose,
   MenuSelectProps = {},
   InputDropdownProps = { sdsStyle: "minimal" },
   value: propValue,
@@ -198,6 +200,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
+    onClose();
     setAnchorEl(null);
   }
 
@@ -224,6 +227,7 @@ export default function Dropdown<Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
+    onClose();
     setAnchorEl(null);
   }
 


### PR DESCRIPTION
### Summary
- **What:** Add onClose to Dropdown
- **Why:** allow consumers to clear search or take other action
- **Discussion:** https://czi-sci.slack.com/archives/C032S43KKFV/p1656621162122669

### Demos
http://localhost:6007/?path=/story/dropdown--search-with-on-close

### Checklist
- [x] I merged latest `trunk`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [x] I added relevant storybook stories
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design