### PR TITLE
docs(cellcomponent): update cellcomponent default story to toggle between cell sizes

### DIFF
--- a/src/core/CellComponent/index.stories.tsx
+++ b/src/core/CellComponent/index.stories.tsx
@@ -36,6 +36,9 @@ const CellComponent = (props: Args): JSX.Element => {
 
 export default {
   argTypes: {
+    fitCellToComponent: {
+      control: { type: "boolean" },
+    },
     horizontalAlign: {
       control: { type: "select" },
       options: ["left", "center", "right"],
@@ -50,13 +53,27 @@ export default {
 };
 
 const Template: Story = (props: Args) => {
-  const { horizontalAlign, verticalAlign } = props;
+  const { horizontalAlign, verticalAlign, fitCellToComponent } = props;
+
+  if (fitCellToComponent) {
+    return (
+      <CellComponent
+        horizontalAlign={horizontalAlign}
+        verticalAlign={verticalAlign}
+        data-testid="CellComponent"
+        {...props}
+      >
+        <InputToggle />
+      </CellComponent>
+    );
+  }
 
   return (
     <CellComponent
       horizontalAlign={horizontalAlign}
       verticalAlign={verticalAlign}
       data-testid="CellComponent"
+      style={{ height: 100, width: 100 }}
       {...props}
     >
       <InputToggle />


### PR DESCRIPTION


## Summary

**CellComponent**
Changed default story to allow demonstration of the vertical and horizontal alignment props. This was achieved by adding a toggle that switches between a cell with defined dimensions and a cell that fits the child's size

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
