### PR TITLE
style(buttonicon): fix primary buttonIcon size

### DIFF
--- a/src/core/ButtonIcon/style.ts
+++ b/src/core/ButtonIcon/style.ts
@@ -152,6 +152,7 @@ const large = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
 
   return css`
     .MuiSvgIcon-root {
+      box-sizing: content-box;
       height: ${iconSizes?.xl.height}px;
       width: ${iconSizes?.xl.height}px;
       ${sdsType === "primary" ? `padding: 5px;` : ""}

--- a/src/core/ButtonIcon/style.ts
+++ b/src/core/ButtonIcon/style.ts
@@ -152,10 +152,9 @@ const large = <ButtonIconSize extends keyof ButtonIconSizeToTypes>(
 
   return css`
     .MuiSvgIcon-root {
-      box-sizing: content-box;
       height: ${iconSizes?.xl.height}px;
       width: ${iconSizes?.xl.height}px;
-      ${sdsType === "primary" ? `padding: 5px;` : ""}
+      ${sdsType === "primary" ? `margin: 5px;` : ""}
     }
   `;
 };

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-13pwrar-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-dw2tn7-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -248,7 +248,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-13pwrar-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-dw2tn7-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-dw2tn7-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-13pwrar-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -248,7 +248,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-dw2tn7-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-13pwrar-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >


### PR DESCRIPTION
A 'box-sizing' of 'content-box' resolved the primary ButtonIcon's size issue.