### PR TITLE
refactor(tooltip): remove subtitle text from light tooltip

### DIFF
--- a/src/core/BasicCell/__snapshots__/index.test.tsx.snap
+++ b/src/core/BasicCell/__snapshots__/index.test.tsx.snap
@@ -4,22 +4,71 @@ exports[`<BasicCell /> Test story renders snapshot 1`] = `
 <table>
   <tbody>
     <tr>
-      <td
-        class=" css-lw14ji"
-        data-mui-internal-clone-element="true"
-        data-testid="BasicCell"
-      >
-        <span
-          class="css-1w283yb"
-        >
-          Primary text
-        </span>
-        <span
-          class="css-1rl2dmz"
-        >
-          Secondary Text
-        </span>
-      </td>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <label
+                class="css-19c61dz"
+                for="maxWidth"
+              >
+                Set a max-width to see text wrap inside the cell
+              </label>
+              <div
+                class="MuiFormControl-root MuiTextField-root css-9u937e-MuiFormControl-root-MuiTextField-root"
+              >
+                <div
+                  class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                >
+                  <input
+                    aria-invalid="false"
+                    aria-label="Set a max-width to see text wrap inside the cell"
+                    class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="maxWidth"
+                    placeholder="max-width"
+                    type="text"
+                    value="100"
+                  />
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-hdw1oc"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </td>
+          </tr>
+          <tr
+            style="display: block; max-width: 100px;"
+          >
+            <td
+              class=" css-vj1dg5"
+              data-mui-internal-clone-element="true"
+              data-testid="BasicCell"
+            >
+              <span
+                class="css-z41sca"
+              >
+                Primary Text
+              </span>
+              <span
+                class="css-1rl2dmz"
+              >
+                Secondary Text
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </tr>
   </tbody>
 </table>

--- a/src/core/BasicCell/__snapshots__/index.test.tsx.snap
+++ b/src/core/BasicCell/__snapshots__/index.test.tsx.snap
@@ -4,71 +4,22 @@ exports[`<BasicCell /> Test story renders snapshot 1`] = `
 <table>
   <tbody>
     <tr>
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <label
-                class="css-19c61dz"
-                for="maxWidth"
-              >
-                Set a max-width to see text wrap inside the cell
-              </label>
-              <div
-                class="MuiFormControl-root MuiTextField-root css-9u937e-MuiFormControl-root-MuiTextField-root"
-              >
-                <div
-                  class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
-                >
-                  <input
-                    aria-invalid="false"
-                    aria-label="Set a max-width to see text wrap inside the cell"
-                    class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-                    id="maxWidth"
-                    placeholder="max-width"
-                    type="text"
-                    value="100"
-                  />
-                  <fieldset
-                    aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                  >
-                    <legend
-                      class="css-hdw1oc"
-                    >
-                      <span
-                        class="notranslate"
-                      >
-                        ​
-                      </span>
-                    </legend>
-                  </fieldset>
-                </div>
-              </div>
-            </td>
-          </tr>
-          <tr
-            style="display: block; max-width: 100px;"
-          >
-            <td
-              class=" css-vj1dg5"
-              data-mui-internal-clone-element="true"
-              data-testid="BasicCell"
-            >
-              <span
-                class="css-z41sca"
-              >
-                Primary Text
-              </span>
-              <span
-                class="css-1rl2dmz"
-              >
-                Secondary Text
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <td
+        class=" css-vj1dg5"
+        data-mui-internal-clone-element="true"
+        data-testid="BasicCell"
+      >
+        <span
+          class="css-z41sca"
+        >
+          Primary Text
+        </span>
+        <span
+          class="css-1rl2dmz"
+        >
+          Secondary Text
+        </span>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/src/core/BasicCell/__snapshots__/index.test.tsx.snap
+++ b/src/core/BasicCell/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<BasicCell /> Test story renders snapshot 1`] = `
+<table>
+  <tbody>
+    <tr>
+      <td
+        class=" css-lw14ji"
+        data-mui-internal-clone-element="true"
+        data-testid="BasicCell"
+      >
+        <span
+          class="css-1w283yb"
+        >
+          Primary text
+        </span>
+        <span
+          class="css-1rl2dmz"
+        >
+          Secondary Text
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/src/core/BasicCell/index.stories.tsx
+++ b/src/core/BasicCell/index.stories.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable no-use-before-define */
+import { Args, Story } from "@storybook/react";
+import * as React from "react";
+import BasicCell from "./index";
+
+const Demo = (props: Args): JSX.Element => (
+  <table>
+    <tbody>
+      <tr>
+        <BasicCell
+          data-testid="BasicCell"
+          primaryText="Primary Text"
+          tooltipProps={{ sdsStyle: "light" }}
+          {...props}
+        />
+      </tr>
+    </tbody>
+  </table>
+);
+
+export default {
+  argTypes: {
+    primaryText: {
+      control: { type: "text" },
+    },
+    secondaryText: {
+      control: { type: "text" },
+    },
+    shouldShowTooltipOnHover: {
+      control: { type: "boolean" },
+    },
+    shouldTextWrap: {
+      control: { type: "boolean" },
+    },
+    textPosition: {
+      control: { type: "select" },
+      options: ["left", "center", "right"],
+    },
+    tooltipProps: {
+      control: { type: "object" },
+      defaultValue: {
+        sdsStyle: "dark",
+      },
+    },
+  },
+  component: Demo,
+  title: "BasicCell",
+};
+
+const Template: Story = (args) => <Demo {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = {
+  primaryText: "Primary text",
+  secondaryText: "Secondary Text",
+  shouldShowTooltipOnHover: true,
+  shouldTextWrap: true,
+  textPosition: "right",
+};
+
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+export const Test = Template.bind({});
+
+Test.args = {
+  primaryText: "Primary text",
+  secondaryText: "Secondary Text",
+};

--- a/src/core/BasicCell/index.stories.tsx
+++ b/src/core/BasicCell/index.stories.tsx
@@ -1,30 +1,62 @@
 /* eslint-disable no-use-before-define */
 import { Args, Story } from "@storybook/react";
 import * as React from "react";
-import BasicCell from "./index";
+import InputText from "../InputText";
+import BasicCellRaw from "./index";
 
-const Demo = (props: Args): JSX.Element => (
-  <table>
-    <tbody>
-      <tr>
-        <BasicCell
-          data-testid="BasicCell"
-          primaryText="Primary Text"
-          tooltipProps={{ sdsStyle: "light" }}
-          {...props}
-        />
-      </tr>
-    </tbody>
-  </table>
-);
+const BasicCell = (props: Args): JSX.Element => {
+  const [maxWidth, setMaxWidth] = React.useState(100);
+
+  const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxWidth(+event.target.value);
+  };
+
+  return (
+    <table>
+      <tbody>
+        <tr>
+          {/* <span>Set a max-width to see text wrap inside the cell</span> */}
+          <td>
+            <InputText
+              id="maxWidth"
+              label="Set a max-width to see text wrap inside the cell"
+              placeholder="max-width"
+              value={maxWidth}
+              onChange={changeHandler}
+            />
+          </td>
+        </tr>
+        <tr
+          style={{
+            display: "block",
+            maxWidth: `${maxWidth}px`,
+          }}
+        >
+          <BasicCellRaw
+            data-testid="BasicCell"
+            primaryText="Primary Text"
+            tooltipProps={{ sdsStyle: "light" }}
+            {...props}
+          />
+        </tr>
+      </tbody>
+    </table>
+  );
+};
 
 export default {
   argTypes: {
     primaryText: {
       control: { type: "text" },
     },
+    primaryTextWrapLineCount: {
+      control: { type: "number" },
+    },
     secondaryText: {
       control: { type: "text" },
+    },
+    secondaryTextWrapLineCount: {
+      control: { type: "number" },
     },
     shouldShowTooltipOnHover: {
       control: { type: "boolean" },
@@ -38,25 +70,24 @@ export default {
     },
     tooltipProps: {
       control: { type: "object" },
-      defaultValue: {
-        sdsStyle: "dark",
-      },
     },
   },
-  component: Demo,
+  component: BasicCell,
   title: "BasicCell",
 };
 
-const Template: Story = (args) => <Demo {...args} />;
+const Template: Story = (args) => <BasicCell {...args} />;
 
 export const Default = Template.bind({});
 
 Default.args = {
-  primaryText: "Primary text",
+  primaryText: "Primary Text",
+  primaryTextWrapLineCount: 3,
   secondaryText: "Secondary Text",
+  secondaryTextWrapLineCount: 1,
   shouldShowTooltipOnHover: true,
   shouldTextWrap: true,
-  textPosition: "right",
+  tooltipProps: { sdsStyle: "dark" },
 };
 
 Default.parameters = {
@@ -65,7 +96,25 @@ Default.parameters = {
   },
 };
 
-export const Test = Template.bind({});
+const TestDemo = (): JSX.Element => (
+  <table>
+    <tbody>
+      <tr>
+        <BasicCell
+          data-testid="BasicCell"
+          primaryText="Primary Text"
+          secondaryText="Secondary Text"
+          textPosition="right"
+          tooltipProps={{ sdsStyle: "light", title: "testTooltipTitle" }}
+        />
+      </tr>
+    </tbody>
+  </table>
+);
+
+const TestTemplate: Story = (args) => <TestDemo {...args} />;
+
+export const Test = TestTemplate.bind({});
 
 Test.args = {
   primaryText: "Primary text",

--- a/src/core/BasicCell/index.stories.tsx
+++ b/src/core/BasicCell/index.stories.tsx
@@ -100,7 +100,7 @@ const TestDemo = (): JSX.Element => (
   <table>
     <tbody>
       <tr>
-        <BasicCell
+        <BasicCellRaw
           data-testid="BasicCell"
           primaryText="Primary Text"
           secondaryText="Secondary Text"

--- a/src/core/BasicCell/index.test.tsx
+++ b/src/core/BasicCell/index.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 import { composeStory } from "@storybook/testing-react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import * as snapshotTestStoryFile from "./index.stories";
 import Meta, { Test as TestStory } from "./index.stories";
@@ -15,5 +15,22 @@ describe("<BasicCell />", () => {
     render(<Test />);
     const elements = screen.getAllByTestId("BasicCell");
     expect(elements).toBeTruthy();
+  });
+
+  it("renders tooltip on hover", async () => {
+    render(<Test />);
+    const basicCellElement = screen.getByTestId("BasicCell");
+    fireEvent.mouseOver(basicCellElement);
+    await screen.findByText("testTooltipTitle");
+  });
+
+  it("renders text at right side", async () => {
+    render(<Test />);
+    const basicCellElement = screen.getByTestId("BasicCell");
+    const renderedElement = document.getElementsByClassName(
+      basicCellElement.className
+    )[0];
+    const style = window.getComputedStyle(renderedElement);
+    expect(style.textAlign).toBe("right");
   });
 });

--- a/src/core/BasicCell/index.test.tsx
+++ b/src/core/BasicCell/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<BasicCell />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders basic cell component", () => {
+    render(<Test />);
+    const elements = screen.getAllByTestId("BasicCell");
+    expect(elements).toBeTruthy();
+  });
+});

--- a/src/core/BasicCell/index.tsx
+++ b/src/core/BasicCell/index.tsx
@@ -1,0 +1,73 @@
+import React, { forwardRef } from "react";
+import Tooltip, { TooltipProps } from "../Tooltip";
+
+import {
+  BasicCellExtraProps,
+  PrimaryText,
+  SecondaryText,
+  StyledTableData,
+} from "./style";
+
+interface BasicCellContentProps {
+  primaryText: string;
+  secondaryText?: string;
+  shouldTextWrap?: boolean;
+}
+
+export interface BasicCellRawProps {
+  shouldShowTooltipOnHover?: boolean;
+  tooltipProps?: Partial<TooltipProps>;
+}
+
+export type BasicCellProps = BasicCellRawProps &
+  BasicCellExtraProps &
+  BasicCellContentProps;
+
+const BasicCellContent = forwardRef(
+  (props: BasicCellContentProps, _): JSX.Element | null => {
+    const { primaryText, secondaryText, shouldTextWrap = false } = props;
+
+    return (
+      <>
+        <PrimaryText shouldTextWrap={shouldTextWrap}>{primaryText}</PrimaryText>
+
+        {secondaryText && (
+          <SecondaryText shouldTextWrap={shouldTextWrap}>
+            {secondaryText}
+          </SecondaryText>
+        )}
+      </>
+    );
+  }
+);
+
+const BasicCell = forwardRef((props: BasicCellProps, _): JSX.Element | null => {
+  const {
+    primaryText,
+    secondaryText,
+    shouldShowTooltipOnHover = true,
+    tooltipProps,
+  } = props;
+
+  if (shouldShowTooltipOnHover) {
+    return (
+      <Tooltip
+        title={primaryText}
+        subtitle={secondaryText}
+        arrow
+        {...tooltipProps}
+      >
+        <StyledTableData {...props}>
+          <BasicCellContent {...props} />
+        </StyledTableData>
+      </Tooltip>
+    );
+  }
+  return (
+    <StyledTableData {...props}>
+      <BasicCellContent {...props} />
+    </StyledTableData>
+  );
+});
+
+export default BasicCell;

--- a/src/core/BasicCell/index.tsx
+++ b/src/core/BasicCell/index.tsx
@@ -10,7 +10,9 @@ import {
 
 interface BasicCellContentProps {
   primaryText: string;
+  primaryTextWrapLineCount?: number;
   secondaryText?: string;
+  secondaryTextWrapLineCount?: number;
   shouldTextWrap?: boolean;
 }
 
@@ -25,14 +27,28 @@ export type BasicCellProps = BasicCellRawProps &
 
 const BasicCellContent = forwardRef(
   (props: BasicCellContentProps, _): JSX.Element | null => {
-    const { primaryText, secondaryText, shouldTextWrap = false } = props;
+    const {
+      primaryText,
+      primaryTextWrapLineCount,
+      secondaryText,
+      secondaryTextWrapLineCount,
+      shouldTextWrap = false,
+    } = props;
 
     return (
       <>
-        <PrimaryText shouldTextWrap={shouldTextWrap}>{primaryText}</PrimaryText>
+        <PrimaryText
+          shouldTextWrap={shouldTextWrap}
+          primaryTextWrapLineCount={primaryTextWrapLineCount}
+        >
+          {primaryText}
+        </PrimaryText>
 
         {secondaryText && (
-          <SecondaryText shouldTextWrap={shouldTextWrap}>
+          <SecondaryText
+            shouldTextWrap={shouldTextWrap}
+            secondaryTextWrapLineCount={secondaryTextWrapLineCount}
+          >
             {secondaryText}
           </SecondaryText>
         )}

--- a/src/core/BasicCell/style.ts
+++ b/src/core/BasicCell/style.ts
@@ -11,6 +11,8 @@ import {
 export interface BasicCellExtraProps extends CommonThemeProps {
   textPosition?: "left" | "center" | "right";
   shouldTextWrap?: boolean;
+  primaryTextWrapLineCount?: number;
+  secondaryTextWrapLineCount?: number;
 }
 
 const doNotForwardProps = [
@@ -20,28 +22,42 @@ const doNotForwardProps = [
   "shouldTextWrap",
   "shouldShowTooltipOnHover",
   "tooltipProps",
+  "primaryTextWrapLineCount",
+  "secondaryTextWrapLineCount",
 ];
 
 export const StyledTableData = styled("td", {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   ${(props: BasicCellExtraProps) => {
+    const { textPosition = "left" } = props;
+
     const spacings = getSpaces(props);
     const typography = getTypography(props);
 
     return `
         font-family: ${typography?.fontFamily};
         padding: ${spacings?.l}px ${spacings?.s}px;
-        text-align: ${props.textPosition};
+        text-align: ${textPosition};
         min-width: 96px;
+        max-width: 100%;
+        display: block;
         overflow: hidden;
         border: dashed 1px #ddd;
-        max-width: 100px;
     `;
   }}
 `;
 
-const ShouldNotWrap = () => {
+const ShouldWrap = (lineCount: number) => {
+  return `
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: ${lineCount};
+    -webkit-box-orient: vertical; 
+  `;
+};
+
+const ShouldTruncate = () => {
   return `
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -55,10 +71,16 @@ export const PrimaryText = styled("span", {
   ${fontBodyS}
 
   ${(props: BasicCellExtraProps) => {
+    const { primaryTextWrapLineCount = 3 } = props;
+
     return `
-        display: block;
-        line-height: 20px;
-        ${props.shouldTextWrap ? null : ShouldNotWrap()}
+      display: block;
+      line-height: 20px;
+      ${
+        props.shouldTextWrap
+          ? ShouldWrap(primaryTextWrapLineCount)
+          : ShouldTruncate()
+      }
     `;
   }}
 `;
@@ -69,6 +91,8 @@ export const SecondaryText = styled("span", {
   ${fontBodyXxs}
 
   ${(props: BasicCellExtraProps) => {
+    const { secondaryTextWrapLineCount = 1 } = props;
+
     const colors = getColors(props);
     const spaces = getSpaces(props);
 
@@ -77,7 +101,11 @@ export const SecondaryText = styled("span", {
       color: ${colors?.gray[600]};
       padding-top: ${spaces?.xxxs}px;
 
-      ${props.shouldTextWrap ? null : ShouldNotWrap()}
+      ${
+        props.shouldTextWrap
+          ? ShouldWrap(secondaryTextWrapLineCount)
+          : ShouldTruncate()
+      }
     `;
   }}
 `;

--- a/src/core/BasicCell/style.ts
+++ b/src/core/BasicCell/style.ts
@@ -1,0 +1,83 @@
+import { styled } from "@mui/material/styles";
+import {
+  CommonThemeProps,
+  fontBodyS,
+  fontBodyXxs,
+  getColors,
+  getSpaces,
+  getTypography,
+} from "../styles";
+
+export interface BasicCellExtraProps extends CommonThemeProps {
+  textPosition?: "left" | "center" | "right";
+  shouldTextWrap?: boolean;
+}
+
+const doNotForwardProps = [
+  "textPosition",
+  "primaryText",
+  "secondaryText",
+  "shouldTextWrap",
+  "shouldShowTooltipOnHover",
+  "tooltipProps",
+];
+
+export const StyledTableData = styled("td", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${(props: BasicCellExtraProps) => {
+    const spacings = getSpaces(props);
+    const typography = getTypography(props);
+
+    return `
+        font-family: ${typography?.fontFamily};
+        padding: ${spacings?.l}px ${spacings?.s}px;
+        text-align: ${props.textPosition};
+        min-width: 96px;
+        overflow: hidden;
+        border: dashed 1px #ddd;
+        max-width: 100px;
+    `;
+  }}
+`;
+
+const ShouldNotWrap = () => {
+  return `
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  `;
+};
+
+export const PrimaryText = styled("span", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${fontBodyS}
+
+  ${(props: BasicCellExtraProps) => {
+    return `
+        display: block;
+        line-height: 20px;
+        ${props.shouldTextWrap ? null : ShouldNotWrap()}
+    `;
+  }}
+`;
+
+export const SecondaryText = styled("span", {
+  shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
+})`
+  ${fontBodyXxs}
+
+  ${(props: BasicCellExtraProps) => {
+    const colors = getColors(props);
+    const spaces = getSpaces(props);
+
+    return `
+      display: block;
+      color: ${colors?.gray[600]};
+      padding-top: ${spaces?.xxxs}px;
+
+      ${props.shouldTextWrap ? null : ShouldNotWrap()}
+    `;
+  }}
+`;

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -56,6 +56,13 @@ const Tooltip = forwardRef(function Tooltip(
     );
   }
 
+  if (subtitle && sdsStyle === "light") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Warning: The 'subtitle' text is only available for dark tooltips."
+    );
+  }
+
   const theme = useTheme();
 
   const extraProps = {
@@ -88,7 +95,7 @@ const Tooltip = forwardRef(function Tooltip(
   const content = (
     <>
       {title}
-      {subtitle && <Subtitle>{subtitle}</Subtitle>}
+      {sdsStyle === "dark" && subtitle && <Subtitle>{subtitle}</Subtitle>}
     </>
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export * from "./core/Alert";
 export { default as Alert } from "./core/Alert";
 export * from "./core/Banner";
 export { default as Banner } from "./core/Banner";
+export * from "./core/BasicCell";
+export { default as BasicCell } from "./core/BasicCell";
 export * from "./core/Button";
 export { default as Button } from "./core/Button";
 export * from "./core/ButtonDropdown";


### PR DESCRIPTION
## Summary

**Tooltip**
Shortcut ticket: [sh-211324](https://app.shortcut.com/sci-design-system/story/211324/remove-subtitle-from-light-tooltip)

The light version should not have the ability to have a subtitle, only the main text.
