### PR TITLE
feat(tableheader): tableHeader implementation

### DIFF
--- a/src/core/CellHeader/index.tsx
+++ b/src/core/CellHeader/index.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef } from "react";
 import Icon, { IconNameToSizes } from "../Icon";
 import Tooltip, { TooltipProps } from "../Tooltip";
-
 import {
   CellHeaderExtraProps,
   StyledSortingIcon,

--- a/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TableHeader /> Test story renders snapshot 1`] = `
+<table>
+  <tbody>
+    <thead
+      class="css-poibjc"
+      data-testid="TableHeader"
+    >
+      <th
+        class="css-11balri"
+      >
+        <div>
+          <span>
+            Column 1
+          </span>
+        </div>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
+          data-testid="iconButton"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="css-jbvua0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+              data-jest-file-name="IconChevronDownSmall.svg"
+              data-jest-svg-name="IconChevronDownSmall"
+              data-testid="IconChevronDownSmall"
+              fillcontrast="white"
+              focusable="false"
+              viewBox="0 0 14 14"
+            />
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </th>
+    </thead>
+  </tbody>
+</table>
+`;

--- a/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -2,17 +2,52 @@
 
 exports[`<TableHeader /> Test story renders snapshot 1`] = `
 <table>
-  <tbody>
-    <thead
-      class="css-poibjc"
-      data-testid="TableHeader"
+  <thead
+    class="css-1426k2b"
+    data-testid="TableHeader"
+  >
+    <tr
+      class="css-1eqhtgs"
     >
+      <th
+        class="css-dwltcx"
+      >
+        <div>
+          <span>
+            Column 1
+          </span>
+        </div>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1j31s22-MuiButtonBase-root-MuiIconButton-root"
+          data-testid="iconButton"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="css-jbvua0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+              data-jest-file-name="IconChevronDownSmall.svg"
+              data-jest-svg-name="IconChevronDownSmall"
+              data-testid="IconChevronDownSmall"
+              fillcontrast="white"
+              focusable="false"
+              viewBox="0 0 14 14"
+            />
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </th>
       <th
         class="css-11balri"
       >
         <div>
           <span>
-            Column 1
+            Column 2
           </span>
         </div>
         <button
@@ -40,7 +75,40 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
           />
         </button>
       </th>
-    </thead>
-  </tbody>
+      <th
+        class="css-11balri"
+      >
+        <div>
+          <span>
+            Column 3
+          </span>
+        </div>
+        <button
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
+          data-testid="iconButton"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="css-jbvua0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+              data-jest-file-name="IconChevronDownSmall.svg"
+              data-jest-svg-name="IconChevronDownSmall"
+              data-testid="IconChevronDownSmall"
+              fillcontrast="white"
+              focusable="false"
+              viewBox="0 0 14 14"
+            />
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </th>
+    </tr>
+  </thead>
 </table>
 `;

--- a/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -10,103 +10,115 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
       class="css-1eqhtgs"
     >
       <th
-        class="css-dwltcx"
+        class="css-1f4hh9k"
       >
-        <div>
-          <span>
-            Column 1
-          </span>
-        </div>
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1j31s22-MuiButtonBase-root-MuiIconButton-root"
-          data-testid="iconButton"
-          tabindex="0"
-          type="button"
+        <div
+          class="css-s7bxyi"
         >
-          <div
-            class="css-jbvua0"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
-              data-jest-file-name="IconChevronDownSmall.svg"
-              data-jest-svg-name="IconChevronDownSmall"
-              data-testid="IconChevronDownSmall"
-              fillcontrast="white"
-              focusable="false"
-              viewBox="0 0 14 14"
-            />
+          <div>
+            <span>
+              Column 1
+            </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1j31s22-MuiButtonBase-root-MuiIconButton-root"
+            data-testid="iconButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-jbvua0"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+                data-jest-file-name="IconChevronDownSmall.svg"
+                data-jest-svg-name="IconChevronDownSmall"
+                data-testid="IconChevronDownSmall"
+                fillcontrast="white"
+                focusable="false"
+                viewBox="0 0 14 14"
+              />
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
       </th>
       <th
-        class="css-11balri"
+        class="css-iz3tbo"
       >
-        <div>
-          <span>
-            Column 2
-          </span>
-        </div>
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
-          data-testid="iconButton"
-          tabindex="0"
-          type="button"
+        <div
+          class="css-s7bxyi"
         >
-          <div
-            class="css-jbvua0"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
-              data-jest-file-name="IconChevronDownSmall.svg"
-              data-jest-svg-name="IconChevronDownSmall"
-              data-testid="IconChevronDownSmall"
-              fillcontrast="white"
-              focusable="false"
-              viewBox="0 0 14 14"
-            />
+          <div>
+            <span>
+              Column 2
+            </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
+            data-testid="iconButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-jbvua0"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+                data-jest-file-name="IconChevronDownSmall.svg"
+                data-jest-svg-name="IconChevronDownSmall"
+                data-testid="IconChevronDownSmall"
+                fillcontrast="white"
+                focusable="false"
+                viewBox="0 0 14 14"
+              />
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
       </th>
       <th
-        class="css-11balri"
+        class="css-iz3tbo"
       >
-        <div>
-          <span>
-            Column 3
-          </span>
-        </div>
-        <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
-          data-testid="iconButton"
-          tabindex="0"
-          type="button"
+        <div
+          class="css-s7bxyi"
         >
-          <div
-            class="css-jbvua0"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
-              data-jest-file-name="IconChevronDownSmall.svg"
-              data-jest-svg-name="IconChevronDownSmall"
-              data-testid="IconChevronDownSmall"
-              fillcontrast="white"
-              focusable="false"
-              viewBox="0 0 14 14"
-            />
+          <div>
+            <span>
+              Column 3
+            </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1o14r5s-MuiButtonBase-root-MuiIconButton-root"
+            data-testid="iconButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-jbvua0"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+                data-jest-file-name="IconChevronDownSmall.svg"
+                data-jest-svg-name="IconChevronDownSmall"
+                data-testid="IconChevronDownSmall"
+                fillcontrast="white"
+                focusable="false"
+                viewBox="0 0 14 14"
+              />
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
       </th>
     </tr>
   </thead>

--- a/src/core/TableHeader/index.stories.tsx
+++ b/src/core/TableHeader/index.stories.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable no-use-before-define */
+import { Args, Story } from "@storybook/react";
+import * as React from "react";
+import CellHeader from "../CellHeader";
+import TableHeaderRaw from "./index";
+
+const TableHeader = (props: Args): JSX.Element => {
+  return (
+    <table>
+      <TableHeaderRaw {...props}>
+        <CellHeader active>Column 1</CellHeader>
+        <CellHeader>Column 2</CellHeader>
+        <CellHeader>Column 3</CellHeader>
+      </TableHeaderRaw>
+    </table>
+  );
+};
+
+export default {
+  component: TableHeader,
+  title: "TableHeader",
+};
+
+const Template: Story = (args) => <TableHeader {...args} />;
+
+export const Default = Template.bind({});
+
+Default.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
+
+const TestDemo = (): JSX.Element => (
+  <table>
+    <tbody>
+      <TableHeaderRaw data-testid="TableHeader">
+        <CellHeader>Column 1</CellHeader>
+      </TableHeaderRaw>
+    </tbody>
+  </table>
+);
+
+const TestTemplate: Story = (args) => <TestDemo {...args} />;
+
+export const Test = TestTemplate.bind({});

--- a/src/core/TableHeader/index.stories.tsx
+++ b/src/core/TableHeader/index.stories.tsx
@@ -2,15 +2,18 @@
 import { Args, Story } from "@storybook/react";
 import * as React from "react";
 import CellHeader from "../CellHeader";
+import TableRow from "../TableRow";
 import TableHeaderRaw from "./index";
 
 const TableHeader = (props: Args): JSX.Element => {
   return (
     <table>
       <TableHeaderRaw {...props}>
-        <CellHeader active>Column 1</CellHeader>
-        <CellHeader>Column 2</CellHeader>
-        <CellHeader>Column 3</CellHeader>
+        <TableRow hover={false} shouldShowTooltipOnHover={false}>
+          <CellHeader active>Column 1</CellHeader>
+          <CellHeader>Column 2</CellHeader>
+          <CellHeader>Column 3</CellHeader>
+        </TableRow>
       </TableHeaderRaw>
     </table>
   );
@@ -33,11 +36,13 @@ Default.parameters = {
 
 const TestDemo = (): JSX.Element => (
   <table>
-    <tbody>
-      <TableHeaderRaw data-testid="TableHeader">
-        <CellHeader>Column 1</CellHeader>
-      </TableHeaderRaw>
-    </tbody>
+    <TableHeaderRaw data-testid="TableHeader">
+      <TableRow hover={false} shouldShowTooltipOnHover={false}>
+        <CellHeader active>Column 1</CellHeader>
+        <CellHeader>Column 2</CellHeader>
+        <CellHeader>Column 3</CellHeader>
+      </TableRow>
+    </TableHeaderRaw>
   </table>
 );
 

--- a/src/core/TableHeader/index.test.tsx
+++ b/src/core/TableHeader/index.test.tsx
@@ -1,0 +1,19 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { composeStory } from "@storybook/testing-react";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import * as snapshotTestStoryFile from "./index.stories";
+import Meta, { Test as TestStory } from "./index.stories";
+
+// Returns a component that already contain all decorators from story level, meta level and global level.
+const Test = composeStory(TestStory, Meta);
+
+describe("<TableHeader />", () => {
+  generateSnapshots(snapshotTestStoryFile);
+
+  it("renders row component", () => {
+    render(<Test />);
+    const elements = screen.getAllByTestId("TableHeader");
+    expect(elements).toBeTruthy();
+  });
+});

--- a/src/core/TableHeader/index.tsx
+++ b/src/core/TableHeader/index.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from "react";
+import { StyledTableHeader } from "./style";
+
+interface TableHeaderProps {
+  children: React.ReactNode;
+}
+
+const TableHeader = forwardRef<HTMLTableElement["tHead"], TableHeaderProps>(
+  (props: TableHeaderProps, ref): JSX.Element | null => {
+    const { children } = props;
+
+    return (
+      <StyledTableHeader ref={ref} {...props}>
+        {children}
+      </StyledTableHeader>
+    );
+  }
+);
+
+export default TableHeader;

--- a/src/core/TableHeader/style.ts
+++ b/src/core/TableHeader/style.ts
@@ -6,8 +6,6 @@ export const StyledTableHeader = styled("thead")`
     const colors = getColors(props);
 
     return `
-      display: flex;
-      align-items: center;
       border-bottom: solid 2px ${colors?.gray[300]};
     `;
   }}

--- a/src/core/TableHeader/style.ts
+++ b/src/core/TableHeader/style.ts
@@ -1,0 +1,14 @@
+import { styled } from "@mui/material/styles";
+import { getColors } from "../styles";
+
+export const StyledTableHeader = styled("thead")`
+  ${(props) => {
+    const colors = getColors(props);
+
+    return `
+      display: flex;
+      align-items: center;
+      border-bottom: solid 2px ${colors?.gray[300]};
+    `;
+  }}
+`;


### PR DESCRIPTION
## Summary

**TableHeader**
Shortcut ticket: [sh-213499](https://app.shortcut.com/sci-design-system/story/213499/tableheader-component)
Implemented with &lt;thead&gt; under the hood.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
