### PR TITLE
refactor(buttonicon): buttonIcon now accepts sdsIcon and sdsIconProps

### DIFF
--- a/src/common/warnings.ts
+++ b/src/common/warnings.ts
@@ -2,6 +2,7 @@ export enum SDSWarningTypes {
   ButtonMissingSDSProps = "buttonMissingProps",
   ChipDeprecated = "chipDeprecated",
   MenuSelectDeprecated = "menuSelectDeprecated",
+  ButtonIconMediumSize = "buttonIconMediumSize",
 }
 
 const SDS_WARNINGS = {
@@ -18,6 +19,10 @@ const SDS_WARNINGS = {
     hasWarned: false,
     message:
       "Warning: MenuSelect will be deprecated and replaced with <DropdownMenu />",
+  },
+  [SDSWarningTypes.ButtonIconMediumSize]: {
+    hasWarned: false,
+    message: "Warning: A medium size ButtonIcon can only be of type tertiary!",
   },
 };
 

--- a/src/core/Banner/__snapshots__/banner.test.tsx.snap
+++ b/src/core/Banner/__snapshots__/banner.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-reo6um-MuiButtonBase-root-MuiIconButton-root"
-      data-testid="iconButton"
       tabindex="0"
       type="button"
     >
@@ -96,7 +95,6 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-quxuam-MuiButtonBase-root-MuiIconButton-root"
-      data-testid="iconButton"
       tabindex="0"
       type="button"
     >
@@ -155,7 +153,6 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-reo6um-MuiButtonBase-root-MuiIconButton-root"
-      data-testid="iconButton"
       tabindex="0"
       type="button"
     >
@@ -215,7 +212,6 @@ exports[`<Banner /> Test story renders snapshot 1`] = `
   </div>
   <button
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-reo6um-MuiButtonBase-root-MuiIconButton-root"
-    data-testid="iconButton"
     tabindex="0"
     type="button"
   >

--- a/src/core/Banner/index.tsx
+++ b/src/core/Banner/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useState } from "react";
+import React, { ForwardedRef, forwardRef, useState } from "react";
+import { ButtonIconSizeToTypes } from "../ButtonIcon";
 import Icon from "../Icon";
 import {
   BannerExtraProps,
@@ -9,16 +10,19 @@ import {
   Text,
 } from "./style";
 
-export interface BannerProps extends BannerExtraProps {
+export interface BannerProps<ButtonIconSize extends keyof ButtonIconSizeToTypes>
+  extends BannerExtraProps<ButtonIconSize> {
   dismissed?: boolean;
   dismissible?: boolean;
   onClose?: (e: React.MouseEvent) => void;
   text: string;
 }
 
-const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
-  props,
-  ref
+const Banner = forwardRef(function Banner<
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+>(
+  props: BannerProps<ButtonIconSize>,
+  ref: ForwardedRef<HTMLDivElement | null>
 ): JSX.Element | null {
   const {
     dismissed,
@@ -55,9 +59,8 @@ const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
           sdsType="tertiary"
           sdsSize="small"
           onClick={handleClose}
-        >
-          <Icon sdsIcon="xMark" sdsSize="s" sdsType="iconButton" />
-        </StyledButtonIcon>
+          sdsIcon="xMark"
+        />
       )}
     </StyledBanner>
   );

--- a/src/core/Banner/style.ts
+++ b/src/core/Banner/style.ts
@@ -1,6 +1,9 @@
 import { styled } from "@mui/material/styles";
 import ButtonIcon from "../ButtonIcon";
-import { ButtonIconExtraProps } from "../ButtonIcon/style";
+import {
+  ButtonIconExtraProps,
+  ButtonIconSizeToTypes,
+} from "../ButtonIcon/style";
 import {
   CommonThemeProps,
   fontBodyS,
@@ -10,8 +13,10 @@ import {
   getTypography,
 } from "../styles";
 
-export interface BannerExtraProps extends CommonThemeProps {
-  sdsType: "primary" | "secondary";
+export interface BannerExtraProps<
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+> extends CommonThemeProps {
+  sdsType: ButtonIconSizeToTypes[ButtonIconSize];
 }
 
 export const Centered = styled("div")`
@@ -22,7 +27,9 @@ export const Centered = styled("div")`
 `;
 
 export const IconWrapper = styled("div")`
-  ${(props: ButtonIconExtraProps) => {
+  ${<ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+    props: ButtonIconExtraProps<ButtonIconSize>
+  ) => {
     const iconSizes = getIconSizes(props);
     const spaces = getSpaces(props);
 
@@ -33,14 +40,17 @@ export const IconWrapper = styled("div")`
   }}
 `;
 
-type ButtonIconType = ButtonIconExtraProps & { bannerType: string };
+type ButtonIconType<ButtonIconSize extends keyof ButtonIconSizeToTypes> =
+  ButtonIconExtraProps<ButtonIconSize> & { bannerType: string };
 const doNotForwardPropsButtonIcon = ["bannerType"];
 
 export const StyledButtonIcon = styled(ButtonIcon, {
   shouldForwardProp: (prop: string) =>
     !doNotForwardPropsButtonIcon.includes(prop),
 })`
-  ${(props: ButtonIconType) => {
+  ${<ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+    props: ButtonIconType<ButtonIconSize>
+  ) => {
     const spaces = getSpaces(props);
 
     return `
@@ -49,7 +59,9 @@ export const StyledButtonIcon = styled(ButtonIcon, {
     `;
   }}
 
-  ${(props: ButtonIconType) => {
+  ${<ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+    props: ButtonIconType<ButtonIconSize>
+  ) => {
     const { bannerType } = props;
     const colors = getColors(props);
 
@@ -74,7 +86,9 @@ export const Text = styled("div")`
   }}
 `;
 
-const primary = (props: BannerExtraProps) => {
+const primary = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: BannerExtraProps<ButtonIconSize>
+) => {
   const colors = getColors(props);
 
   return `
@@ -86,7 +100,9 @@ const primary = (props: BannerExtraProps) => {
   `;
 };
 
-const secondary = (props: BannerExtraProps) => {
+const secondary = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: BannerExtraProps<ButtonIconSize>
+) => {
   const colors = getColors(props);
 
   return `
@@ -105,7 +121,9 @@ export const StyledBanner = styled("div", {
   height: 40px;
   width: 100%;
 
-  ${(props: BannerExtraProps) => {
+  ${<ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+    props: BannerExtraProps<ButtonIconSize>
+  ) => {
     const { sdsType } = props;
 
     return `

--- a/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
+++ b/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
@@ -2,8 +2,7 @@
 
 exports[`<ButtonIcon /> Test story renders snapshot 1`] = `
 <button
-  aria-label="info"
-  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-1hws01p-MuiButtonBase-root-MuiIconButton-root"
+  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-w1by74-MuiButtonBase-root-MuiIconButton-root"
   data-testid="iconButton"
   tabindex="0"
   type="button"
@@ -14,9 +13,9 @@ exports[`<ButtonIcon /> Test story renders snapshot 1`] = `
     <svg
       aria-hidden="true"
       class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
-      data-jest-file-name="IconSearchLarge.svg"
-      data-jest-svg-name="IconSearchLarge"
-      data-testid="IconSearchLarge"
+      data-jest-file-name="IconDotsHorizontal3Large.svg"
+      data-jest-svg-name="IconDotsHorizontal3Large"
+      data-testid="IconDotsHorizontal3Large"
       fillcontrast="white"
       focusable="false"
       viewBox="0 0 32 32"

--- a/src/core/ButtonIcon/index.stories.tsx
+++ b/src/core/ButtonIcon/index.stories.tsx
@@ -1,24 +1,23 @@
 import { Args, Story } from "@storybook/react";
 import React from "react";
-import Icon from "../Icon";
 import { defaultAppTheme } from "../styles";
-import ButtonIcon from "./index";
+import ButtonIconRaw from "./index";
 
-const Demo = (props: Args): JSX.Element => {
-  const { icon, ...rest } = props;
+const ButtonIcon = (props: Args): JSX.Element => {
+  const { sdsIcon, ...rest } = props;
 
   const [active, setActive] = React.useState(false);
   const handleButtonClick = () => setActive(!active);
 
   return (
-    <ButtonIcon
+    <ButtonIconRaw
       onClick={handleButtonClick}
       active={active}
+      sdsIcon={sdsIcon}
+      sdsSize="medium"
+      sdsType="primary"
       {...rest}
-      size="large"
-    >
-      {icon}
-    </ButtonIcon>
+    />
   );
 };
 
@@ -36,6 +35,21 @@ export default {
       },
       defaultValue: false,
     },
+    sdsIcon: {
+      control: {
+        type: "select",
+      },
+      defaultValue: "dotsHorizontal",
+      options: [
+        "dotsHorizontal",
+        "copy",
+        "download",
+        "people",
+        "treeHorizontal",
+        "grid",
+        "virus",
+      ],
+    },
     sdsSize: {
       control: {
         type: "select",
@@ -51,18 +65,18 @@ export default {
       options: ["primary", "secondary", "tertiary"],
     },
   },
-  component: Demo,
+  component: ButtonIcon,
   title: "ButtonIcon",
 };
 
-const Template: Story = (args) => <Demo {...args} />;
+const Template: Story = (args) => <ButtonIcon {...args} />;
 
 export const Default = Template.bind({});
 
 Default.args = {
   "aria-label": "info",
   disabled: false,
-  icon: <Icon sdsIcon="infoCircle" sdsSize="xl" sdsType="iconButton" />,
+  sdsIcon: "dotsHorizontal",
   sdsSize: "large",
   sdsType: "primary",
 };
@@ -71,16 +85,6 @@ Default.parameters = {
   snapshot: {
     skip: true,
   },
-};
-
-export const Test = Template.bind({});
-
-Test.args = {
-  "aria-label": "info",
-  disabled: false,
-  icon: <Icon sdsIcon="search" sdsSize="xl" sdsType="iconButton" />,
-  sdsSize: "large",
-  sdsType: "secondary",
 };
 
 const LivePreviewDemo = (): JSX.Element => {
@@ -96,97 +100,81 @@ const LivePreviewDemo = (): JSX.Element => {
   return (
     <div style={livePreviewStyles as React.CSSProperties}>
       <div style={{ display: "flex" }}>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.xxs }}
-          icon={<Icon sdsIcon="grid" sdsSize="l" sdsType="iconButton" />}
+          sdsIcon="grid"
           sdsSize="large"
           sdsType="primary"
         />
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.xxs }}
-          icon={<Icon sdsIcon="grid" sdsSize="l" sdsType="iconButton" />}
+          sdsIcon="grid"
           sdsSize="large"
           sdsType="primary"
         />
       </div>
       <div style={{ display: "flex" }}>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.m }}
-          icon={
-            <Icon sdsIcon="infoSpeechBubble" sdsSize="l" sdsType="iconButton" />
-          }
+          sdsIcon="infoSpeechBubble"
           sdsSize="large"
           sdsType="secondary"
         />
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.m }}
-          icon={
-            <Icon sdsIcon="infoSpeechBubble" sdsSize="l" sdsType="iconButton" />
-          }
+          sdsIcon="infoSpeechBubble"
           sdsSize="large"
           sdsType="secondary"
         />
       </div>
       <div>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.m }}
-          icon={<Icon sdsIcon="xMark" sdsSize="l" sdsType="iconButton" />}
+          sdsIcon="xMark"
           sdsSize="large"
           sdsType="tertiary"
         />
       </div>
       <div>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.m }}
-          icon={<Icon sdsIcon="xMark" sdsSize="s" sdsType="iconButton" />}
+          sdsIcon="xMark"
           sdsSize="medium"
           sdsType="tertiary"
         />
       </div>
       <div style={{ display: "flex" }}>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.s }}
-          icon={
-            <Icon
-              sdsIcon="barChartVertical3"
-              sdsSize="s"
-              sdsType="iconButton"
-            />
-          }
+          sdsIcon="barChartVertical3"
           sdsSize="small"
           sdsType="primary"
         />
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.s }}
-          icon={
-            <Icon
-              sdsIcon="barChartVertical3"
-              sdsSize="s"
-              sdsType="iconButton"
-            />
-          }
+          sdsIcon="barChartVertical3"
           sdsSize="small"
           sdsType="primary"
         />
       </div>
       <div style={{ display: "flex" }}>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.s }}
-          icon={<Icon sdsIcon="plusCircle" sdsSize="s" sdsType="iconButton" />}
+          sdsIcon="plusCircle"
           sdsSize="small"
           sdsType="secondary"
         />
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.s }}
-          icon={<Icon sdsIcon="plusCircle" sdsSize="s" sdsType="iconButton" />}
+          sdsIcon="plusCircle"
           sdsSize="small"
           sdsType="secondary"
         />
       </div>
       <div>
-        <Demo
+        <ButtonIcon
           style={{ marginRight: spacings?.s }}
-          icon={<Icon sdsIcon="xMark" sdsSize="s" sdsType="iconButton" />}
+          sdsIcon="xMark"
           sdsSize="small"
           sdsType="tertiary"
         />
@@ -203,3 +191,19 @@ LivePreview.parameters = {
     skip: true,
   },
 };
+
+const TestDemo = (): JSX.Element => {
+  return (
+    <ButtonIconRaw
+      data-testid="iconButton"
+      active
+      sdsIcon="dotsHorizontal"
+      sdsSize="medium"
+      sdsType="primary"
+    />
+  );
+};
+
+const TestTemplate: Story = () => <TestDemo />;
+
+export const Test = TestTemplate.bind({});

--- a/src/core/ButtonIcon/index.tsx
+++ b/src/core/ButtonIcon/index.tsx
@@ -1,18 +1,56 @@
 import { IconButtonProps as RawButtonIconProps } from "@mui/material";
-import React, { forwardRef } from "react";
-import { ButtonIconExtraProps, StyledButtonIcon } from "./style";
+import React, { ForwardedRef, forwardRef } from "react";
+import Icon, { IconNameToSizes, IconProps } from "../Icon";
+import {
+  ButtonIconExtraProps,
+  ButtonIconSizeToTypes,
+  StyledButtonIcon,
+} from "./style";
 
-type ButtonIconProps = ButtonIconExtraProps & RawButtonIconProps;
-
+export type { ButtonIconSizeToTypes };
 export type { ButtonIconProps };
+export interface ButtonIconInternalProps<
+  IconName extends keyof IconNameToSizes
+> {
+  sdsIcon: IconName;
+  sdsIconProps?: Partial<IconProps<IconName>>;
+}
+
+type ButtonIconProps<
+  IconName extends keyof IconNameToSizes,
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+> = ButtonIconExtraProps<ButtonIconSize> &
+  RawButtonIconProps &
+  ButtonIconInternalProps<IconName>;
+
+const ButtonIconSizeToSdsIconSize = {
+  large: "xl",
+  medium: "l",
+  small: "s",
+};
 
 /**
  * @see https://v4.mui.com/components/buttons/#icon-buttons
  */
-const ButtonIcon = forwardRef<HTMLButtonElement | null, ButtonIconProps>(
-  (props, ref): JSX.Element => {
-    return <StyledButtonIcon data-testid="iconButton" {...props} ref={ref} />;
-  }
-);
+const ButtonIcon = forwardRef(function ButtonIcon<
+  IconName extends keyof IconNameToSizes,
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+>(
+  props: ButtonIconProps<IconName, ButtonIconSize>,
+  ref: ForwardedRef<HTMLButtonElement | null>
+): JSX.Element {
+  const { sdsIcon, sdsSize = "large", sdsIconProps } = props;
+  const iconSize = ButtonIconSizeToSdsIconSize[sdsSize];
+  return (
+    <StyledButtonIcon {...props} ref={ref}>
+      <Icon
+        sdsType="iconButton"
+        {...sdsIconProps}
+        sdsIcon={sdsIcon}
+        sdsSize={iconSize as IconNameToSizes[IconName]}
+      />
+    </StyledButtonIcon>
+  );
+});
 
 export default ButtonIcon;

--- a/src/core/ButtonIcon/style.ts
+++ b/src/core/ButtonIcon/style.ts
@@ -2,20 +2,28 @@ import { css, SerializedStyles } from "@emotion/react";
 import { IconButton } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {
-  CommonThemeProps,
-  getColors,
-  getIconSizes,
-  getSpaces,
-} from "../styles";
+  SDSWarningTypes,
+  showWarningIfFirstOccurence,
+} from "src/common/warnings";
+import { CommonThemeProps, getColors, getIconSizes } from "../styles";
 
-export interface ButtonIconExtraProps extends CommonThemeProps {
+export interface ButtonIconSizeToTypes {
+  small: "primary" | "secondary" | "tertiary";
+  medium: "tertiary";
+  large: "primary" | "secondary" | "tertiary";
+}
+export interface ButtonIconExtraProps<
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+> extends CommonThemeProps {
   active?: boolean;
   disabled?: boolean;
-  sdsSize?: "small" | "medium" | "large";
-  sdsType?: "primary" | "secondary" | "tertiary";
+  sdsSize?: ButtonIconSize;
+  sdsType?: ButtonIconSizeToTypes[ButtonIconSize];
 }
 
-const isActive = (props: ButtonIconExtraProps): SerializedStyles => {
+const isActive = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const { sdsType } = props;
   const colors = getColors(props);
 
@@ -33,7 +41,9 @@ const isActive = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const isDisabled = (props: ButtonIconExtraProps): SerializedStyles => {
+const isDisabled = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const colors = getColors(props);
 
   return css`
@@ -41,7 +51,9 @@ const isDisabled = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const primary = (props: ButtonIconExtraProps): SerializedStyles => {
+const primary = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const colors = getColors(props);
   const { sdsSize } = props;
 
@@ -59,7 +71,9 @@ const primary = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const secondary = (props: ButtonIconExtraProps): SerializedStyles => {
+const secondary = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const colors = getColors(props);
 
   return css`
@@ -72,7 +86,9 @@ const secondary = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const tertiary = (props: ButtonIconExtraProps): SerializedStyles => {
+const tertiary = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const colors = getColors(props);
 
   return css`
@@ -89,7 +105,9 @@ const tertiary = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const small = (props: ButtonIconExtraProps): SerializedStyles => {
+const small = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const iconSizes = getIconSizes(props);
 
   return css`
@@ -104,10 +122,21 @@ const small = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const medium = (props: ButtonIconExtraProps): SerializedStyles => {
+const medium = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
+  const { sdsType } = props;
   const iconSizes = getIconSizes(props);
 
+  if (sdsType === "primary" || sdsType === "secondary") {
+    showWarningIfFirstOccurence(SDSWarningTypes.ButtonIconMediumSize);
+  }
+
   return css`
+    &:hover {
+      background: none;
+    }
+
     .MuiSvgIcon-root {
       height: ${iconSizes?.l.height}px;
       width: ${iconSizes?.l.width}px;
@@ -115,13 +144,14 @@ const medium = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const large = (props: ButtonIconExtraProps): SerializedStyles => {
+const large = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+  props: ButtonIconExtraProps<ButtonIconSize>
+): SerializedStyles => {
   const { sdsType } = props;
-  const spacings = getSpaces(props);
   const iconSizes = getIconSizes(props);
 
   return css`
-    padding: ${sdsType === "primary" ? spacings?.xxs : 0}px;
+    ${sdsType === "primary" ? `height: 42px; width: 42px;` : ""}
 
     .MuiSvgIcon-root {
       height: ${iconSizes?.xl.height}px;
@@ -130,14 +160,16 @@ const large = (props: ButtonIconExtraProps): SerializedStyles => {
   `;
 };
 
-const doNotForwardProps = ["active", "sdsSize", "sdsType"];
+const doNotForwardProps = ["active", "sdsSize", "sdsType", "sdsIcon"];
 
 export const StyledButtonIcon = styled(IconButton, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),
 })`
   padding: 0;
 
-  ${(props: ButtonIconExtraProps) => {
+  ${<ButtonIconSize extends keyof ButtonIconSizeToTypes>(
+    props: ButtonIconExtraProps<ButtonIconSize>
+  ) => {
     const { active, disabled, sdsSize, sdsType } = props;
 
     return css`

--- a/src/core/Callout/index.tsx
+++ b/src/core/Callout/index.tsx
@@ -75,13 +75,8 @@ const Callout = ({
           }}
           sdsSize="small"
           sdsType="tertiary"
-        >
-          <Icon
-            sdsIcon={collapsed ? "chevronDown" : "chevronUp"}
-            sdsSize="s"
-            sdsType="button"
-          />
-        </ButtonIcon>
+          sdsIcon={collapsed ? "chevronDown" : "chevronUp"}
+        />
       );
     }
     return onClose ? (
@@ -90,10 +85,8 @@ const Callout = ({
         sdsSize="small"
         sdsType="tertiary"
         size="large"
-      >
-        {" "}
-        <Icon sdsIcon="xMark" sdsSize="s" sdsType="iconButton" />{" "}
-      </ButtonIcon>
+        sdsIcon="xMark"
+      />
     ) : null;
   };
 

--- a/src/core/CellHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/CellHeader/__snapshots__/index.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`<CellHeader /> Test story renders snapshot 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1c9gy53-MuiButtonBase-root-MuiIconButton-root"
-            data-testid="iconButton"
             tabindex="0"
             type="button"
           >

--- a/src/core/CellHeader/index.tsx
+++ b/src/core/CellHeader/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import Icon, { IconNameToSizes } from "../Icon";
+import { IconNameToSizes } from "../Icon";
 import Tooltip, { TooltipProps } from "../Tooltip";
 import {
   CellHeaderExtraProps,
@@ -45,9 +45,12 @@ const CellHeaderContent = (
     direction === "asc" ? "chevronUp" : "chevronDown";
 
   const sortIcon = (
-    <StyledSortingIcon sdsType="tertiary" sdsSize="small" active={active}>
-      <Icon sdsSize="s" sdsIcon={sdsIconName} sdsType="iconButton" />
-    </StyledSortingIcon>
+    <StyledSortingIcon
+      sdsType="tertiary"
+      sdsSize="small"
+      active={active}
+      sdsIcon={sdsIconName}
+    />
   );
 
   return (

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 1`] = `
 >
   <button
     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1f83sro-MuiButtonBase-root-MuiIconButton-root"
-    data-testid="iconButton"
     tabindex="0"
     type="button"
   >
@@ -89,8 +88,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 4`] = `
   id="mui-2"
 >
   <button
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-5pzevu-MuiButtonBase-root-MuiIconButton-root"
-    data-testid="iconButton"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-100qpau-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -171,8 +169,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
   id="mui-3"
 >
   <button
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-d7ftbp-MuiButtonBase-root-MuiIconButton-root"
-    data-testid="iconButton"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1265qs5-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -253,8 +250,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
   id="mui-4"
 >
   <button
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-d7ftbp-MuiButtonBase-root-MuiIconButton-root"
-    data-testid="iconButton"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1265qs5-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >

--- a/src/core/DialogTitle/components/CloseButton/index.tsx
+++ b/src/core/DialogTitle/components/CloseButton/index.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef } from "react";
-import { ButtonIconProps } from "src/core/ButtonIcon";
+import React, { ForwardedRef, forwardRef } from "react";
+import { ButtonIconProps, ButtonIconSizeToTypes } from "src/core/ButtonIcon";
 import { DialogContext } from "src/core/Dialog/components/common";
-import Icon, { IconNameToSizes, IconProps } from "src/core/Icon";
+import { IconNameToSizes } from "src/core/Icon";
 import { StyledButtonIcon } from "./style";
 
 const SDS_SIZE_TO_COMPONENT_SIZE = {
@@ -11,40 +11,30 @@ const SDS_SIZE_TO_COMPONENT_SIZE = {
   xs: "small",
 };
 
-const SDS_SIZE_TO_ICON_SIZE = {
-  l: "xl",
-  m: "xl",
-  s: "l",
-  xs: "s",
-};
+const CloseButton = forwardRef(function CloseButton<
+  IconName extends keyof IconNameToSizes,
+  ButtonIconSize extends keyof ButtonIconSizeToTypes
+>(
+  props: ButtonIconProps<IconName, ButtonIconSize>,
+  ref: ForwardedRef<HTMLButtonElement | null>
+) {
+  return (
+    <DialogContext.Consumer>
+      {({ sdsSize }) => {
+        const size = SDS_SIZE_TO_COMPONENT_SIZE[sdsSize] as ButtonIconSize;
 
-const CloseButton = forwardRef<HTMLButtonElement, ButtonIconProps>(
-  function CloseButton(props, ref) {
-    return (
-      <DialogContext.Consumer>
-        {({ sdsSize }) => {
-          const size = SDS_SIZE_TO_COMPONENT_SIZE[
-            sdsSize
-          ] as ButtonIconProps["sdsSize"];
-
-          const iconSize = SDS_SIZE_TO_ICON_SIZE[sdsSize] as IconProps<
-            keyof IconNameToSizes
-          >["sdsSize"];
-
-          return (
-            <StyledButtonIcon
-              ref={ref}
-              sdsType="tertiary"
-              sdsSize={size}
-              {...props}
-            >
-              <Icon sdsIcon="xMark" sdsSize={iconSize} sdsType="iconButton" />
-            </StyledButtonIcon>
-          );
-        }}
-      </DialogContext.Consumer>
-    );
-  }
-);
+        return (
+          <StyledButtonIcon
+            ref={ref}
+            sdsType="tertiary"
+            sdsSize={size}
+            {...props}
+            sdsIcon="xMark"
+          />
+        );
+      }}
+    </DialogContext.Consumer>
+  );
+});
 
 export default CloseButton;

--- a/src/core/DialogTitle/index.tsx
+++ b/src/core/DialogTitle/index.tsx
@@ -29,7 +29,7 @@ const DialogTitle = forwardRef<HTMLHeadingElement, DialogTitleProps>(
       <StyledDialogTitle ref={ref} {...rest}>
         {children || (
           <>
-            {onClose && <CloseButton onClick={onClose} />}
+            {onClose && <CloseButton sdsIcon="xMark" onClick={onClose} />}
             <Title>{title}</Title>
             <Subtitle>{subtitle}</Subtitle>
           </>

--- a/src/core/DropdownMenu/index.stories.tsx
+++ b/src/core/DropdownMenu/index.stories.tsx
@@ -2,7 +2,6 @@ import { ClickAwayListener, styled } from "@mui/material";
 import { Args, Story } from "@storybook/react";
 import React, { SyntheticEvent, useState } from "react";
 import ButtonIcon from "../ButtonIcon";
-import Icon from "../Icon";
 import InputDropdown from "../InputDropdown";
 import DropdownMenu, { DefaultDropdownMenuOption } from "./index";
 
@@ -255,13 +254,8 @@ const LivePreviewDemo = (): JSX.Element => {
               active={false}
               sdsSize="large"
               sdsType="secondary"
-            >
-              <Icon
-                sdsIcon="infoSpeechBubble"
-                sdsSize="l"
-                sdsType="iconButton"
-              />
-            </ButtonIcon>
+              sdsIcon="infoSpeechBubble"
+            />
 
             <DropdownMenu
               anchorEl={anchorEl2}

--- a/src/core/DropdownMenu/index.tsx
+++ b/src/core/DropdownMenu/index.tsx
@@ -10,7 +10,6 @@ import {
 import React, { SyntheticEvent, useState } from "react";
 import { noop } from "src/common/utils";
 import ButtonIcon from "../ButtonIcon";
-import Icon from "../Icon";
 import { InputSearchProps } from "../InputSearch";
 import {
   InputBaseWrapper,
@@ -158,13 +157,11 @@ export default function DropdownMenu<
                 ...params.InputProps.ref,
                 endAdornment: (
                   <InputAdornment position="end">
-                    <ButtonIcon sdsType="secondary">
-                      <Icon
-                        sdsIcon="search"
-                        sdsSize="s"
-                        sdsType="interactive"
-                      />
-                    </ButtonIcon>
+                    <ButtonIcon
+                      sdsType="secondary"
+                      sdsSize="small"
+                      sdsIcon="search"
+                    />
                   </InputAdornment>
                 ),
                 inputProps: params.inputProps,

--- a/src/core/InputSearch/index.tsx
+++ b/src/core/InputSearch/index.tsx
@@ -4,7 +4,6 @@ import {
 } from "@mui/material";
 import React, { forwardRef, useState } from "react";
 import ButtonIcon from "../ButtonIcon";
-import Icon from "../Icon";
 import { InputSearchExtraProps, StyledLabel, StyledSearchBase } from "./style";
 
 export interface AccessibleInputSearchProps {
@@ -77,10 +76,12 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
                   aria-label="search-button"
                   onClick={localHandleSubmit}
                   sdsType="secondary"
-                  size="large"
-                >
-                  <Icon sdsIcon="search" sdsSize="s" sdsType="interactive" />
-                </ButtonIcon>
+                  sdsSize="small"
+                  sdsIconProps={{
+                    sdsType: "interactive",
+                  }}
+                  sdsIcon="search"
+                />
               </InputAdornment>
             ),
           }}

--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -15,7 +15,6 @@ import {
   showWarningIfFirstOccurence,
 } from "src/common/warnings";
 import ButtonIcon from "../ButtonIcon";
-import Icon from "../Icon";
 import { InputSearchProps } from "../InputSearch";
 import {
   InputBaseWrapper,
@@ -115,9 +114,14 @@ export default function MenuSelect<
               ...params.InputProps.ref,
               endAdornment: (
                 <InputAdornment position="end">
-                  <ButtonIcon sdsType="secondary" size="large">
-                    <Icon sdsIcon="search" sdsSize="s" sdsType="interactive" />
-                  </ButtonIcon>
+                  <ButtonIcon
+                    sdsType="secondary"
+                    sdsSize="small"
+                    sdsIconProps={{
+                      sdsType: "interactive",
+                    }}
+                    sdsIcon="search"
+                  />
                 </InputAdornment>
               ),
               inputProps: params.inputProps,

--- a/src/core/Notification/index.tsx
+++ b/src/core/Notification/index.tsx
@@ -86,11 +86,8 @@ const Notification = ({
                   sdsSize="small"
                   sdsType="tertiary"
                   data-testid="notificationCloseButton"
-                  size="large"
-                >
-                  {" "}
-                  <Icon sdsIcon="xMark" sdsSize="s" sdsType="iconButton" />{" "}
-                </ButtonIcon>
+                  sdsIcon="xMark"
+                />
               ) : null
             }
             icon={getIcon()}

--- a/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1c9gy53-MuiButtonBase-root-MuiIconButton-root"
-            data-testid="iconButton"
             tabindex="0"
             type="button"
           >
@@ -55,7 +54,6 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-xhp77i-MuiButtonBase-root-MuiIconButton-root"
-            data-testid="iconButton"
             tabindex="0"
             type="button"
           >
@@ -90,7 +88,6 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
           </span>
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-xhp77i-MuiButtonBase-root-MuiIconButton-root"
-            data-testid="iconButton"
             tabindex="0"
             type="button"
           >

--- a/src/core/Tooltip/index.stories.tsx
+++ b/src/core/Tooltip/index.stories.tsx
@@ -3,7 +3,6 @@ import { Args, Story } from "@storybook/react";
 import React from "react";
 import Button from "../Button";
 import ButtonIcon from "../ButtonIcon";
-import Icon from "../Icon";
 import Tooltip from "./index";
 
 const Demo = (props: Args): JSX.Element => {
@@ -104,9 +103,11 @@ const LivePreviewDemo = (): JSX.Element => {
   return (
     <div style={livePreviewStyles as React.CSSProperties}>
       <Tooltip title="Label lorem" sdsStyle="dark" placement="top" arrow open>
-        <ButtonIcon sdsType="secondary" sdsSize="large">
-          <Icon sdsIcon="infoSpeechBubble" sdsSize="xl" sdsType="iconButton" />
-        </ButtonIcon>
+        <ButtonIcon
+          sdsType="secondary"
+          sdsSize="large"
+          sdsIcon="infoSpeechBubble"
+        />
       </Tooltip>
       <Tooltip
         title="Label lorem ipsum tellus ac cursus commodo, tortor mauris."


### PR DESCRIPTION
BREAKING CHANGE: ButtonIcon will not accept children anymore; the icon name should be sent as a `sdsIcon` prop to the ButtonIcon component.

## Summary

**ButtonIcon**
Shortcut ticket: [sh-223306](https://app.shortcut.com/sci-design-system/story/223306/fix-iconbutton-component)

Slack issue link:
https://czi-sci.slack.com/archives/C032S43KKFV/p1664822160586109

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
