### PR TITLE
refactor(radio button): change stories to csf format

### DIFF
--- a/src/core/Radio/__snapshots__/index.test.tsx.snap
+++ b/src/core/Radio/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Radio /> Test story renders snapshot 1`] = `
+<div>
+  <div>
+    <label
+      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+    >
+      <span
+        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked css-b0a55y-MuiButtonBase-root-MuiRadio-root"
+        data-testid="radioButton"
+        stage="checked"
+      >
+        <input
+          checked=""
+          class="PrivateSwitchBase-input css-1m9pwf3"
+          type="radio"
+          value="demo1"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-jest-file-name="IconRadioChecked.svg"
+          data-jest-svg-name="IconRadioChecked"
+          data-testid="IconRadioChecked"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 16 16"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
+  <div>
+    <label
+      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+    >
+      <span
+        class="MuiRadio-root MuiRadio-colorDefault MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root css-1vqgfov-MuiButtonBase-root-MuiRadio-root"
+        data-testid="radioButton"
+        stage="unchecked"
+      >
+        <input
+          class="PrivateSwitchBase-input css-1m9pwf3"
+          type="radio"
+          value="demo2"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-jest-file-name="IconRadioUnchecked.svg"
+          data-jest-svg-name="IconRadioUnchecked"
+          data-testid="IconRadioUnchecked"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 16 16"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
+  <div>
+    <label
+      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+    >
+      <span
+        class="MuiRadio-root MuiRadio-colorDefault MuiButtonBase-root MuiRadio-root MuiRadio-colorDefault PrivateSwitchBase-root css-1vqgfov-MuiButtonBase-root-MuiRadio-root"
+        data-testid="radioButton"
+        stage="unchecked"
+      >
+        <input
+          class="PrivateSwitchBase-input css-1m9pwf3"
+          type="radio"
+          value="demo3"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-jest-file-name="IconRadioUnchecked.svg"
+          data-jest-svg-name="IconRadioUnchecked"
+          data-testid="IconRadioUnchecked"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 16 16"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/src/core/Radio/index.stories.tsx
+++ b/src/core/Radio/index.stories.tsx
@@ -13,7 +13,7 @@ const DefaultDemo = (props: Args): JSX.Element => {
       name="radio-buttons-group"
     >
       <FormControlLabel
-        control={<RadioButton stage="checked" />}
+        control={<RadioButton stage="checked" {...props} />}
         label={text}
         value="demo"
       />
@@ -43,7 +43,7 @@ Default.args = {
 const LivePreviewDemo = (props: Args): JSX.Element => {
   const { text } = props;
 
-  const [checked, setChecked] = React.useState([true, false]);
+  const [checked, setChecked] = React.useState([true, false, false]);
 
   const handleCheck1 = () => {
     setChecked([true, false, false]);
@@ -63,6 +63,7 @@ const LivePreviewDemo = (props: Args): JSX.Element => {
             <RadioButton
               onChange={handleCheck1}
               stage={checked[0] ? "checked" : "unchecked"}
+              data-testid="radioButton"
             />
           }
           label={text}
@@ -75,6 +76,7 @@ const LivePreviewDemo = (props: Args): JSX.Element => {
             <RadioButton
               stage={checked[1] ? "checked" : "unchecked"}
               onChange={handleCheck2}
+              data-testid="radioButton"
             />
           }
           label={text}
@@ -87,6 +89,7 @@ const LivePreviewDemo = (props: Args): JSX.Element => {
             <RadioButton
               stage={checked[2] ? "checked" : "unchecked"}
               onChange={handleCheck3}
+              data-testid="radioButton"
             />
           }
           label={text}

--- a/src/core/Radio/index.stories.tsx
+++ b/src/core/Radio/index.stories.tsx
@@ -1,77 +1,117 @@
-import { FormControlLabel } from "@mui/material";
-import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/react";
+import { FormControlLabel, RadioGroup } from "@mui/material";
+import { Args, Story } from "@storybook/react";
 import React from "react";
 import RadioButton from "./index";
 
-const actions = {
-  onChange: action("onChange"),
+const DefaultDemo = (props: Args): JSX.Element => {
+  const { text } = props;
+
+  return (
+    <RadioGroup
+      aria-labelledby="demo-radio-buttons-group-label"
+      defaultValue="demo"
+      name="radio-buttons-group"
+    >
+      <FormControlLabel
+        control={<RadioButton stage="checked" />}
+        label={text}
+        value="demo"
+      />
+    </RadioGroup>
+  );
 };
 
-const storyColumn = {
-  alignItems: "flex-start",
-  display: "flex",
-  flexDirection: "column",
+export default {
+  component: DefaultDemo,
+  title: "Radio Button",
 };
 
-storiesOf("Radio Button", module).add("unchecked", () => (
-  <div style={storyColumn as React.CSSProperties}>
-    <p>
-      <strong>Accessibility</strong>: All radio buttons should have a label.
-      This can be done with a visible form label or with the aria-label
-      attribute. Note aria labels should be meaningful based on your content.{" "}
-      <br /> Good: &ldquo;XYZ Gene&ldquo;
-      <br /> Bad: &ldquo;Unchecked&ldquo; <br />{" "}
-      https://mui.com/material-ui/react-radio-button/#accessibility
-    </p>
-    <FormControlLabel
-      control={<RadioButton onChange={actions.onChange} stage="unchecked" />}
-      label="Unchecked"
-    />
-    <FormControlLabel
-      control={
-        <RadioButton disabled onChange={actions.onChange} stage="unchecked" />
-      }
-      label="Unchecked & disabled"
-    />
-    With aria labels:
-    <RadioButton
-      inputProps={{ "aria-label": "radio button unchecked" }}
-      onChange={actions.onChange}
-      stage="unchecked"
-    />
-    <RadioButton
-      disabled
-      inputProps={{ "aria-label": "radio button unchecked and disabled" }}
-      onChange={actions.onChange}
-      stage="unchecked"
-    />
-  </div>
-));
+const DefaultTemplate: Story = (args) => <DefaultDemo {...args} />;
 
-storiesOf("Radio Button", module).add("checked", () => (
-  <div style={storyColumn as React.CSSProperties}>
-    <FormControlLabel
-      control={<RadioButton onChange={actions.onChange} stage="checked" />}
-      label="Checked"
-    />
-    <FormControlLabel
-      control={
-        <RadioButton disabled onChange={actions.onChange} stage="checked" />
-      }
-      label="Checked & disabled"
-    />
-    With aria labels:
-    <RadioButton
-      inputProps={{ "aria-label": "checked" }}
-      onChange={actions.onChange}
-      stage="checked"
-    />
-    <RadioButton
-      disabled
-      inputProps={{ "aria-label": "checked and disabled" }}
-      onChange={actions.onChange}
-      stage="checked"
-    />
-  </div>
-));
+export const Default = DefaultTemplate.bind({});
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+Default.args = {
+  disabled: false,
+  text: "Label",
+};
+
+const LivePreviewDemo = (props: Args): JSX.Element => {
+  const { text } = props;
+
+  const [checked, setChecked] = React.useState([true, false]);
+
+  const handleCheck1 = () => {
+    setChecked([true, false, false]);
+  };
+  const handleCheck2 = () => {
+    setChecked([false, true, false]);
+  };
+  const handleCheck3 = () => {
+    setChecked([false, false, true]);
+  };
+
+  return (
+    <div>
+      <div>
+        <FormControlLabel
+          control={
+            <RadioButton
+              onChange={handleCheck1}
+              stage={checked[0] ? "checked" : "unchecked"}
+            />
+          }
+          label={text}
+          value="demo1"
+        />
+      </div>
+      <div>
+        <FormControlLabel
+          control={
+            <RadioButton
+              stage={checked[1] ? "checked" : "unchecked"}
+              onChange={handleCheck2}
+            />
+          }
+          label={text}
+          value="demo2"
+        />
+      </div>
+      <div>
+        <FormControlLabel
+          control={
+            <RadioButton
+              stage={checked[2] ? "checked" : "unchecked"}
+              onChange={handleCheck3}
+            />
+          }
+          label={text}
+          value="demo3"
+        />
+      </div>
+    </div>
+  );
+};
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+export const LivePreview = LivePreviewTemplate.bind({});
+
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+LivePreview.args = {
+  text: "Label",
+};
+
+export const Test = LivePreviewTemplate.bind({});
+
+Test.args = {
+  text: "Test Label",
+};

--- a/src/core/Radio/index.test.tsx
+++ b/src/core/Radio/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<Radio />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders 3 radio buttons", async () => {
+    render(<Test {...Test.args} />);
+    const radio = screen.getAllByTestId("radioButton");
+    expect(radio).toHaveLength(3);
+  });
+});

--- a/src/core/Radio/index.tsx
+++ b/src/core/Radio/index.tsx
@@ -37,6 +37,7 @@ const RadioButton = (props: RadioProps): JSX.Element => {
 
   return (
     <StyledRadioButton
+      data-testid="radioButton"
       {...newProps}
       checkedIcon={
         <SvgIcon

--- a/src/core/Radio/index.tsx
+++ b/src/core/Radio/index.tsx
@@ -37,7 +37,6 @@ const RadioButton = (props: RadioProps): JSX.Element => {
 
   return (
     <StyledRadioButton
-      data-testid="radioButton"
       {...newProps}
       checkedIcon={
         <SvgIcon


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](https://app.shortcut.com/sci-design-system/story/167634/update-stories-for-inputradio-to-csf-format)

The caption functionality is not yet implemented, I have made a ticket to implement it here: https://app.shortcut.com/sci-design-system/story/205655/add-caption-to-radio-button-component
As well, the label is not currently part of the library component, I have created a ticket to add the label to the component (consistent with checkbox) here: https://app.shortcut.com/sci-design-system/story/205654/add-optional-label-to-radio-button-component

In order to support testing and ZeroHeight, we are moving away from the StoriesOf() syntax and are adopting the [CSF Format](https://storybook.js.org/docs/react/api/csf).

In addition, there should be 3 stories per component: Default (all props are interactable via storybook controls, will occasionally include some external components to trigger effects and states), LivePreview (a number of components as defined by our ZeroHeight implementation), and Test (a single component).

New components will be created with this format, but already published components will need to be updated.

Default and LivePreview should have the following parameters set so a snapshot is only taken of the single component:

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
