### PR TITLE
chore: Update default release branch from main to prod

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,9 +1,12 @@
 module.exports = {
-  // (thuang) Use `main` instead of `master`
-  // https://github.com/semantic-release/semantic-release/issues/1581#issuecomment-647657317
+  /**
+   * (thuang): Merging to `main` branch will not trigger a release.
+   * We only want to release from `prod` branch
+   * https://github.com/semantic-release/semantic-release/issues/1581#issuecomment-647657317
+   */
   branches: [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "main",
+    "prod",
     "next",
     "next-major",
     {


### PR DESCRIPTION
## Summary

This ticket changes the default release branch from `main` to `prod`. Which means future releases will require merging `main` into `prod`

Context:
https://github.com/semantic-release/semantic-release/blob/master/docs/usage/workflow-configuration.md#branches-properties