### PR TITLE
fix(button): fix outline button border color

### DIFF
--- a/src/core/Button/style.ts
+++ b/src/core/Button/style.ts
@@ -27,8 +27,11 @@ const ButtonBase = styled(Button, {
     }px`;
 
     const padding = variant === "outlined" ? outlinedPadding : containedPadding;
+    const outlineBorder =
+      variant === "outlined" ? `border-color: ${colors?.primary[400]};` : "";
 
     return `
+      ${outlineBorder}
       padding: ${padding};
       min-width: 120px;
       height: 34px;


### PR DESCRIPTION
### Summary
- **What:** Change outline style button border color from MUI default to primary[400]
- **Why:** To match spec
- **Discussion:** https://czi-sci.slack.com/archives/C032S43KKFV/p1656442239103319
- **Design:** https://sds.czi.design/009eaf17b/v/0/p/47778c-buttons/t/58ae47

### Testing
Check out storybook

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [x] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] Chromatic build verified by @chanzuckerberg/sds-design