### PR TITLE
fix(tag): fix the type error for the hover prop of the tag component

### DIFF
--- a/src/core/Tag/index.stories.tsx
+++ b/src/core/Tag/index.stories.tsx
@@ -5,18 +5,9 @@ import Icon from "../Icon";
 import Tag from "./index";
 
 const Demo = (props: Args): JSX.Element => {
-  const { color, icon, label, sdsStyle, sdsType } = props;
+  const { label } = props;
 
-  return (
-    <Tag
-      color={color}
-      icon={icon}
-      label={label}
-      sdsStyle={sdsStyle}
-      sdsType={sdsType}
-      {...props}
-    />
-  );
+  return <Tag label={label} {...props} />;
 };
 
 const customColorTuples = {

--- a/src/core/Tag/style.ts
+++ b/src/core/Tag/style.ts
@@ -231,7 +231,7 @@ const typeToCss = {
   secondary,
 };
 
-const doNotForwardProps = ["sdsType", "sdsStyle", "tagColor"];
+const doNotForwardProps = ["sdsType", "sdsStyle", "tagColor", "hover"];
 
 export const StyledTag = styled(Chip, {
   shouldForwardProp: (prop) => !doNotForwardProps.includes(prop as string),


### PR DESCRIPTION
## Summary

**Tag**
Github ticket: #352 

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
