### PR TITLE
refactor(loading indicator): refactor stories to CSF

### DIFF
--- a/src/core/LoadingIndicator/__snapshots__/index.test.tsx.snap
+++ b/src/core/LoadingIndicator/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LoadingIndicator /> Test story renders snapshot 1`] = `
+<div
+  style="display: grid; grid-template-columns: repeat(2, 70px); grid-template-rows: 1fr;"
+>
+  <div
+    style="margin-bottom: 14px; margin-right: 14px; margin-top: 14px;"
+  >
+    <div
+      class="css-1o5w4es"
+    >
+      <div
+        class="css-jbvua0"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-25m3b5-MuiSvgIcon-root"
+          data-jest-file-name="IconLoadingLarge.svg"
+          data-jest-svg-name="IconLoadingLarge"
+          data-testid="IconLoadingLarge"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 32 32"
+        />
+      </div>
+      <span
+        class="css-1xm9l9z"
+      >
+        Loading
+      </span>
+    </div>
+  </div>
+  <div
+    style="margin-bottom: 14px; margin-right: 14px; margin-top: 14px;"
+  >
+    <div
+      class="css-k87s1p"
+    >
+      <div
+        class="css-jbvua0"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-25m3b5-MuiSvgIcon-root"
+          data-jest-file-name="IconLoadingLarge.svg"
+          data-jest-svg-name="IconLoadingLarge"
+          data-testid="IconLoadingLarge"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 32 32"
+        />
+      </div>
+      <span
+        class="css-1xm9l9z"
+      >
+        Loading
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/src/core/LoadingIndicator/index.stories.tsx
+++ b/src/core/LoadingIndicator/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Args, Story } from "@storybook/react";
 import React from "react";
+import { defaultAppTheme } from "../styles";
 import LoadingIndicator from "./index";
 
 const Demo = (props: Args): JSX.Element => {
@@ -8,20 +9,75 @@ const Demo = (props: Args): JSX.Element => {
 };
 
 export default {
+  argTypes: {
+    sdsStyle: {
+      control: { type: "select" },
+      options: ["minimal", "tag"],
+    },
+  },
   component: Demo,
   title: "LoadingIndicator",
 };
 
 const Template: Story = (args) => <Demo {...args} />;
 
-export const Minimal = Template.bind({});
+export const Default = Template.bind({});
 
-Minimal.args = {
+Default.args = {
   sdsStyle: "minimal",
 };
 
-export const Tag = Template.bind({});
-
-Tag.args = {
-  sdsStyle: "tag",
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
 };
+
+const LivePreviewDemo = (props: Args): JSX.Element => {
+  const spacings = defaultAppTheme?.spacing;
+
+  const livePreviewStyles = {
+    display: "grid",
+    gridColumnGap: "24px",
+    gridRowGap: "0px",
+    gridTemplateColumns: "repeat(2, 70px)",
+    gridTemplateRows: "1fr",
+  };
+
+  return (
+    <div style={livePreviewStyles as React.CSSProperties}>
+      <div
+        style={{
+          marginBottom: spacings?.l,
+          marginRight: spacings?.l,
+          marginTop: spacings?.l,
+        }}
+      >
+        <LoadingIndicator sdsStyle="minimal" {...props} />
+      </div>
+      <div
+        style={{
+          marginBottom: spacings?.l,
+          marginRight: spacings?.l,
+          marginTop: spacings?.l,
+        }}
+      >
+        <LoadingIndicator sdsStyle="tag" {...props} />
+      </div>
+    </div>
+  );
+};
+
+const LivePreviewTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const LivePreview = LivePreviewTemplate.bind({});
+
+LivePreview.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+const TestTemplate: Story = (args) => <LivePreviewDemo {...args} />;
+
+export const Test = TestTemplate.bind({});

--- a/src/core/LoadingIndicator/index.test.tsx
+++ b/src/core/LoadingIndicator/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<LoadingIndicator />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders loading indicator component", () => {
+    render(<Test />);
+    const elements = screen.getAllByTestId("IconLoadingLarge");
+    expect(elements).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

**Loading Indicator**
Shortcut ticket: [sh-167629](https://app.shortcut.com/sci-design-system/story/167629/update-stories-for-loadingindicator-to-csf-format)
In order to support testing and ZeroHeight, we are moving away from the StoriesOf() syntax and are adopting the [CSF Format](https://storybook.js.org/docs/react/api/csf).

In addition, there should be 3 stories per component: Default (all props are interactable via storybook controls, will occasionally include some external components to trigger effects and states), LivePreview (a number of components as defined by our ZeroHeight implementation), and Test (a single component).

New components will be created with this format, but already published components will need to be updated.

Default and LivePreview should have the following parameters set so a snapshot is only taken of the single component:

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
