### PR TITLE
refactor(tabs): change width to 150px in live preview

### DIFF
--- a/src/core/Tabs/index.stories.tsx
+++ b/src/core/Tabs/index.stories.tsx
@@ -90,7 +90,7 @@ const livePreviewWrapperStyle: React.CSSProperties = {
 function LivePreviewDemo(props: Args): JSX.Element {
   const finalProps = {
     ...props,
-    style: { width: "250px" },
+    style: { width: "150px" },
   };
 
   return (
@@ -117,7 +117,6 @@ function LivePreviewDemo(props: Args): JSX.Element {
           {...finalProps}
         />
       </div>
-      <div />
       <div>
         <Template
           sdsSize="small"


### PR DESCRIPTION
## Summary

**Tabs**
Shortcut ticket: [sh-210651](https://app.shortcut.com/sci-design-system/story/210651/reduce-width-of-tabs-live-previews-in-storybook)

Currently each Tabs component that is in the live preview story in Storybook is 250px wide; they should be 120px so they all fit on the screen in Zeroheight.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
