### PR TITLE
refactor(dropdown): fix click outside behavior

### DIFF
--- a/src/core/Dropdown/index.stories.tsx
+++ b/src/core/Dropdown/index.stories.tsx
@@ -107,7 +107,7 @@ export const Default = Template.bind({});
 Default.args = {
   buttonPosition: "left",
   buttons: false,
-  closeOnBlur: false,
+  closeOnBlur: true,
   disabled: false,
   isTriggerChangeOnOptionClick: false,
   label: LABEL,

--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -3,7 +3,10 @@ import {
   AutocompleteValue,
 } from "@mui/material/useAutocomplete";
 import React, { ReactNode, useEffect, useState } from "react";
-import DropdownMenu, { DefaultDropdownMenuOption } from "../DropdownMenu";
+import DropdownMenu, {
+  DefaultDropdownMenuOption,
+  DropdownMenuProps as SdsDropdownMenuProps,
+} from "../DropdownMenu";
 import { StyledPaper, StyledPopper } from "../DropdownMenu/style";
 import InputDropdown, {
   InputDropdownProps as InputDropdownPropsType,
@@ -35,7 +38,7 @@ export type MUIValue<Multiple> = AutocompleteValue<
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RenderFunctionType = (props: any) => JSX.Element;
 
-export interface DropdownProps<Multiple> {
+export interface DropdownProps<Multiple extends boolean | undefined> {
   buttonPosition?: "left" | "right";
   buttons?: boolean;
   closeOnBlur?: boolean;
@@ -46,7 +49,14 @@ export interface DropdownProps<Multiple> {
   onClose?: () => void;
   multiple?: Multiple;
   search?: boolean;
-  DropdownMenuProps?: Partial<typeof DropdownMenu>;
+  DropdownMenuProps?: Partial<
+    SdsDropdownMenuProps<
+      DefaultDropdownMenuOption,
+      Multiple,
+      undefined,
+      undefined
+    >
+  >;
   InputDropdownProps?: Partial<InputDropdownPropsType>;
   value?: Value<DefaultDropdownMenuOption, Multiple>;
   style?: React.CSSProperties;
@@ -57,7 +67,7 @@ export interface DropdownProps<Multiple> {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-const Dropdown = <Multiple extends boolean | undefined = false>({
+const Dropdown = <Multiple extends boolean | undefined = undefined>({
   options,
   label = "",
   multiple = false,
@@ -184,7 +194,9 @@ const Dropdown = <Multiple extends boolean | undefined = false>({
 
   function handleClickAway() {
     if (open) {
-      setOpen(false);
+      if (closeOnBlur && !shouldShowButtons) {
+        setOpen(false);
+      }
 
       if (multiple) {
         setValue(pendingValue as MUIValue<Multiple>);
@@ -236,8 +248,8 @@ const Dropdown = <Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
-    if (closeOnBlur) {
-      if (onClose) onClose();
+    if (shouldShowButtons || closeOnBlur) {
+      onClose?.();
       setOpen(false);
     }
   }
@@ -273,10 +285,8 @@ const Dropdown = <Multiple extends boolean | undefined = false>({
       anchorEl.focus();
     }
 
-    if (closeOnBlur) {
-      if (onClose) onClose();
-      setOpen(false);
-    }
+    onClose?.();
+    setOpen(false);
   }
 
   function getInitialValue(): Value<DefaultDropdownMenuOption, Multiple> {

--- a/src/core/Dropdown/index.tsx
+++ b/src/core/Dropdown/index.tsx
@@ -67,7 +67,7 @@ export interface DropdownProps<Multiple extends boolean | undefined> {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-const Dropdown = <Multiple extends boolean | undefined = undefined>({
+const Dropdown = <Multiple extends boolean | undefined = false>({
   options,
   label = "",
   multiple = false,
@@ -194,6 +194,10 @@ const Dropdown = <Multiple extends boolean | undefined = undefined>({
 
   function handleClickAway() {
     if (open) {
+      // (masoudmanson): We want to keep the dropdown menu open in two scenarios:
+      // 1. If the dropdown has buttons,
+      // 2. When there are no buttons, and the closeOnBlur property is set to false,
+      // In all other cases, we close the menu.
       if (closeOnBlur && !shouldShowButtons) {
         setOpen(false);
       }

--- a/src/core/DropdownMenu/index.stories.tsx
+++ b/src/core/DropdownMenu/index.stories.tsx
@@ -147,6 +147,9 @@ const groupByOptions = [
 
 export default {
   argTypes: {
+    ClickAwayListenerProps: {
+      control: { type: "object" },
+    },
     groupBy: {
       control: {
         labels: ["No group by", "Group by section names"],


### PR DESCRIPTION
## Summary

**Dropdown**
GitHub issue: #414 

Amend the `Dropdown` menu to stay open only for the button variant.