### PR TITLE
[DO NOT MERGE] Example of dropdown onchange bug

### DIFF
--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -21,7 +21,6 @@ const BugWrapper = (): JSX.Element => {
   const [buttonProp, setButtonProp] = useState("a");
   const clickHandler = () => {
     setButtonProp(`${buttonProp}a`);
-    console.log(buttonProp);
   };
   return (
     <>
@@ -45,6 +44,7 @@ const BugDropdown = ({ someProp }): JSX.Element => {
         value={dropdownVal}
         onChange={() => {
           changeCount.current += 1;
+          console.log("dropdown value: ", dropdownVal);
         }}
         options={GITHUB_LABELS}
         multiple

--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Paper, styled } from "@mui/material";
 import { Args, Story } from "@storybook/react";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { noop } from "src/common/utils";
 import { DefaultDropdownMenuOption } from "../DropdownMenu";
 import LoadingIndicator from "../LoadingIndicator";
@@ -14,6 +14,42 @@ const Demo = (props: Args): JSX.Element => {
       options={GITHUB_LABELS}
       {...props}
     />
+  );
+};
+
+const BugWrapper = (): JSX.Element => {
+  const [buttonProp, setButtonProp] = useState("a");
+  const clickHandler = () => {
+    setButtonProp(`${buttonProp}a`);
+    console.log(buttonProp);
+  };
+  return (
+    <>
+      <div onClick={clickHandler}>Change Prop</div>
+      <BugDropdown someProp={buttonProp} />
+    </>
+  );
+};
+
+const BugDropdown = ({ someProp }): JSX.Element => {
+  const dropdownVal: never[] | DefaultDropdownMenuOption | null | undefined =
+    [];
+
+  const changeCount = useRef(0);
+  return (
+    <>
+      <div>Some prop in parent: {someProp}</div>
+      <div>Onchange called count: {changeCount.current}</div>
+      <Dropdown
+        label="Dropdown label"
+        value={dropdownVal}
+        onChange={() => {
+          changeCount.current += 1;
+        }}
+        options={GITHUB_LABELS}
+        multiple
+      />
+    </>
   );
 };
 
@@ -96,8 +132,15 @@ export default {
 };
 
 const Template: Story = (args) => <Demo {...args} />;
+const TemplateBug: Story = (args) => <BugWrapper {...args} />;
 const LABEL = "Click Target";
 
+export const Buggy = TemplateBug.bind({});
+Buggy.parameters = {
+  snapshot: {
+    skip: true,
+  },
+};
 export const Default = Template.bind({});
 
 Default.args = {


### PR DESCRIPTION
## Summary
Slack context:
https://czi-sci.slack.com/archives/C032S43KKFV/p1665076950918139

> Issue Description: I'm not sure if this is a bug or intended behavior, but I noticed that if you have a parent component that included a `Dropdown`, and one of the props on the parent changes (even a prop that is not passed into the `Dropdown` at all).  It causes the dropdown to fire its `onChange` callback.  So basically that callback is being called even when the value selected is not changing.
I put together branch / PR demoing this (also included a screen recording in the description: https://github.com/chanzuckerberg/sci-components/pull/270 

Reproduce potential dropdown bug in storybook

### Video demo
https://user-images.githubusercontent.com/2072627/194223813-4eea18b7-2f71-41f5-baed-b9c372294a87.mov

## Checklist
- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
