### PR TITLE
refactor(menuitem): change to default and test format

### DIFF
--- a/src/core/MenuItem/__snapshots__/index.test.tsx.snap
+++ b/src/core/MenuItem/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MenuItem /> Test story renders snapshot 1`] = `
+<div
+  class="css-1m75yyh"
+>
+  <li
+    class="MuiMenuItem-root MuiMenuItem-gutters MuiButtonBase-root css-1ggg2ns-MuiButtonBase-root-MuiMenuItem-root"
+    data-testid="MenuItem"
+    role="menuitem"
+    tabindex="-1"
+  >
+    <span
+      class="css-pe6vce"
+    >
+      <span
+        class="primary-text css-13a4omo"
+      >
+        test text
+      </span>
+      <span
+        class="css-1hhtny0"
+      >
+        test column
+      </span>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+</div>
+`;

--- a/src/core/MenuItem/index.stories.tsx
+++ b/src/core/MenuItem/index.stories.tsx
@@ -1,147 +1,30 @@
 /* eslint-disable no-use-before-define */
-import { InputLabel, Select, SelectProps } from "@mui/material";
-import FormControl from "@mui/material/FormControl";
-import { styled } from "@mui/material/styles";
 import { Args, Story } from "@storybook/react";
 import * as React from "react";
-import { getSpaces } from "../styles";
 import MenuItem from "./index";
 import { DemoWrapper } from "./style";
 
-const ITEM_HEIGHT = 48;
-const ITEM_PADDING_TOP = 8;
-
-const MenuProps = {
-  PaperProps: {
-    style: {
-      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
-      width: 250,
-    },
-  },
-};
-
-const PERSONS = [
-  { name: "Harley Thomas", number: 1 },
-  { name: "Janeece Pourroy", number: 2 },
-  { name: "Jennifer Tang", number: 3 },
-  { name: "Jonathan Sheu", number: 4 },
-  { name: "Julie Han", number: 5 },
-  { name: "Katrina Kalantar", number: 6 },
-  { name: "Omar Valenzuela", number: 7 },
-  { name: "Seve Badajoz", number: 8 },
-  { name: "Tiago Carvalho", number: 9 },
-  { name: "Timmy Huang", number: 10 },
-];
-
-function renderMenuItems(personName: string[]) {
-  return PERSONS.map((person) => {
-    const { name, number } = person;
-
-    return (
-      <MenuItem
-        key={name}
-        value={name}
-        column={number}
-        selected={personName.includes(name)}
-        isMultiSelect
-      >
-        {name}
-      </MenuItem>
-    );
-  });
-}
-
-const StyledFormControl = styled(FormControl)`
-  ${(props) => {
-    const spacings = getSpaces(props);
-    return `
-      margin: ${spacings?.xxl}px;
-      max-width: 300px;
-      min-width: 120px;
-    `;
-  }}
-`;
-
-export const MultipleSelect = MultipleSelectDemo.bind({});
-
-function MultipleSelectDemo() {
-  const [personName, setPersonName] = React.useState<string[]>([]);
-
-  const handleChange: SelectProps["onChange"] = (event) => {
-    setPersonName(event.target.value as string[]);
-  };
-
-  return (
-    <div>
-      <StyledFormControl variant="standard">
-        <InputLabel id="demo-simple-select-outlined-label">Name</InputLabel>
-        <Select
-          MenuProps={MenuProps}
-          multiple
-          labelId="demo-simple-select-outlined-label"
-          id="demo-simple-select-outlined"
-          value={personName}
-          onChange={handleChange}
-          label="Name"
-          renderValue={(selected) => {
-            return (selected as string[]).join(", ");
-          }}
-          variant="standard"
-        >
-          {renderMenuItems(personName)}
-        </Select>
-      </StyledFormControl>
-
-      <br />
-
-      <StyledFormControl variant="outlined">
-        <InputLabel id="demo-simple-select-outlined-label">Name</InputLabel>
-        <Select
-          labelId="demo-simple-select-outlined-label"
-          id="demo-simple-select-outlined"
-          multiple
-          value={personName}
-          onChange={handleChange}
-          MenuProps={MenuProps}
-          label="Name"
-          renderValue={(selected) => {
-            return (selected as string[]).join(", ");
-          }}
-        >
-          {renderMenuItems(personName)}
-        </Select>
-      </StyledFormControl>
-
-      <br />
-
-      <StyledFormControl variant="filled">
-        <InputLabel id="demo-simple-select-filled-label">Name</InputLabel>
-        <Select
-          MenuProps={MenuProps}
-          multiple
-          labelId="demo-simple-select-filled-label"
-          id="demo-simple-select-filled"
-          value={personName}
-          onChange={handleChange}
-          renderValue={(selected) => {
-            return (selected as string[]).join(", ");
-          }}
-          variant="filled"
-        >
-          {renderMenuItems(personName)}
-        </Select>
-      </StyledFormControl>
-    </div>
-  );
-}
-
 const Demo = (props: Args): JSX.Element => (
   <DemoWrapper>
-    <MenuItem {...props} />
+    <MenuItem data-testid="MenuItem" {...props} />
   </DemoWrapper>
 );
 
 export default {
+  argTypes: {
+    column: {
+      control: { type: "text" },
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+    isMultiSelect: {
+      control: { type: "boolean" },
+    },
+    selected: {
+      control: { type: "boolean" },
+    },
+  },
   component: Demo,
   title: "MenuItem",
 };
@@ -152,47 +35,18 @@ export const Default = Template.bind({});
 
 Default.args = {
   children: "text here",
-  value: "value-here",
+  column: "column value here",
 };
 
-export const WithColumn = Template.bind({});
-
-WithColumn.args = {
-  ...Default.args,
-  column: "column value",
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
 };
 
-export const WithMultiSelect = Template.bind({});
+export const Test = Template.bind({});
 
-WithMultiSelect.args = {
-  ...Default.args,
-  isMultiSelect: true,
+Test.args = {
+  children: "test text",
+  column: "test column",
 };
-
-export const WithMultiSelectSelected = Template.bind({});
-
-WithMultiSelectSelected.args = {
-  ...Default.args,
-  isMultiSelect: true,
-  selected: true,
-};
-
-export const Disabled = DisabledMenuItem.bind({});
-
-function DisabledMenuItem() {
-  return (
-    <>
-      <div>Single Select</div>
-      <Demo {...Default.args} disabled isMultiSelect={false} />
-      <Demo {...Default.args} disabled isMultiSelect={false} selected />
-      <br />
-      <div>Multi Select</div>
-      <Demo {...Default.args} disabled isMultiSelect />
-      <Demo {...Default.args} disabled isMultiSelect selected />
-      <br />
-      <div>With Column</div>
-      <Demo {...Default.args} disabled column="column value" />
-      <Demo {...Default.args} disabled column="column value" selected />
-    </>
-  );
-}

--- a/src/core/MenuItem/index.test.tsx
+++ b/src/core/MenuItem/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<MenuItem />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders menu item component", () => {
+    render(<Test />);
+    const elements = screen.getAllByTestId("MenuItem");
+    expect(elements).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-167631](https://app.shortcut.com/sci-design-system/story/167631/update-stories-for-menuitem-to-csf-format)

This element does not have a live preview because its use is demonstrated in other dropdown live previews. 

In order to support testing and ZeroHeight, we are moving away from the StoriesOf() syntax and are adopting the [CSF Format](https://storybook.js.org/docs/react/api/csf).

In addition, there should be 3 stories per component: Default (all props are interactable via storybook controls, will occasionally include some external components to trigger effects and states), LivePreview (a number of components as defined by our ZeroHeight implementation), and Test (a single component).

New components will be created with this format, but already published components will need to be updated.



## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
