### PR TITLE
docs(button): add onClick documentation in storybook

### DIFF
--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -2,7 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { Args, Story } from "@storybook/react";
 import React from "react";
 import Icon from "../Icon";
-import Button from "./index";
+import RawButton from "./index";
 
 const text = "Label";
 const sdsStyles = ["rounded", "square", "minimal"];
@@ -12,12 +12,12 @@ const actions = {
   onClick: action("onClick"),
 };
 
-const Demo = (props: Args): JSX.Element => {
+const Button = (props: Args): JSX.Element => {
   const { sdsType, sdsStyle } = props;
   return (
-    <Button sdsType={sdsType} sdsStyle={sdsStyle} {...props}>
+    <RawButton sdsType={sdsType} sdsStyle={sdsStyle} {...props}>
       {text}
-    </Button>
+    </RawButton>
   );
 };
 
@@ -39,11 +39,11 @@ export default {
       },
     },
   },
-  component: Demo,
+  component: Button,
   title: "Button",
 };
 
-const Template: Story = (props) => <Demo {...props} />;
+const Template: Story = (props) => <Button {...props} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
@@ -79,29 +79,29 @@ const placementStyles = {
 const RoundedLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={placementStyles as React.CSSProperties}>
-      <Button {...props} sdsStyle="rounded" sdsType="primary">
+      <RawButton {...props} sdsStyle="rounded" sdsType="primary">
         {text}
-      </Button>
+      </RawButton>
 
-      <Button
+      <RawButton
         {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
         sdsStyle="rounded"
         sdsType="primary"
       >
         {text}
-      </Button>
-      <Button {...props} sdsStyle="rounded" sdsType="secondary">
+      </RawButton>
+      <RawButton {...props} sdsStyle="rounded" sdsType="secondary">
         {text}
-      </Button>
-      <Button
+      </RawButton>
+      <RawButton
         {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
         sdsStyle="rounded"
         sdsType="secondary"
       >
         {text}
-      </Button>
+      </RawButton>
     </div>
   );
 };
@@ -116,28 +116,28 @@ export const RoundedLivePreview = RoundedLivePreviewDemo.bind({});
 const SquareLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={placementStyles as React.CSSProperties}>
-      <Button {...props} sdsStyle="square" sdsType="primary">
+      <RawButton {...props} sdsStyle="square" sdsType="primary">
         {text}
-      </Button>
-      <Button
+      </RawButton>
+      <RawButton
         {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
         sdsStyle="square"
         sdsType="primary"
       >
         {text}
-      </Button>
-      <Button {...props} sdsStyle="square" sdsType="secondary">
+      </RawButton>
+      <RawButton {...props} sdsStyle="square" sdsType="secondary">
         {text}
-      </Button>
-      <Button
+      </RawButton>
+      <RawButton
         {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
         sdsStyle="square"
         sdsType="secondary"
       >
         {text}
-      </Button>
+      </RawButton>
     </div>
   );
 };
@@ -160,21 +160,21 @@ const minimalPlacementStyles = {
 const MinimalLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={minimalPlacementStyles as React.CSSProperties}>
-      <Button {...props} sdsStyle="minimal" sdsType="primary">
+      <RawButton {...props} sdsStyle="minimal" sdsType="primary">
         {text}
-      </Button>
+      </RawButton>
 
-      <Button
+      <RawButton
         {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
         sdsStyle="minimal"
         sdsType="primary"
       >
         {text}
-      </Button>
-      <Button {...props} sdsStyle="minimal" sdsType="secondary">
+      </RawButton>
+      <RawButton {...props} sdsStyle="minimal" sdsType="secondary">
         {text}
-      </Button>
+      </RawButton>
     </div>
   );
 };

--- a/src/core/Button/index.stories.tsx
+++ b/src/core/Button/index.stories.tsx
@@ -15,12 +15,7 @@ const actions = {
 const Demo = (props: Args): JSX.Element => {
   const { sdsType, sdsStyle } = props;
   return (
-    <Button
-      onClick={actions.onClick}
-      sdsType={sdsType}
-      sdsStyle={sdsStyle}
-      {...props}
-    >
+    <Button sdsType={sdsType} sdsStyle={sdsStyle} {...props}>
       {text}
     </Button>
   );
@@ -28,6 +23,8 @@ const Demo = (props: Args): JSX.Element => {
 
 export default {
   argTypes: {
+    // https://storybook.js.org/docs/react/essentials/actions#action-argtype-annotation
+    onClick: { action: actions.onClick },
     sdsStyle: {
       control: { type: "select" },
       options: sdsStyles,
@@ -46,7 +43,7 @@ export default {
   title: "Button",
 };
 
-const Template: Story = (args) => <Demo {...args} />;
+const Template: Story = (props) => <Demo {...props} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
@@ -79,27 +76,27 @@ const placementStyles = {
   gridTemplateRows: "1fr",
 };
 
-const RoundedLivePreviewDemo = (): JSX.Element => {
+const RoundedLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={placementStyles as React.CSSProperties}>
-      <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="primary">
+      <Button {...props} sdsStyle="rounded" sdsType="primary">
         {text}
       </Button>
 
       <Button
+        {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-        onClick={actions.onClick}
         sdsStyle="rounded"
         sdsType="primary"
       >
         {text}
       </Button>
-      <Button onClick={actions.onClick} sdsStyle="rounded" sdsType="secondary">
+      <Button {...props} sdsStyle="rounded" sdsType="secondary">
         {text}
       </Button>
       <Button
+        {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-        onClick={actions.onClick}
         sdsStyle="rounded"
         sdsType="secondary"
       >
@@ -116,26 +113,26 @@ RoundedLivePreviewDemo.parameters = {
 };
 export const RoundedLivePreview = RoundedLivePreviewDemo.bind({});
 
-const SquareLivePreviewDemo = (): JSX.Element => {
+const SquareLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={placementStyles as React.CSSProperties}>
-      <Button onClick={actions.onClick} sdsStyle="square" sdsType="primary">
+      <Button {...props} sdsStyle="square" sdsType="primary">
         {text}
       </Button>
       <Button
+        {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-        onClick={actions.onClick}
         sdsStyle="square"
         sdsType="primary"
       >
         {text}
       </Button>
-      <Button onClick={actions.onClick} sdsStyle="square" sdsType="secondary">
+      <Button {...props} sdsStyle="square" sdsType="secondary">
         {text}
       </Button>
       <Button
+        {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-        onClick={actions.onClick}
         sdsStyle="square"
         sdsType="secondary"
       >
@@ -160,22 +157,22 @@ const minimalPlacementStyles = {
   gridTemplateRows: "1fr",
 };
 
-const MinimalLivePreviewDemo = (): JSX.Element => {
+const MinimalLivePreviewDemo = (props: Args): JSX.Element => {
   return (
     <div style={minimalPlacementStyles as React.CSSProperties}>
-      <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="primary">
+      <Button {...props} sdsStyle="minimal" sdsType="primary">
         {text}
       </Button>
 
       <Button
+        {...props}
         startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-        onClick={actions.onClick}
         sdsStyle="minimal"
         sdsType="primary"
       >
         {text}
       </Button>
-      <Button onClick={actions.onClick} sdsStyle="minimal" sdsType="secondary">
+      <Button {...props} sdsStyle="minimal" sdsType="secondary">
         {text}
       </Button>
     </div>


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
This ticket adds `onClick` in storybook!

<img width="1792" alt="Screen Shot 2022-08-23 at 2 14 17 PM" src="https://user-images.githubusercontent.com/6309723/186267342-41937337-6dbc-428e-adf1-cb03c09e5e97.png">


## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
