### PR TITLE
refactor(accordion): add forwardRef to Accordion + Fix data-testId

### DIFF
--- a/src/core/Accordion/index.stories.tsx
+++ b/src/core/Accordion/index.stories.tsx
@@ -2,12 +2,17 @@ import { Args, Story } from "@storybook/react";
 import React from "react";
 import AccordionDetails from "./components/AccordionDetails";
 import AccordionHeader from "./components/AccordionHeader";
-import Accordion from "./index";
+import RawAccordion from "./index";
 
-const Template: Story = (props: Args) => {
+const Accordion = (props: Args): JSX.Element => {
   const { id, subtitle, useDivider, togglePosition } = props;
   return (
-    <Accordion id={id} useDivider={useDivider} togglePosition={togglePosition}>
+    <RawAccordion
+      id={id}
+      useDivider={useDivider}
+      togglePosition={togglePosition}
+      {...props}
+    >
       <AccordionHeader id={id} subtitle={subtitle}>
         Accordion Header
       </AccordionHeader>
@@ -15,9 +20,11 @@ const Template: Story = (props: Args) => {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
         malesuada lacus ex, sit amet blandit leo lobortis eget.
       </AccordionDetails>
-    </Accordion>
+    </RawAccordion>
   );
 };
+
+const Template: Story = (props) => <Accordion {...props} />;
 
 export default {
   argTypes: {
@@ -53,7 +60,11 @@ Default.args = {
   togglePosition: "right",
 };
 
-export const Test = Template.bind({});
+const TestTemplate: Story = (props) => (
+  <Accordion {...props} data-testid="accordion" />
+);
+
+export const Test = TestTemplate.bind({});
 
 Test.args = {
   id: "test-story",

--- a/src/core/Accordion/index.tsx
+++ b/src/core/Accordion/index.tsx
@@ -7,28 +7,30 @@ export type AccordionProps = RawAccordionProps & AccordionExtraProps;
 /**
  * @see https://v4.mui.com/components/accordion/
  */
-const Accordion = (props: AccordionProps) => {
-  const { children, useDivider, togglePosition = "right", id } = props;
-  const [expanded, setExpanded] = React.useState<string | false>(false);
+const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+  (props, ref) => {
+    const { children, useDivider, togglePosition = "right", id } = props;
+    const [expanded, setExpanded] = React.useState<string | false>(false);
 
-  const handleChange =
-    (panel: string) =>
-    (_event: React.ChangeEvent<unknown>, isExpanded: boolean) => {
-      setExpanded(isExpanded ? panel : false);
-    };
-  return (
-    <StyledAccordion
-      id={id}
-      square
-      useDivider={useDivider}
-      togglePosition={togglePosition}
-      expanded={expanded === id}
-      onChange={handleChange(id)}
-      data-testid="accordion"
-    >
-      {children}
-    </StyledAccordion>
-  );
-};
+    const handleChange =
+      (panel: string) =>
+      (_event: React.ChangeEvent<unknown>, isExpanded: boolean) => {
+        setExpanded(isExpanded ? panel : false);
+      };
+    return (
+      <StyledAccordion
+        square
+        useDivider={useDivider}
+        togglePosition={togglePosition}
+        expanded={expanded === id}
+        onChange={handleChange(id)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </StyledAccordion>
+    );
+  }
+);
 
 export default Accordion;


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-224676](https://app.shortcut.com/sci-design-system/story/224676/remove-data-testid-from-index-files)

Right now, data-testid is sometimes included in the index file of components and is then always present whenever that component is used. It should only be used in the test file. We need to remove it from index files and add it to test files where needed.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
