### PR TITLE
fix(icon): pass styled-components classnames to icon

### DIFF
--- a/src/core/Icon/index.tsx
+++ b/src/core/Icon/index.tsx
@@ -11,7 +11,7 @@ export type IconProps<IconName extends keyof IconNameToSizes> =
  * @see https://v4.mui.com/components/dialogs/
  */
 const Icon = forwardRef(function Icon<IconName extends keyof IconNameToSizes>(
-  { sdsIcon, sdsSize, sdsType }: IconProps<IconName>,
+  { className, sdsIcon, sdsSize, sdsType }: IconProps<IconName>,
   ref: ForwardedRef<HTMLDivElement | null>
 ): JSX.Element | null {
   const icon = iconMap[sdsIcon] ?? {};
@@ -21,6 +21,7 @@ const Icon = forwardRef(function Icon<IconName extends keyof IconNameToSizes>(
     return (
       <StyledIcon ref={ref}>
         <StyledSvgIcon
+          className={className}
           fillcontrast="white"
           viewBox="0 0 14 14"
           component={smallIcon}
@@ -35,6 +36,7 @@ const Icon = forwardRef(function Icon<IconName extends keyof IconNameToSizes>(
     return (
       <StyledIcon ref={ref}>
         <StyledSvgIcon
+          className={className}
           fillcontrast="white"
           viewBox="0 0 32 32"
           component={largeIcon}

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -7,6 +7,7 @@ import { IconNameToSizes } from "./map";
 
 export interface IconExtraProps<IconName extends keyof IconNameToSizes>
   extends CommonThemeProps {
+  className?: string;
   sdsIcon: IconName;
   sdsSize: IconNameToSizes[IconName];
   sdsType: "iconButton" | "interactive" | "static" | "button";


### PR DESCRIPTION
### Summary
- **What:** Pass custom classes through to icon svg component
- **Why:** so consuming applications can style icons directly with styled-components instead of using a wrapper

### Checklist
- [x] I merged latest `main`
- [x] I manually verified the change
- [x] I added labels to my PR
- [ ] I either asked design for a review or hid my changes behind a feature flag
- [ ] I tested in multiple browsers
- [ ] I added relevant unit tests
- [ ] I have notified others of changes they need to make locally (migrations, jobs, package updates, etc)