### PR TITLE
fix(link): type

### DIFF
--- a/src/common/styles-dictionary/css/variables.css
+++ b/src/common/styles-dictionary/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 12 Aug 2022 18:51:53 GMT
+ * Generated on Fri, 12 Aug 2022 21:49:52 GMT
  */
 
 :root {

--- a/src/common/styles-dictionary/scss/_variables.scss
+++ b/src/common/styles-dictionary/scss/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 12 Aug 2022 18:51:53 GMT
+// Generated on Fri, 12 Aug 2022 21:49:52 GMT
 
 $sds-font-letter-spacing-default: 0.3px;
 $sds-font-letter-spacing-caps: 1px;

--- a/src/core/Link/index.stories.tsx
+++ b/src/core/Link/index.stories.tsx
@@ -53,6 +53,13 @@ const LivePreviewDemo = (props: LinkProps): JSX.Element => {
         </Link>{" "}
         consectetur, adipisicing elit.
       </p>
+      <p style={{ backgroundColor: "#EFF2FC", padding: "10px" }}>
+        Lorem ipsum{" "}
+        <Link href="/" sdsStyle="dashed" component="button" {...props}>
+          button element
+        </Link>{" "}
+        consectetur, adipisicing elit.
+      </p>
     </div>
   );
 };

--- a/src/core/Link/index.tsx
+++ b/src/core/Link/index.tsx
@@ -1,4 +1,3 @@
-import { Link as RawLink } from "@mui/material";
 import React, { ForwardedRef, forwardRef } from "react";
 import { LinkProps, StyledLink } from "./style";
 
@@ -6,7 +5,10 @@ import { LinkProps, StyledLink } from "./style";
  * @see https://v4.mui.com/components/links/
  */
 const Link = forwardRef(
-  (props: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
+  <C extends React.ElementType>(
+    props: LinkProps<C>,
+    ref: ForwardedRef<HTMLAnchorElement>
+  ) => {
     const { sdsStyle } = props;
     let underline: LinkProps["underline"];
 
@@ -16,7 +18,7 @@ const Link = forwardRef(
 
     return <StyledLink {...props} underline={underline} ref={ref} />;
   }
-) as typeof RawLink;
+);
 
 export type { LinkProps };
 


### PR DESCRIPTION
I removed manual casting SDS Link as `RawLink`, since that's the root cause of the bug @ehoops-cz 's seeing in [slack](https://czi-sci.slack.com/archives/C032S43KKFV/p1660325285598779)

The intention was to fix a Link linter error in [this commit](https://github.com/chanzuckerberg/sci-components/commit/bfbb2f23cfc22b3b72e047df528cbe112848bdce), which I think casting the `styled(Link) as typeof Link` should have been enough? @masoudmanson please help confirm on Monday 🙏 Thanks so much!

<img width="512" alt="Screen Shot 2022-08-12 at 2 14 27 PM" src="https://user-images.githubusercontent.com/6309723/184445885-cf99a471-2a0f-4b41-af5d-15de8177eb20.png">

