### PR TITLE
fix(MenuSelect): Fix backspace unselect item

### DIFF
--- a/src/core/MenuSelect/index.tsx
+++ b/src/core/MenuSelect/index.tsx
@@ -100,6 +100,12 @@ const MenuSelect = <
             ref={params.InputProps.ref}
             search={search}
             autoFocus
+            // (masoudmanson): This prevents Backspace from deselecting selected dropdown options.
+            onKeyDown={(event) => {
+              if (event.key === "Backspace") {
+                event.stopPropagation();
+              }
+            }}
             InputProps={{
               /**
                * (thuang): Works with css caret-color: "transparent" to hide


### PR DESCRIPTION
## Summary

Requested by SCB to fix deprecated MenuSelect as well, since Dropdown and MenuSelect styles are different and SCB doesn't have time to restyle Dropdown to look closer to MenuSelect at the moment!

SCB ticket: https://github.com/chanzuckerberg/single-cell-data-portal/issues/4156

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
