### PR TITLE
feat(github): use a Personal Access Token in GitHub deploy workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_AND_TESTS }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs-build # The folder that the build-storybook script generates files.
           CLEAN: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
use a Personal Access Token in GitHub deploy workflow to enable triggering the deployment_status event and run the storybook_test workflow afterwards
