### PR TITLE
feat(banner): remove text prop and add children

### DIFF
--- a/src/core/Banner/__snapshots__/banner.test.tsx.snap
+++ b/src/core/Banner/__snapshots__/banner.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
   style="padding: 24px; width: 600px;"
 >
   <div
-    class="css-9mzx1i"
+    class="css-1v3i1xe"
     role="banner"
   >
     <div
@@ -29,11 +29,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
           />
         </div>
       </div>
-      <div
-        class="css-1xpysbw"
-      >
-        Banner text lorem ipsum dolor mit
-      </div>
+      Banner text lorem ipsum dolor mit
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-reo6um-MuiButtonBase-root-MuiIconButton-root"
@@ -64,7 +60,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
     style="height: 24px;"
   />
   <div
-    class="css-1x062lx"
+    class="css-1doigm5"
     role="banner"
   >
     <div
@@ -88,11 +84,16 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
           />
         </div>
       </div>
+      Banner text lorem ipsum dolor mit
       <div
-        class="css-1xpysbw"
+        style="padding: 5px;"
+      />
+      <a
+        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineNone css-otz8ol-MuiTypography-root-MuiLink-root"
+        href="/"
       >
-        Banner text lorem ipsum dolor mit
-      </div>
+        Learn More
+      </a>
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-quxuam-MuiButtonBase-root-MuiIconButton-root"
@@ -123,7 +124,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
     style="height: 24px;"
   />
   <div
-    class="css-yd06ia"
+    class="css-n7miuv"
     role="banner"
   >
     <div
@@ -147,11 +148,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
           />
         </div>
       </div>
-      <div
-        class="css-1xpysbw"
-      >
-        Stylable. Should have pink background color
-      </div>
+      Stylable. Should have pink background color
     </div>
     <button
       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-reo6um-MuiButtonBase-root-MuiIconButton-root"
@@ -183,8 +180,9 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
 
 exports[`<Banner /> Test story renders snapshot 1`] = `
 <div
-  class="css-9mzx1i"
+  class="css-1v3i1xe"
   role="banner"
+  text="test text"
 >
   <div
     class="css-1879pua"
@@ -206,11 +204,6 @@ exports[`<Banner /> Test story renders snapshot 1`] = `
           viewBox="0 0 32 32"
         />
       </div>
-    </div>
-    <div
-      class="css-1xpysbw"
-    >
-      test text
     </div>
   </div>
   <button

--- a/src/core/Banner/banner.test.tsx
+++ b/src/core/Banner/banner.test.tsx
@@ -19,7 +19,7 @@ describe("<Banner />", () => {
 
   it("renders text given to it", () => {
     const text = "this is a test component";
-    render(<Test {...Test.args} text={text} />);
+    render(<Test {...Test.args} children={text} />);
     const bannerText = screen.getByText(text);
     expect(bannerText).not.toBeNull();
   });

--- a/src/core/Banner/index.stories.tsx
+++ b/src/core/Banner/index.stories.tsx
@@ -1,13 +1,18 @@
 import { styled } from "@mui/material/styles";
 import { Args, Story } from "@storybook/react";
 import React from "react";
+import Link from "../Link";
 import Banner from "./index";
 
 const BANNER_TEXT = "Banner text lorem ipsum dolor mit";
 
 const Demo = (props: Args): JSX.Element => {
-  const { sdsType, text } = props;
-  return <Banner sdsType={sdsType} text={text} {...props} />;
+  const { children, sdsType } = props;
+  return (
+    <Banner sdsType={sdsType} {...props}>
+      {children}
+    </Banner>
+  );
 };
 
 export default {
@@ -55,14 +60,21 @@ const StyledBanner = styled(Banner)`
 const LivePreviewDemo = (): JSX.Element => {
   return (
     <div style={{ padding: "24px", width: "600px" }}>
-      <Banner dismissible sdsType="primary" text={BANNER_TEXT} />
+      <Banner dismissible sdsType="primary">
+        {BANNER_TEXT}
+      </Banner>
       <div style={{ height: "24px" }} />
-      <Banner dismissible sdsType="secondary" text={BANNER_TEXT} />
+      <Banner dismissible sdsType="secondary">
+        {BANNER_TEXT}
+        <div style={{ padding: 5 }} />
+        <Link href="/" sdsStyle="default">
+          Learn More
+        </Link>
+      </Banner>
       <div style={{ height: "24px" }} />
-      <StyledBanner
-        sdsType="primary"
-        text="Stylable. Should have pink background color"
-      />
+      <StyledBanner sdsType="primary">
+        Stylable. Should have pink background color
+      </StyledBanner>
     </div>
   );
 };

--- a/src/core/Banner/index.tsx
+++ b/src/core/Banner/index.tsx
@@ -6,28 +6,20 @@ import {
   IconWrapper,
   StyledBanner,
   StyledButtonIcon,
-  Text,
 } from "./style";
 
 export interface BannerProps extends BannerExtraProps {
+  children: React.ReactNode;
   dismissed?: boolean;
   dismissible?: boolean;
   onClose?: (e: React.MouseEvent) => void;
-  text: string;
 }
 
 const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
   props,
   ref
 ): JSX.Element | null {
-  const {
-    dismissed,
-    dismissible = true,
-    onClose,
-    sdsType,
-    text,
-    ...rest
-  } = props;
+  const { dismissed, dismissible = true, onClose, sdsType, ...rest } = props;
 
   const [wasDismissed, setWasDismissed] = useState<boolean>(false);
 
@@ -47,7 +39,7 @@ const Banner = forwardRef<HTMLDivElement, BannerProps>(function Banner(
         <IconWrapper>
           <Icon sdsIcon="infoCircle" sdsSize="l" sdsType="static" />
         </IconWrapper>
-        <Text>{text}</Text>
+        {props.children}
       </Centered>
       {dismissible && (
         <StyledButtonIcon

--- a/src/core/Banner/style.ts
+++ b/src/core/Banner/style.ts
@@ -104,13 +104,15 @@ export const StyledBanner = styled("div", {
   align-items: center;
   height: 40px;
   width: 100%;
-
+  ${fontBodyS}
   ${(props: BannerExtraProps) => {
     const { sdsType } = props;
+    const typography = getTypography(props);
 
     return `
       ${sdsType === "primary" ? primary(props) : ""}
       ${sdsType === "secondary" ? secondary(props) : ""}
+      font-family: ${typography?.fontFamily};
     `;
   }}
 `;


### PR DESCRIPTION
BREAKING CHANGE: the banner component no longer accepts a text prop. This can be fixed by changing the text to be a child of the banner component

## Summary

**Banner**
Shortcut ticket: [sh-226199](https://app.shortcut.com/sci-design-system/story/226199/add-child-to-banner)
CZ Gen Epi wants to add a banner that includes a link. Currently the banner requires a text prop and does not accept children. As a result it isn't possible to include a link. Would SDS be open to a PR that would make it possible to pass a child component instead of text?

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
