### PR TITLE
fix(dropdown): dropdown triggers onChange unnecessarily when the pare…

### DIFF
--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -89,9 +89,8 @@ const Dropdown = <Multiple extends boolean | undefined = false>({
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  const [value, setValue] = useState<
-    Value<DefaultDropdownMenuOption, Multiple>
-  >(getInitialValue());
+  const [value, setValue] =
+    useState<Value<DefaultDropdownMenuOption, Multiple>>(getInitialValue);
 
   const [pendingValue, setPendingValue] = useState<
     Value<DefaultDropdownMenuOption, true>


### PR DESCRIPTION
closes #270 

…nt re-renders

Dropdown has a useState that calls `getInitialValue` incorrectly, which caused the unnecessary onChange() calls

## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Shortcut ticket: [sh-XXXX](link)

My bad! I forgot that the state initializing function shouldn't be invoked in the `useState()` call, otherwise it will recreate the initial state with every render 🤦  

Explicitly,

```ts
// GOOD
const [value, setValue] = useState(getInitialValue); // this only invokes `getInitialValue()` once

// BAD
const [value, setValue] = useState(getInitialValue()); // notice that this invokes `getInitialValue()` every time
```

[React doc](https://beta.reactjs.org/apis/react/useState#avoiding-recreating-the-initial-state)

This subtle difference causes a huge side effect down the stream because `getInitialValue()` initializes a new empty array by default, so every time the parent re-renders, it re-renders Dropdown, and invokes `getInitialValue()`, which creates a new array, which triggers another `useEffect()` that listens to the value change from one empty array to the new empty array, thus triggering `onChange()` every time



https://github.com/chanzuckerberg/sci-components/pull/270

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
