### PR TITLE
refactor(tooltip): remove subtitle from light version

### DIFF
--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -145,7 +145,7 @@ const PlacementDemo = (): JSX.Element => {
 
   return (
     <div style={placementStyles as React.CSSProperties}>
-      <Tooltip title="Text" placement="top-start" arrow open sdsStyle="dark">
+      <Tooltip title="Text" placement="top-start" arrow open>
         <Button sdsStyle="minimal" sdsType="secondary">
           top-start
         </Button>

--- a/src/core/Tooltip/index.tsx
+++ b/src/core/Tooltip/index.tsx
@@ -56,6 +56,13 @@ const Tooltip = forwardRef(function Tooltip(
     );
   }
 
+  if (subtitle && sdsStyle === "light") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Warning: The 'subtitle' text is only available for dark tooltips."
+    );
+  }
+
   const theme = useTheme();
 
   const extraProps = {
@@ -88,7 +95,7 @@ const Tooltip = forwardRef(function Tooltip(
   const content = (
     <>
       {title}
-      {subtitle && <Subtitle>{subtitle}</Subtitle>}
+      {sdsStyle === "dark" && subtitle && <Subtitle>{subtitle}</Subtitle>}
     </>
   );
 


### PR DESCRIPTION
## Summary

**Tooltip**
Shortcut ticket: [sh-211324](https://app.shortcut.com/sci-design-system/story/211324/remove-subtitle-from-light-tooltip)

The light version should not have the ability to have a subtitle, only the main text.

