### PR TITLE
fix(cellcomponent): remove min width

### DIFF
--- a/src/core/CellComponent/__snapshots__/index.test.tsx.snap
+++ b/src/core/CellComponent/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<CellComponent /> Test story renders snapshot 1`] = `
           style="display: block; max-width: 280px;"
         >
           <td
-            class="cell-component css-laz68p"
+            class="cell-component css-i1o3nx"
             data-testid="CellComponentA"
           >
             <div
@@ -60,7 +60,7 @@ exports[`<CellComponent /> Test story renders snapshot 1`] = `
           style="display: block; max-width: 280px;"
         >
           <td
-            class="cell-component css-1lcwo8q"
+            class="cell-component css-1tllcjx"
             data-testid="CellComponentB"
           >
             <div

--- a/src/core/CellComponent/style.ts
+++ b/src/core/CellComponent/style.ts
@@ -31,7 +31,6 @@ export const StyledCellComponentData = styled("td", {
         align-items: center;
         text-align: ${horizontalAlign};
         vertical-align: ${verticalAlign};
-        width: 96px;
         overflow: hidden;
         padding: ${spacings?.l}px ${spacings?.s}px;
     `;


### PR DESCRIPTION
## Summary

**CellComponent**
remove minimum width from cell component

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
