### PR TITLE
refactor(buttonicon): update storybook arg types

### DIFF
--- a/src/core/ButtonIcon/index.stories.tsx
+++ b/src/core/ButtonIcon/index.stories.tsx
@@ -23,6 +23,34 @@ const Demo = (props: Args): JSX.Element => {
 };
 
 export default {
+  argTypes: {
+    active: {
+      control: {
+        type: "boolean",
+      },
+      defaultValue: false,
+    },
+    disabled: {
+      control: {
+        type: "boolean",
+      },
+      defaultValue: false,
+    },
+    sdsSize: {
+      control: {
+        type: "select",
+      },
+      defaultValue: "medium",
+      options: ["small", "medium", "large"],
+    },
+    sdsType: {
+      control: {
+        type: "select",
+      },
+      defaultValue: "primary",
+      options: ["primary", "secondary", "tertiary"],
+    },
+  },
   component: Demo,
   title: "ButtonIcon",
 };

--- a/src/core/ButtonIcon/index.test.tsx
+++ b/src/core/ButtonIcon/index.test.tsx
@@ -1,5 +1,4 @@
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
-import { StoryFileExports } from "@chanzuckerberg/story-utils/build/getStories";
 import { composeStory } from "@storybook/testing-react";
 import { render, screen } from "@testing-library/react";
 import React from "react";
@@ -10,9 +9,7 @@ import Meta, { Test as TestStory } from "./index.stories";
 const Test = composeStory(TestStory, Meta);
 
 describe("<ButtonIcon />", () => {
-  generateSnapshots<StoryFileExports<typeof Meta>, typeof Meta>(
-    snapshotTestStoryFile
-  );
+  generateSnapshots(snapshotTestStoryFile);
 
   it("renders ButtonIcon component", () => {
     render(<Test />);


### PR DESCRIPTION
## Summary

**ButtonIcon**
Shortcut ticket: [sh-167116](https://app.shortcut.com/sci-design-system/story/167116/add-medium-size-primary-and-secondary-iconbuttons-to-sds)
Add medium size Primary and Secondary IconButtons to SDS

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
