### PR TITLE
feat(minimal inputdropdown): update Minimal Dropdown Style

### DIFF
--- a/src/core/Accordion/__snapshots__/index.test.tsx.snap
+++ b/src/core/Accordion/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<Accordion /> Test story renders snapshot 1`] = `
       class="MuiAccordionSummary-expandIconWrapper css-yw020d-MuiAccordionSummary-expandIconWrapper"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"

--- a/src/core/Banner/__snapshots__/banner.test.tsx.snap
+++ b/src/core/Banner/__snapshots__/banner.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
         class="css-1f3aume"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -38,7 +38,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
       type="button"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -70,7 +70,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
         class="css-1f3aume"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -102,7 +102,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
       type="button"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -134,7 +134,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
         class="css-1f3aume"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -157,7 +157,7 @@ exports[`<Banner /> LivePreview story renders snapshot 1`] = `
       type="button"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -190,7 +190,7 @@ exports[`<Banner /> Test story renders snapshot 1`] = `
       class="css-1f3aume"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -213,7 +213,7 @@ exports[`<Banner /> Test story renders snapshot 1`] = `
     type="button"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"

--- a/src/core/Button/__snapshots__/index.test.tsx.snap
+++ b/src/core/Button/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<button /> MinimalLivePreview story renders snapshot 1`] = `
       class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -78,7 +78,7 @@ exports[`<button /> RoundedLivePreview story renders snapshot 1`] = `
       class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -116,7 +116,7 @@ exports[`<button /> RoundedLivePreview story renders snapshot 1`] = `
       class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -161,7 +161,7 @@ exports[`<button /> SquareLivePreview story renders snapshot 1`] = `
       class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -199,7 +199,7 @@ exports[`<button /> SquareLivePreview story renders snapshot 1`] = `
       class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"

--- a/src/core/ButtonDropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/ButtonDropdown/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<ButtonDropdown /> Test story renders snapshot 1`] = `
     class="MuiButton-startIcon MuiButton-iconSizeMedium css-1d6wzja-MuiButton-startIcon"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"
@@ -31,7 +31,7 @@ exports[`<ButtonDropdown /> Test story renders snapshot 1`] = `
     class="MuiButton-endIcon MuiButton-iconSizeMedium css-9tj150-MuiButton-endIcon"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"

--- a/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
+++ b/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<ButtonIcon /> Test story renders snapshot 1`] = `
   type="button"
 >
   <div
-    class="css-jbvua0"
+    class="css-1ft6wgl"
   >
     <svg
       aria-hidden="true"

--- a/src/core/CellBasic/__snapshots__/index.test.tsx.snap
+++ b/src/core/CellBasic/__snapshots__/index.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`<CellBasic /> Test story renders snapshot 1`] = `
             class="css-fm7ypo"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"

--- a/src/core/CellHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/CellHeader/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<CellHeader /> Ascending story renders snapshot 1`] = `
             type="button"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"
@@ -67,7 +67,7 @@ exports[`<CellHeader /> Test story renders snapshot 1`] = `
             type="button"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"

--- a/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
+    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-4n1h51-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"
@@ -14,7 +14,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
       class="css-t2kylo"
     >
       <span
-        class="styled-label css-1sjvubj"
+        class="styled-label css-1wq753n"
       >
         Click Target
       </span>
@@ -34,7 +34,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
       </div>
     </span>
     <div
-      class="css-194gbul"
+      class="css-z8cnb2"
     />
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,30 +5,37 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-6o30iu-MuiButtonBase-root-MuiButton-root"
+    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"
   >
     <span
-      class="css-1sjvubj"
+      class="css-t2kylo"
     >
-      Click Target
+      <span
+        class="styled-label css-1sjvubj"
+      >
+        Click Target
+      </span>
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+          data-jest-file-name="IconChevronDownSmall.svg"
+          data-jest-svg-name="IconChevronDownSmall"
+          data-testid="IconChevronDownSmall"
+          fillcontrast="white"
+          focusable="false"
+          viewBox="0 0 14 14"
+        />
+      </div>
     </span>
     <div
-      class="css-jbvua0"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
-        data-jest-file-name="IconChevronDownSmall.svg"
-        data-jest-svg-name="IconChevronDownSmall"
-        data-testid="IconChevronDownSmall"
-        fillcontrast="white"
-        focusable="false"
-        viewBox="0 0 14 14"
-      />
-    </div>
+      class="css-194gbul"
+    />
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />

--- a/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-4n1h51-MuiButtonBase-root-MuiButton-root"
+    class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"

--- a/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 1`] = `
     type="button"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"
@@ -93,7 +93,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 4`] = `
     type="button"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"
@@ -173,7 +173,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
     type="button"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"
@@ -253,7 +253,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
     type="button"
   >
     <div
-      class="css-jbvua0"
+      class="css-1ft6wgl"
     >
       <svg
         aria-hidden="true"

--- a/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Test story renders snapshot 1`] = `
 <button
-  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
+  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-4n1h51-MuiButtonBase-root-MuiButton-root"
   data-testid="dropdown"
   label="Click Target"
   tabindex="0"
@@ -12,7 +12,7 @@ exports[`<Dropdown /> Test story renders snapshot 1`] = `
     class="css-t2kylo"
   >
     <span
-      class="styled-label css-1sjvubj"
+      class="styled-label css-1wq753n"
     >
       Click Target
     </span>
@@ -32,7 +32,7 @@ exports[`<Dropdown /> Test story renders snapshot 1`] = `
     </div>
   </span>
   <div
-    class="css-194gbul"
+    class="css-z8cnb2"
   />
   <span
     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"

--- a/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,31 +2,38 @@
 
 exports[`<Dropdown /> Test story renders snapshot 1`] = `
 <button
-  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-6o30iu-MuiButtonBase-root-MuiButton-root"
+  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
   data-testid="dropdown"
   label="Click Target"
   tabindex="0"
   type="button"
 >
   <span
-    class="css-1sjvubj"
+    class="css-t2kylo"
   >
-    Click Target
+    <span
+      class="styled-label css-1sjvubj"
+    >
+      Click Target
+    </span>
+    <div
+      class="css-1ft6wgl"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+        data-jest-file-name="IconChevronDownSmall.svg"
+        data-jest-svg-name="IconChevronDownSmall"
+        data-testid="IconChevronDownSmall"
+        fillcontrast="white"
+        focusable="false"
+        viewBox="0 0 14 14"
+      />
+    </div>
   </span>
   <div
-    class="css-jbvua0"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
-      data-jest-file-name="IconChevronDownSmall.svg"
-      data-jest-svg-name="IconChevronDownSmall"
-      data-testid="IconChevronDownSmall"
-      fillcontrast="white"
-      focusable="false"
-      viewBox="0 0 14 14"
-    />
-  </div>
+    class="css-194gbul"
+  />
   <span
     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
   />

--- a/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Test story renders snapshot 1`] = `
 <button
-  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-4n1h51-MuiButtonBase-root-MuiButton-root"
+  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-je8px9-MuiButtonBase-root-MuiButton-root"
   data-testid="dropdown"
   label="Click Target"
   tabindex="0"

--- a/src/core/DropdownMenu/__snapshots__/index.test.tsx.snap
+++ b/src/core/DropdownMenu/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
     class="css-112kt0x"
   >
     <span
-      class="styled-label css-1sjvubj"
+      class="styled-label css-1wq753n"
     >
       Click Target
     </span>

--- a/src/core/DropdownMenu/__snapshots__/index.test.tsx.snap
+++ b/src/core/DropdownMenu/__snapshots__/index.test.tsx.snap
@@ -2,30 +2,34 @@
 
 exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-1ptdbw3-MuiButtonBase-root-MuiButton-root"
+  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-1t6yh93-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"
 >
   <span
-    class="css-1sjvubj"
+    class="css-112kt0x"
   >
-    Click Target
+    <span
+      class="styled-label css-1sjvubj"
+    >
+      Click Target
+    </span>
+    <div
+      class="css-1ft6wgl"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+        data-jest-file-name="IconChevronDownSmall.svg"
+        data-jest-svg-name="IconChevronDownSmall"
+        data-testid="IconChevronDownSmall"
+        fillcontrast="white"
+        focusable="false"
+        viewBox="0 0 14 14"
+      />
+    </div>
   </span>
-  <div
-    class="css-jbvua0"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
-      data-jest-file-name="IconChevronDownSmall.svg"
-      data-jest-svg-name="IconChevronDownSmall"
-      data-testid="IconChevronDownSmall"
-      fillcontrast="white"
-      focusable="false"
-      viewBox="0 0 14 14"
-    />
-  </div>
   <span
     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
   />

--- a/src/core/Icon/style.ts
+++ b/src/core/Icon/style.ts
@@ -91,5 +91,6 @@ export const StyledSvgIcon = styled(SvgIcon, {
 `;
 
 export const StyledIcon = styled("div")`
+  /* display: contents causes an element's children to appear as if they were direct children of the element's parent, ignoring the element itself. This can be useful when a wrapper element should be ignored when using CSS grid or similar layout techniques. */
   display: contents;
 `;

--- a/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -2,31 +2,35 @@
 
 exports[`<InputDropdown /> Test story renders snapshot 1`] = `
 <button
-  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-160ufda-MuiButtonBase-root-MuiButton-root"
+  class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root css-18rcnae-MuiButtonBase-root-MuiButton-root"
   data-testid="InputDropdown"
   label="Label"
   tabindex="0"
   type="button"
 >
   <span
-    class="css-1sjvubj"
+    class="css-112kt0x"
   >
-    Label
+    <span
+      class="styled-label css-1sjvubj"
+    >
+      Label
+    </span>
+    <div
+      class="css-1ft6wgl"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+        data-jest-file-name="IconChevronDownSmall.svg"
+        data-jest-svg-name="IconChevronDownSmall"
+        data-testid="IconChevronDownSmall"
+        fillcontrast="white"
+        focusable="false"
+        viewBox="0 0 14 14"
+      />
+    </div>
   </span>
-  <div
-    class="css-jbvua0"
-  >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
-      data-jest-file-name="IconChevronDownSmall.svg"
-      data-jest-svg-name="IconChevronDownSmall"
-      data-testid="IconChevronDownSmall"
-      fillcontrast="white"
-      focusable="false"
-      viewBox="0 0 14 14"
-    />
-  </div>
   <span
     class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
   />

--- a/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<InputDropdown /> Test story renders snapshot 1`] = `
     class="css-112kt0x"
   >
     <span
-      class="styled-label css-1sjvubj"
+      class="styled-label css-1wq753n"
     >
       Label
     </span>

--- a/src/core/InputDropdown/index.stories.tsx
+++ b/src/core/InputDropdown/index.stories.tsx
@@ -6,7 +6,10 @@ import InputDropdown from "./index";
 
 const StyledInputDropdown = styled(InputDropdown)`
   ${({ width }: Args) => {
-    return `width: ${width || 160}px;`;
+    return `
+      width: fit-content;
+      max-width: ${width || 160}px;
+    `;
   }}
 `;
 
@@ -179,6 +182,8 @@ Default.parameters = {
 };
 
 const storyRow = {
+  // lprins: This prevents InputDropdown component from stretching height in grid
+  alignItems: "start",
   display: "grid",
   gridColumnGap: "24px",
   gridTemplateColumns: "repeat(3, 160px)",

--- a/src/core/InputDropdown/index.stories.tsx
+++ b/src/core/InputDropdown/index.stories.tsx
@@ -5,7 +5,9 @@ import DropdownMenu from "../DropdownMenu";
 import InputDropdown from "./index";
 
 const StyledInputDropdown = styled(InputDropdown)`
-  width: 160px;
+  ${({ width }: Args) => {
+    return `width: ${width || 160}px;`;
+  }}
 `;
 
 const Demo = (props: Args): JSX.Element => {
@@ -60,7 +62,7 @@ const Demo = (props: Args): JSX.Element => {
   return (
     <>
       {fullWidth ? (
-        <StyledInputDropdown
+        <InputDropdown
           disabled={disabled}
           label={label}
           onClick={handleClick}
@@ -71,7 +73,7 @@ const Demo = (props: Args): JSX.Element => {
           {...rest}
         />
       ) : (
-        <InputDropdown
+        <StyledInputDropdown
           disabled={disabled}
           label={label}
           onClick={handleClick}
@@ -101,32 +103,58 @@ const Demo = (props: Args): JSX.Element => {
 export default {
   argTypes: {
     counter: {
-      control: { type: "number" },
+      control: {
+        type: "number",
+      },
     },
     details: {
-      control: { type: "text" },
+      control: {
+        type: "text",
+      },
     },
     disabled: {
-      control: { type: "boolean" },
+      control: {
+        type: "boolean",
+      },
     },
     intent: {
-      control: { type: "radio" },
+      control: {
+        type: "radio",
+      },
       options: ["default", "error", "warning"],
     },
     label: {
-      control: { type: "text" },
+      control: {
+        type: "text",
+      },
     },
     sdsStage: {
-      control: { type: "radio" },
+      control: {
+        type: "radio",
+      },
       options: ["default", "userInput"],
     },
     sdsStyle: {
-      control: { type: "select" },
+      control: {
+        type: "select",
+      },
       options: ["square", "rounded", "minimal"],
     },
     sdsType: {
-      control: { type: "radio" },
+      control: {
+        type: "radio",
+      },
       options: ["singleSelect", "multiSelect"],
+    },
+    shouldTruncateMinimalDetails: {
+      control: {
+        type: "boolean",
+      },
+    },
+    width: {
+      control: {
+        type: "number",
+      },
     },
   },
   component: Demo,
@@ -222,12 +250,33 @@ const MinimalLivePreviewDemo = (props: Args): JSX.Element => {
   const { sdsStyle, ...rest } = props;
 
   return (
-    <Template
-      sdsType="singleSelect"
-      sdsStyle={sdsStyle}
-      label="Label"
-      {...rest}
-    />
+    <div style={storyRow as React.CSSProperties}>
+      <Template
+        sdsType="singleSelect"
+        sdsStyle={sdsStyle}
+        label="Label"
+        {...rest}
+      />
+
+      {/* Details */}
+      <Template
+        sdsType="singleSelect"
+        sdsStyle={sdsStyle}
+        label="Label"
+        details="Very looooooong details"
+        {...rest}
+      />
+
+      {/* shouldTruncateMinimalDetails */}
+      <Template
+        sdsType="singleSelect"
+        sdsStyle={sdsStyle}
+        label="Label"
+        details="Very looooooong details"
+        shouldTruncateMinimalDetails
+        {...rest}
+      />
+    </div>
   );
 };
 

--- a/src/core/InputDropdown/index.tsx
+++ b/src/core/InputDropdown/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import Icon from "../Icon";
 import {
   InputDropdownProps,
+  LabelWrapper,
+  MinimalDetails,
   StyledCounter,
   StyledDetail,
   StyledInputDropdown,
@@ -14,7 +16,17 @@ export type { InputDropdownProps };
  * @see https://mui.com/material-ui/react-button/
  */
 const InputDropdown = (props: InputDropdownProps): JSX.Element => {
-  const { label, open, sdsType, details, counter } = props;
+  const {
+    label,
+    open,
+    sdsType,
+    sdsStyle,
+    details,
+    counter,
+    shouldTruncateMinimalDetails,
+  } = props;
+
+  const isMinimal = sdsStyle === "minimal";
 
   if (open !== undefined) {
     // eslint-disable-next-line no-console
@@ -23,20 +35,54 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
     );
   }
 
+  const shouldRenderDetails =
+    sdsType === "singleSelect" && details && !isMinimal;
+
+  const shouldRenderCounter =
+    sdsType === "multiSelect" && counter !== undefined;
+
   return (
     <StyledInputDropdown {...props}>
-      <StyledLabel details={details} counter={counter}>
-        {counter !== undefined || details ? `${label}:` : label}
-      </StyledLabel>
-      {sdsType === "singleSelect" && details && (
-        <StyledDetail>{details}</StyledDetail>
+      <LabelWrapper isMinimal={isMinimal}>
+        <StyledLabel
+          className="styled-label"
+          details={details}
+          counter={counter}
+        >
+          {renderLabelText({ counter, details, isMinimal, label })}
+        </StyledLabel>
+        {shouldRenderDetails && <StyledDetail>{details}</StyledDetail>}
+        {shouldRenderCounter && <StyledCounter>{counter}</StyledCounter>}
+        <Icon sdsIcon="chevronDown" sdsSize="s" sdsType="interactive" />
+      </LabelWrapper>
+
+      {isMinimal && (
+        <MinimalDetails
+          shouldTruncateMinimalDetails={shouldTruncateMinimalDetails}
+        >
+          {details}
+        </MinimalDetails>
       )}
-      {sdsType === "multiSelect" && counter !== undefined && (
-        <StyledCounter>{counter}</StyledCounter>
-      )}
-      <Icon sdsIcon="chevronDown" sdsSize="s" sdsType="interactive" />
     </StyledInputDropdown>
   );
 };
+
+function renderLabelText({
+  counter,
+  details,
+  isMinimal,
+  label,
+}: {
+  counter: InputDropdownProps["counter"];
+  details: InputDropdownProps["details"];
+  isMinimal: boolean;
+  label: InputDropdownProps["label"];
+}) {
+  if (isMinimal) {
+    return label;
+  }
+
+  return counter !== undefined || details ? `${label}:` : label;
+}
 
 export default InputDropdown;

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -23,6 +23,7 @@ export interface InputDropdownProps extends CommonThemeProps {
   sdsType?: "singleSelect" | "multiSelect";
   details?: string;
   counter?: string;
+  shouldTruncateMinimalDetails?: boolean;
 }
 
 const labelFontBodyS = fontBody("s");
@@ -36,18 +37,17 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 
   return css`
     border: ${borders?.gray[400]};
-    color: ${colors?.gray[500]};
+    color: black;
     cursor: pointer;
     padding: ${spacings?.xs}px;
+    /* minimal left right will be s px instead */
 
     &.MuiButton-text {
-      justify-content: flex-start;
-
       &:hover {
         color: #000;
       }
 
-      > span {
+      .styled-label {
         margin-right: ${spacings?.xs}px;
         margin-left: ${spacings?.xs}px;
         overflow: hidden;
@@ -74,7 +74,7 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
         fill: ${colors?.gray[600]};
       }
 
-      > span {
+      .styled-label {
         color: #000;
       }
     }
@@ -97,13 +97,22 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 const minimal = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
   const palette = getPalette(props);
+  const spacings = getSpaces(props);
 
   return css`
-    border: none;
-    padding: 0;
+    ${labelStyle(props)}
 
-    & .MuiButton-label {
-      margin: 0;
+    align-items: flex-start;
+    border: none;
+    flex-direction: column;
+    padding: ${spacings?.xs}px ${spacings?.s}px;
+
+    /* Nesting to increase CSS specificity for style override */
+    &.MuiButton-text {
+      .styled-label {
+        margin: 0;
+        margin-right: ${spacings?.xs}px;
+      }
     }
 
     span {
@@ -115,8 +124,9 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
     }
 
     &:hover {
-      color: ${colors?.gray[600]};
+      background-color: ${colors?.gray[100]};
       border: none;
+      color: ${colors?.gray[600]};
 
       span {
         color: ${colors?.gray[600]};
@@ -128,8 +138,9 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
     }
 
     &:active {
-      color: ${palette?.text?.primary};
+      background-color: ${colors?.gray[100]};
       border: none;
+      color: ${palette?.text?.primary};
 
       span {
         color: #000;
@@ -168,23 +179,13 @@ const square = (props: InputDropdownProps): SerializedStyles => {
 
 const rounded = (props: InputDropdownProps): SerializedStyles => {
   const corners = getCorners(props);
-  const colors = getColors(props);
-  const palette = getPalette(props);
-  const labelColor = props.disabled
-    ? colors?.gray[300]
-    : palette?.text?.primary;
 
   return css`
+    ${labelStyle(props)}
+
     border-radius: ${corners?.l}px;
     height: 34px;
     min-width: 90px;
-
-    &.MuiButton-text {
-      > span:first-of-type {
-        font-weight: 600;
-        color: ${labelColor};
-      }
-    }
   `;
 };
 
@@ -268,6 +269,12 @@ export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
   ${labelFontBodyS}
+
+  /* (thuang): in Minimal it's a different value */
+  align-items: center;
+  /* (thuang): in Minimal it's a different value */
+  flex-direction: row;
+
   ${(props: InputDropdownProps) => {
     const { disabled, intent, open, sdsStage, sdsStyle } = props;
 
@@ -338,3 +345,48 @@ export const StyledCounter = styled("span", {
   `;
   }}
 `;
+
+export const MinimalDetails = styled("div")`
+  text-align: left;
+  width: 100%;
+
+  ${({
+    shouldTruncateMinimalDetails,
+  }: {
+    shouldTruncateMinimalDetails: InputDropdownProps["shouldTruncateMinimalDetails"];
+  }) => {
+    if (shouldTruncateMinimalDetails) {
+      return `
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      `;
+    }
+  }}
+`;
+
+export const LabelWrapper = styled("span")`
+  ${({ isMinimal }: { isMinimal: boolean }) => {
+    return `
+      align-items: ${isMinimal ? "center" : undefined};
+      display: ${isMinimal ? "inline-flex" : "contents"};
+    `;
+  }}
+`;
+
+function labelStyle(props: InputDropdownProps): SerializedStyles {
+  const colors = getColors(props);
+  const palette = getPalette(props);
+  const labelColor = props.disabled
+    ? colors?.gray[300]
+    : palette?.text?.primary;
+
+  return css`
+    &.MuiButton-text {
+      .styled-label {
+        font-weight: 600;
+        color: ${labelColor};
+      }
+    }
+  `;
+}

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -4,7 +4,6 @@ import Button from "../Button";
 import {
   CommonThemeProps,
   fontBody,
-  fontHeaderS,
   getBorders,
   getColors,
   getCorners,
@@ -137,7 +136,7 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
     }
 
     &.MuiButton-root.MuiButton-text > span {
-      ${fontHeaderS(props)}
+      ${labelFontBodyS(props)}
       margin-left: 0;
     }
 
@@ -250,7 +249,7 @@ const doNotForwardProps = ["intent", "open", "sdsStage"];
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
-  ${labelFontBodyS}
+  ${labelFontBodyXs}
 
   /* (thuang): in Minimal it's a different value */
   align-items: center;
@@ -277,7 +276,6 @@ export const StyledInputDropdown = styled(Button, {
 export const StyledDetail = styled("span", {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
-  ${labelFontBodyXs}
   ${(props) => {
     const colors = getColors(props);
 
@@ -295,7 +293,6 @@ interface DetailsAndCounter extends CommonThemeProps {
 export const StyledLabel = styled("span", {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
-  ${labelFontBodyXs}
   ${(props: DetailsAndCounter) => {
     const { details, counter } = props;
     const colors = getColors(props);
@@ -313,7 +310,6 @@ export const StyledLabel = styled("span", {
 export const StyledCounter = styled("span", {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
-  ${labelFontBodyXs}
   ${(props) => {
     const colors = getColors(props);
     const corners = getCorners(props);
@@ -328,15 +324,16 @@ export const StyledCounter = styled("span", {
   }}
 `;
 
+interface MinimalDetailsProps extends CommonThemeProps {
+  shouldTruncateMinimalDetails: InputDropdownProps["shouldTruncateMinimalDetails"];
+}
+
 export const MinimalDetails = styled("div")`
+  ${labelFontBodyS}
   text-align: left;
   width: 100%;
 
-  ${({
-    shouldTruncateMinimalDetails,
-  }: {
-    shouldTruncateMinimalDetails: InputDropdownProps["shouldTruncateMinimalDetails"];
-  }) => {
+  ${({ shouldTruncateMinimalDetails }: MinimalDetailsProps) => {
     if (shouldTruncateMinimalDetails) {
       return `
         overflow: hidden;

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -37,10 +37,9 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 
   return css`
     border: ${borders?.gray[400]};
-    color: black;
+    color: ${palette?.text?.primary};
     cursor: pointer;
     padding: ${spacings?.xs}px;
-    /* minimal left right will be s px instead */
 
     &.MuiButton-text {
       &:hover {
@@ -102,6 +101,7 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
   return css`
     ${labelStyle(props)}
 
+    /* this is needed to left align the label text */
     align-items: flex-start;
     border: none;
     flex-direction: column;
@@ -126,29 +126,11 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
     &:hover {
       background-color: ${colors?.gray[100]};
       border: none;
-      color: ${colors?.gray[600]};
-
-      span {
-        color: ${colors?.gray[600]};
-      }
-
-      path {
-        fill: ${colors?.gray[600]};
-      }
     }
 
     &:active {
       background-color: ${colors?.gray[100]};
       border: none;
-      color: ${palette?.text?.primary};
-
-      span {
-        color: #000;
-      }
-
-      path {
-        fill: ${colors?.primary[400]};
-      }
     }
 
     &:focus {
@@ -191,10 +173,11 @@ const rounded = (props: InputDropdownProps): SerializedStyles => {
 
 const userInput = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
+  const palette = getPalette(props);
 
   return css`
     ${props.sdsStyle === "minimal"
-      ? "& > span, &:hover > span { color: black; }"
+      ? `& > span, &:hover > span { color: ${palette?.text?.primary}; }`
       : ""}
 
     path {

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -244,7 +244,7 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const doNotForwardProps = ["intent", "open", "sdsStage"];
+const doNotForwardProps = ["intent", "open", "sdsStage", "isMinimal"];
 
 export const StyledInputDropdown = styled(Button, {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
@@ -344,7 +344,9 @@ export const MinimalDetails = styled("div")`
   }}
 `;
 
-export const LabelWrapper = styled("span")`
+export const LabelWrapper = styled("span", {
+  shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
+})`
   ${({ isMinimal }: { isMinimal: boolean }) => {
     return `
       align-items: ${isMinimal ? "center" : undefined};

--- a/src/core/InputDropdown/style.ts
+++ b/src/core/InputDropdown/style.ts
@@ -95,7 +95,6 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 
 const minimal = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
-  const palette = getPalette(props);
   const spacings = getSpaces(props);
 
   return css`

--- a/src/core/LoadingIndicator/__snapshots__/index.test.tsx.snap
+++ b/src/core/LoadingIndicator/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<LoadingIndicator /> Test story renders snapshot 1`] = `
       class="css-1o5w4es"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -38,7 +38,7 @@ exports[`<LoadingIndicator /> Test story renders snapshot 1`] = `
       class="css-k87s1p"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"

--- a/src/core/Notification/__snapshots__/notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/notification.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Notification /> Test story renders snapshot 1`] = `
       class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"

--- a/src/core/Pagination/__snapshots__/index.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/index.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -71,7 +71,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -106,7 +106,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -157,7 +157,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -191,7 +191,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -224,7 +224,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -278,7 +278,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -312,7 +312,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -365,7 +365,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -399,7 +399,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -433,7 +433,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -466,7 +466,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -509,7 +509,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -543,7 +543,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -577,7 +577,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -611,7 +611,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"
@@ -662,7 +662,7 @@ exports[`<Pagination /> Test story renders snapshot 1`] = `
         type="button"
       >
         <div
-          class="css-jbvua0"
+          class="css-1ft6wgl"
         >
           <svg
             aria-hidden="true"

--- a/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
+++ b/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -46,7 +46,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -74,7 +74,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -102,7 +102,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -139,7 +139,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -167,7 +167,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -195,7 +195,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"
@@ -223,7 +223,7 @@ exports[`<SegmentedControl /> Test story renders snapshot 1`] = `
       data-mui-internal-clone-element="true"
     >
       <div
-        class="css-jbvua0"
+        class="css-1ft6wgl"
       >
         <svg
           aria-hidden="true"

--- a/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
             type="button"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"
@@ -60,7 +60,7 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
             type="button"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"
@@ -95,7 +95,7 @@ exports[`<TableHeader /> Test story renders snapshot 1`] = `
             type="button"
           >
             <div
-              class="css-jbvua0"
+              class="css-1ft6wgl"
             >
               <svg
                 aria-hidden="true"


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Ticket: #337 

Component Name: InputDropdown
Component Requirements: - New component variation, specific parameters as below

sdsType: single-select
sdsStyle: minimal
Details: on
Design link: https://www.figma.com/file/v8T3vabzkmbvH71sQ1EXzh/Kevin---Heatmap-Filters-Redesign?node-id=1047%3A35901&t=8JY2ukyrEk5NnJ6M-1
Team(s) Requesting: CZID
Component Needed By: This is part of the Heatmap - Move Filters to the left project. I will share the eng point of contact after handoff

Plan Details:

There is a version of this that exists but does not match the full requirements, we will take what exists in the code and updating it

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
