### PR TITLE
feat(checkbox): added optional label to checkbox component

### DIFF
--- a/src/core/Checkbox/__snapshots__/index.test.tsx.snap
+++ b/src/core/Checkbox/__snapshots__/index.test.tsx.snap
@@ -1,39 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Checkbox /> Test story renders snapshot 1`] = `
-<div>
-  <label
-    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+<div
+  style="display: grid; grid-template-columns: repeat(2, 100px); grid-template-rows: 1fr;"
+>
+  <div
+    style="grid-area: 1 / 1 / 1 / 2;"
   >
-    <span
-      class="MuiCheckbox-root MuiCheckbox-colorDefault MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root css-1ptfvrq-MuiButtonBase-root-MuiCheckbox-root"
-      data-testid="checkbox"
-      stage="unchecked"
-    >
-      <input
-        class="PrivateSwitchBase-input css-1m9pwf3"
-        data-indeterminate="false"
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-        data-jest-file-name="IconCheckboxUnchecked.svg"
-        data-jest-svg-name="IconCheckboxUnchecked"
-        data-testid="IconCheckboxUnchecked"
-        fillcontrast="white"
-        focusable="false"
-        viewBox="0 0 16 16"
-      />
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
-    </span>
-    <span
-      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
-    >
-      Label
-    </span>
-  </label>
+    <div>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-1x95i3r-MuiButtonBase-root-MuiCheckbox-root"
+          data-testid="labelCheckbox"
+        >
+          <input
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            data-indeterminate="false"
+            type="checkbox"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-jest-file-name="IconCheckboxUnchecked.svg"
+            data-jest-svg-name="IconCheckboxUnchecked"
+            data-testid="IconCheckboxUnchecked"
+            fillcontrast="white"
+            focusable="false"
+            viewBox="0 0 16 16"
+          />
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+        >
+          Lable A
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    style="grid-area: 1 / 2 / 1 / 2;"
+  >
+    <div>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiCheckbox-root MuiCheckbox-colorDefault MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorDefault PrivateSwitchBase-root css-1ptfvrq-MuiButtonBase-root-MuiCheckbox-root"
+          data-testid="checkbox"
+          stage="unchecked"
+        >
+          <input
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            data-indeterminate="false"
+            type="checkbox"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-jest-file-name="IconCheckboxUnchecked.svg"
+            data-jest-svg-name="IconCheckboxUnchecked"
+            data-testid="IconCheckboxUnchecked"
+            fillcontrast="white"
+            focusable="false"
+            viewBox="0 0 16 16"
+          />
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+        >
+          Label
+        </span>
+      </label>
+    </div>
+  </div>
 </div>
 `;

--- a/src/core/Checkbox/index.stories.tsx
+++ b/src/core/Checkbox/index.stories.tsx
@@ -108,37 +108,28 @@ const IndeterminateDemo = (): JSX.Element => {
       <Checkbox
         label="Child 1"
         checkboxProps={{
-          onChange: handleChange2,
           checked: checked[0],
+          onChange: handleChange2,
         }}
       />
       <Checkbox
         label="Child 2"
         checkboxProps={{
-          onChange: handleChange3,
           checked: checked[1],
+          onChange: handleChange3,
         }}
       />
     </Box>
   );
 
-  function getParentStage() {
-    if (checked[0] && checked[1]) {
-      return "checked";
-    }
-    if (checked[0] !== checked[1]) {
-      return "indeterminate";
-    }
-    return "unchecked";
-  }
   return (
     <div>
       <Checkbox
         label="Parent"
         checkboxProps={{
           checked: checked[0] && checked[1],
-          onChange: handleChange1,
           indeterminate: checked[0] !== checked[1],
+          onChange: handleChange1,
         }}
       />
       {children}

--- a/src/core/Checkbox/index.stories.tsx
+++ b/src/core/Checkbox/index.stories.tsx
@@ -105,23 +105,19 @@ const IndeterminateDemo = (): JSX.Element => {
 
   const children = (
     <Box sx={{ display: "flex", flexDirection: "column", ml: 3 }}>
-      <FormControlLabel
+      <Checkbox
         label="Child 1"
-        control={
-          <Checkbox
-            onChange={handleChange2}
-            stage={checked[0] ? "checked" : "unchecked"}
-          />
-        }
+        checkboxProps={{
+          onChange: handleChange2,
+          checked: checked[0],
+        }}
       />
-      <FormControlLabel
+      <Checkbox
         label="Child 2"
-        control={
-          <Checkbox
-            onChange={handleChange3}
-            stage={checked[1] ? "checked" : "unchecked"}
-          />
-        }
+        checkboxProps={{
+          onChange: handleChange3,
+          checked: checked[1],
+        }}
       />
     </Box>
   );
@@ -137,15 +133,13 @@ const IndeterminateDemo = (): JSX.Element => {
   }
   return (
     <div>
-      <FormControlLabel
+      <Checkbox
         label="Parent"
-        control={
-          <Checkbox
-            checked={checked[0] && checked[1]}
-            stage={getParentStage()}
-            onChange={handleChange1}
-          />
-        }
+        checkboxProps={{
+          checked: checked[0] && checked[1],
+          onChange: handleChange1,
+          indeterminate: checked[0] !== checked[1],
+        }}
       />
       {children}
     </div>

--- a/src/core/Checkbox/index.stories.tsx
+++ b/src/core/Checkbox/index.stories.tsx
@@ -3,6 +3,8 @@ import { Args, Story } from "@storybook/react";
 import React from "react";
 import Checkbox from "./index";
 
+const testId = "test-story";
+
 const CheckboxDemo = (props: Args): JSX.Element => {
   const { disabled } = props;
   const [checked, setChecked] = React.useState(true);
@@ -14,6 +16,7 @@ const CheckboxDemo = (props: Args): JSX.Element => {
       <FormControlLabel
         control={
           <Checkbox
+            data-testid="checkbox"
             disabled={disabled}
             onChange={handleChange}
             stage={checked ? "unchecked" : "checked"}
@@ -41,14 +44,44 @@ Default.parameters = {
 };
 
 Default.args = {
-  id: "test-story",
+  id: { testId },
 };
 
-export const Test = Template.bind({});
+const CheckboxLabelDemo = (props: Args): JSX.Element => {
+  const { label, disabled } = props;
+  return (
+    <div>
+      <Checkbox data-testid="labelCheckbox" label={label} disabled={disabled} />
+    </div>
+  );
+};
+
+const TestDemo = (): JSX.Element => {
+  const testStyles = {
+    display: "grid",
+    gridColumnGap: "10px",
+    gridRowGap: "0px",
+    gridTemplateColumns: "repeat(2, 100px)",
+    gridTemplateRows: "1fr",
+  };
+
+  return (
+    <div style={testStyles as React.CSSProperties}>
+      <div style={{ gridArea: "1 / 1 / 1 / 2" }}>
+        <CheckboxLabelDemo label="Lable A" disabled={false} />
+      </div>
+      <div style={{ gridArea: "1 / 2 / 1 / 2" }}>
+        <CheckboxDemo />
+      </div>
+    </div>
+  );
+};
+const TestTemplate: Story = (args) => <TestDemo {...args} />;
+
+export const Test = TestTemplate.bind({});
 
 Test.args = {
-  id: "test-story",
-  togglePosition: "right",
+  id: { testId },
 };
 
 /*
@@ -131,7 +164,7 @@ const LivePreviewDemo = (): JSX.Element => {
   return (
     <div style={livePreviewStyles as React.CSSProperties}>
       <div style={{ gridArea: "1 / 1 / 1 / 2" }}>
-        <CheckboxDemo disabled={false} />
+        <CheckboxLabelDemo label="Label" disabled={false} />
       </div>
       <div style={{ gridArea: "1 / 2 / 1 / 2" }}>
         <CheckboxDemo disabled />

--- a/src/core/Checkbox/index.test.tsx
+++ b/src/core/Checkbox/index.test.tsx
@@ -16,4 +16,10 @@ describe("<Checkbox />", () => {
     const checkboxElement = screen.getByTestId("checkbox");
     expect(checkboxElement).not.toBeNull();
   });
+
+  it("renders checkbox with label component", () => {
+    render(<Test {...Test.args} />);
+    const checkboxElement = screen.getByTestId("labelCheckbox");
+    expect(checkboxElement).not.toBeNull();
+  });
 });

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -1,4 +1,8 @@
-import { CheckboxProps as MUICheckboxProps, SvgIcon } from "@mui/material";
+import {
+  CheckboxProps as MUICheckboxProps,
+  FormControlLabel,
+  SvgIcon,
+} from "@mui/material";
 import React from "react";
 import { ReactComponent as IconCheckboxChecked } from "../../common/svgs/IconCheckboxChecked.svg";
 import { ReactComponent as IconCheckboxIndeterminate } from "../../common/svgs/IconCheckboxIndeterminate.svg";
@@ -7,65 +11,100 @@ import { StyledCheckbox } from "./styles";
 
 export interface CheckboxProps
   extends Omit<MUICheckboxProps, "color" | "defaultChecked" | "indeterminate"> {
-  stage: "checked" | "unchecked" | "indeterminate";
+  stage?: "checked" | "unchecked" | "indeterminate";
+  label?: string;
 }
 
 /**
  * @see https://v4.mui.com/components/checkboxes/
  */
 const Checkbox = (props: CheckboxProps): JSX.Element => {
-  const { stage } = props;
-  let newProps: MUICheckboxProps;
-  switch (stage) {
-    case "checked":
-      newProps = {
-        ...props,
-        checked: true,
-        color: "primary",
-      };
-      break;
-    case "unchecked":
-      newProps = {
-        ...props,
-        checked: false,
-        color: "default",
-      };
-      break;
-    case "indeterminate":
-      newProps = {
-        ...props,
-        checked: true,
-        color: "primary",
-        indeterminate: true,
-      };
-      break;
-    default:
-      newProps = props;
+  const { stage, label, disabled } = props;
+
+  if (label === undefined) {
+    let newProps: MUICheckboxProps;
+    switch (stage) {
+      case "checked":
+        newProps = {
+          ...props,
+          checked: true,
+          color: "primary",
+        };
+        break;
+      case "unchecked":
+        newProps = {
+          ...props,
+          checked: false,
+          color: "default",
+        };
+        break;
+      case "indeterminate":
+        newProps = {
+          ...props,
+          checked: true,
+          color: "primary",
+          indeterminate: true,
+        };
+        break;
+      default:
+        newProps = props;
+    }
+    return (
+      <StyledCheckbox
+        {...newProps}
+        checkedIcon={
+          <SvgIcon
+            fillcontrast="white"
+            component={IconCheckboxChecked}
+            viewBox="0 0 16 16"
+          />
+        }
+        icon={
+          <SvgIcon
+            fillcontrast="white"
+            component={IconCheckboxUnchecked}
+            viewBox="0 0 16 16"
+          />
+        }
+        indeterminateIcon={
+          <SvgIcon
+            fillcontrast="white"
+            component={IconCheckboxIndeterminate}
+            viewBox="0 0 16 16"
+          />
+        }
+      />
+    );
   }
 
   return (
-    <StyledCheckbox
-      data-testid="checkbox"
-      {...newProps}
-      checkedIcon={
-        <SvgIcon
-          fillcontrast="white"
-          component={IconCheckboxChecked}
-          viewBox="0 0 16 16"
-        />
-      }
-      icon={
-        <SvgIcon
-          fillcontrast="white"
-          component={IconCheckboxUnchecked}
-          viewBox="0 0 16 16"
-        />
-      }
-      indeterminateIcon={
-        <SvgIcon
-          fillcontrast="white"
-          component={IconCheckboxIndeterminate}
-          viewBox="0 0 16 16"
+    <FormControlLabel
+      label={label}
+      control={
+        <StyledCheckbox
+          data-testid="labelCheckbox"
+          disabled={disabled}
+          checkedIcon={
+            <SvgIcon
+              fillcontrast="white"
+              component={IconCheckboxChecked}
+              viewBox="0 0 16 16"
+            />
+          }
+          icon={
+            <SvgIcon
+              fillcontrast="white"
+              component={IconCheckboxUnchecked}
+              viewBox="0 0 16 16"
+            />
+          }
+          indeterminateIcon={
+            <SvgIcon
+              fillcontrast="white"
+              component={IconCheckboxIndeterminate}
+              viewBox="0 0 16 16"
+            />
+          }
         />
       }
     />

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -11,8 +11,9 @@ import { StyledCheckbox } from "./styles";
 
 export interface CheckboxProps
   extends Omit<MUICheckboxProps, "color" | "defaultChecked" | "indeterminate"> {
-  stage?: "checked" | "unchecked" | "indeterminate";
+  checkboxProps?: string;
   label?: string;
+  stage?: "checked" | "unchecked" | "indeterminate";
 }
 
 /**
@@ -21,7 +22,7 @@ export interface CheckboxProps
 const Checkbox = (props: CheckboxProps): JSX.Element => {
   const { stage, label, disabled } = props;
 
-  if (label === undefined) {
+  if (label === undefined && stage !== undefined) {
     let newProps: MUICheckboxProps;
     switch (stage) {
       case "checked":

--- a/src/core/Checkbox/index.tsx
+++ b/src/core/Checkbox/index.tsx
@@ -11,7 +11,7 @@ import { StyledCheckbox } from "./styles";
 
 export interface CheckboxProps
   extends Omit<MUICheckboxProps, "color" | "defaultChecked" | "indeterminate"> {
-  checkboxProps?: string;
+  checkboxProps?: Partial<MUICheckboxProps>;
   label?: string;
   stage?: "checked" | "unchecked" | "indeterminate";
 }
@@ -20,7 +20,7 @@ export interface CheckboxProps
  * @see https://v4.mui.com/components/checkboxes/
  */
 const Checkbox = (props: CheckboxProps): JSX.Element => {
-  const { stage, label, disabled } = props;
+  const { stage, label, disabled, checkboxProps } = props;
 
   if (label === undefined && stage !== undefined) {
     let newProps: MUICheckboxProps;
@@ -106,6 +106,7 @@ const Checkbox = (props: CheckboxProps): JSX.Element => {
               viewBox="0 0 16 16"
             />
           }
+          {...checkboxProps}
         />
       }
     />


### PR DESCRIPTION
## Summary

**Checkbox**
Shortcut ticket: [[sh-XXXX](link)](https://app.shortcut.com/sci-design-system/story/205142/add-optional-label-to-checkbox-component)
Currently, the checkbox component only includes a checkbox square but is shown with a label in the Live Preview. We want to include the label as part of the component. Consumers have used it in its current state and built their own labels around it, so to ensure this isn't a breaking change the label will be optional.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
