### PR TITLE
test: Update Button component Chromatic screenshots

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,6 +33,7 @@ module.exports = {
     "@storybook/addon-interactions",
     "@storybook/addon-a11y",
     "@storybook/react",
+    "storybook-addon-pseudo-states",
   ],
   framework: {
     name: "@storybook/react-webpack5",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,3 +8,15 @@ export const decorators = [
     </ThemeProvider>
   ),
 ];
+
+/**
+ * (thuang): This is a temporary fix for the Storybook addon to work with
+ * `storybook-addon-pseudo-states` plugin
+ * https://github.com/chromaui/storybook-addon-pseudo-states/issues/59#issuecomment-1498182067
+ */
+const preview = {
+  globalTypes: {
+    pseudo: {},
+  },
+};
+export default preview;

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "rollup-plugin-ts": "^3.0.2",
     "storybook": "^7.0.5",
     "storybook-addon-emotion-theme": "^2.1.1",
+    "storybook-addon-pseudo-states": "^2.0.1",
     "style-dictionary": "^3.0.3",
     "stylelint": "^13.11.0",
     "stylelint-config-recommended": "^3.0.0",

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -64,6 +64,8 @@ const placementStyles = {
   gridTemplateRows: "1fr",
 };
 
+const PSEUDO_STATES = ["default", "hover", "active", "focus-visible"];
+
 export const RoundedLivePreview = {
   parameters: {
     snapshot: {
@@ -72,32 +74,49 @@ export const RoundedLivePreview = {
   },
   render: (props: Args): JSX.Element => {
     return (
-      <div style={placementStyles as React.CSSProperties}>
-        <RawButton {...props} sdsStyle="rounded" sdsType="primary">
-          {text}
-        </RawButton>
-
-        <RawButton
-          {...props}
-          startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-          sdsStyle="rounded"
-          sdsType="primary"
-        >
-          {text}
-        </RawButton>
-        <RawButton {...props} sdsStyle="rounded" sdsType="secondary">
-          {text}
-        </RawButton>
-        <RawButton
-          {...props}
-          startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-          sdsStyle="rounded"
-          sdsType="secondary"
-        >
-          {text}
-        </RawButton>
-      </div>
+      <>
+        {PSEUDO_STATES.map((state) => {
+          return <ButtonRow state={state} />;
+        })}
+      </>
     );
+
+    function ButtonRow({ state = "default" }) {
+      return (
+        <div id={state} className={`pseudo-${state}`}>
+          <h5>{state}</h5>
+          <div style={placementStyles as React.CSSProperties}>
+            <RawButton {...props} sdsStyle="rounded" sdsType="primary">
+              {text}
+            </RawButton>
+
+            <RawButton
+              {...props}
+              startIcon={
+                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+              }
+              sdsStyle="rounded"
+              sdsType="primary"
+            >
+              {text}
+            </RawButton>
+            <RawButton {...props} sdsStyle="rounded" sdsType="secondary">
+              {text}
+            </RawButton>
+            <RawButton
+              {...props}
+              startIcon={
+                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+              }
+              sdsStyle="rounded"
+              sdsType="secondary"
+            >
+              {text}
+            </RawButton>
+          </div>
+        </div>
+      );
+    }
   },
 };
 

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -5,8 +5,8 @@ import Icon from "../Icon";
 import RawButton from "./index";
 
 const text = "Label";
-const sdsStyles = ["rounded", "square", "minimal"];
-const sdsTypes = ["primary", "secondary"];
+const SDS_STYLES = ["rounded", "square", "minimal"];
+const SDS_TYPES = ["primary", "secondary"];
 
 const actions = {
   onClick: action("onClick"),
@@ -26,16 +26,16 @@ export default {
     // https://storybook.js.org/docs/react/essentials/actions#action-argtype-annotation
     onClick: { action: actions.onClick },
     sdsStyle: {
-      control: { type: "select" },
-      options: sdsStyles,
+      control: { sdsType: "select" },
+      options: SDS_STYLES,
     },
     sdsType: {
-      control: { type: "select" },
-      options: sdsTypes,
+      control: { sdsType: "select" },
+      options: SDS_TYPES,
     },
     text: {
       control: {
-        type: "text",
+        sdsType: "text",
       },
     },
   },
@@ -56,17 +56,25 @@ export const Default = {
 
 // Live Preview
 
-const placementStyles = {
+const buttonPlacementStyles = {
   display: "grid",
   gridColumnGap: "10px",
   gridRowGap: "0px",
-  gridTemplateColumns: "repeat(6, 120px)",
+  gridTemplateColumns: "repeat(4, 120px)",
   gridTemplateRows: "1fr",
+};
+
+const sectionPlacementStyles = {
+  display: "inline-block",
+  marginBottom: "60px",
+  marginRight: "60px",
+  verticalAlign: "text-top",
+  alignItems: "stretch",
 };
 
 const PSEUDO_STATES = ["default", "hover", "active", "focus-visible"];
 
-export const RoundedLivePreview = {
+export const LivePreview = {
   parameters: {
     snapshot: {
       skip: true,
@@ -75,149 +83,68 @@ export const RoundedLivePreview = {
   render: (props: Args): JSX.Element => {
     return (
       <>
-        {PSEUDO_STATES.map((state) => {
-          return <ButtonRow state={state} />;
+        {SDS_STYLES.map((sdsStyle) => {
+          return <ButtonStyle sdsStyle={sdsStyle} key={sdsStyle} />;
         })}
       </>
     );
 
-    function ButtonRow({ state = "default" }) {
+    function ButtonStyle({ sdsStyle }) {
       return (
-        <div id={state} className={`pseudo-${state}`}>
-          <h5>{state}</h5>
-          <div style={placementStyles as React.CSSProperties}>
-            <RawButton {...props} sdsStyle="rounded" sdsType="primary">
-              {text}
-            </RawButton>
-
-            <RawButton
-              {...props}
-              startIcon={
-                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-              }
-              sdsStyle="rounded"
-              sdsType="primary"
-            >
-              {text}
-            </RawButton>
-            <RawButton {...props} sdsStyle="rounded" sdsType="secondary">
-              {text}
-            </RawButton>
-            <RawButton
-              {...props}
-              startIcon={
-                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-              }
-              sdsStyle="rounded"
-              sdsType="secondary"
-            >
-              {text}
-            </RawButton>
-          </div>
+        <div style={sectionPlacementStyles}>
+          <h3>{sdsStyle}</h3>
+          {PSEUDO_STATES.map((state) => {
+            return (
+              <ButtonState state={state} sdsStyle={sdsStyle} key={state} />
+            );
+          })}
         </div>
       );
     }
-  },
-};
 
-export const SquareLivePreview = {
-  parameters: {
-    snapshot: {
-      skip: true,
-    },
-  },
-  render: (props: Args): JSX.Element => {
-    return (
-      <>
-        {PSEUDO_STATES.map((state) => {
-          return <ButtonRowSquare state={state} />;
-        })}
-      </>
-    );
-    function ButtonRowSquare({ state = "default" }) {
+    function ButtonState({ sdsStyle, state = "default" }) {
       return (
-        <div id={state} className={`pseudo-${state}`}>
+        <>
           <h5>{state}</h5>
-          <div style={placementStyles as React.CSSProperties}>
-            <RawButton {...props} sdsStyle="square" sdsType="primary">
-              {text}
-            </RawButton>
-            <RawButton
-              {...props}
-              startIcon={
-                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-              }
-              sdsStyle="square"
-              sdsType="primary"
-            >
-              {text}
-            </RawButton>
-            <RawButton {...props} sdsStyle="square" sdsType="secondary">
-              {text}
-            </RawButton>
-            <RawButton
-              {...props}
-              startIcon={
-                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-              }
-              sdsStyle="square"
-              sdsType="secondary"
-            >
-              {text}
-            </RawButton>
+          <div
+            style={buttonPlacementStyles as React.CSSProperties}
+            id={state}
+            className={`pseudo-${state}`}
+          >
+            {SDS_TYPES.map((sdsType) => {
+              return (
+                <ButtonType
+                  state={state}
+                  sdsStyle={sdsStyle}
+                  sdsType={sdsType}
+                  key={sdsType}
+                />
+              );
+            })}
           </div>
-        </div>
+        </>
       );
     }
-  },
-};
 
-const minimalPlacementStyles = {
-  display: "grid",
-  gridColumnGap: "24px",
-  gridRowGap: "0px",
-  gridTemplateColumns: "repeat(3, min-content)",
-  gridTemplateRows: "1fr",
-};
-
-export const MinimalLivePreview = {
-  parameters: {
-    snapshot: {
-      skip: true,
-    },
-  },
-  render: (props: Args): JSX.Element => {
-    return (
-      <>
-        {PSEUDO_STATES.map((state) => {
-          return <ButtonRowMinimal state={state} />;
-        })}
-      </>
-    );
-    function ButtonRowMinimal({ state = "default" }) {
+    function ButtonType({ sdsStyle, sdsType }) {
       return (
-        <div id={state} className={`pseudo-${state}`}>
-          <h5>{state}</h5>
-          <div style={minimalPlacementStyles as React.CSSProperties}>
-            <RawButton {...props} sdsStyle="minimal" sdsType="primary">
-              {text}
-            </RawButton>
-
+        <>
+          <RawButton {...props} sdsStyle={sdsStyle} sdsType={sdsType}>
+            {text}
+          </RawButton>
+          {(sdsStyle !== "minimal" || sdsType === "primary") && (
             <RawButton
               {...props}
               startIcon={
                 <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
               }
-              sdsStyle="minimal"
-              sdsType="primary"
+              sdsStyle={sdsStyle}
+              sdsType={sdsType}
             >
               {text}
             </RawButton>
-            <RawButton {...props} sdsStyle="minimal" sdsType="secondary">
-              {text}
-            </RawButton>
-          </div>
-        </div>
+          )}
+        </>
       );
     }
   },

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -128,31 +128,47 @@ export const SquareLivePreview = {
   },
   render: (props: Args): JSX.Element => {
     return (
-      <div style={placementStyles as React.CSSProperties}>
-        <RawButton {...props} sdsStyle="square" sdsType="primary">
-          {text}
-        </RawButton>
-        <RawButton
-          {...props}
-          startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-          sdsStyle="square"
-          sdsType="primary"
-        >
-          {text}
-        </RawButton>
-        <RawButton {...props} sdsStyle="square" sdsType="secondary">
-          {text}
-        </RawButton>
-        <RawButton
-          {...props}
-          startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-          sdsStyle="square"
-          sdsType="secondary"
-        >
-          {text}
-        </RawButton>
-      </div>
+      <>
+        {PSEUDO_STATES.map((state) => {
+          return <ButtonRowSquare state={state} />;
+        })}
+      </>
     );
+    function ButtonRowSquare({ state = "default" }) {
+      return (
+        <div id={state} className={`pseudo-${state}`}>
+          <h5>{state}</h5>
+          <div style={placementStyles as React.CSSProperties}>
+            <RawButton {...props} sdsStyle="square" sdsType="primary">
+              {text}
+            </RawButton>
+            <RawButton
+              {...props}
+              startIcon={
+                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+              }
+              sdsStyle="square"
+              sdsType="primary"
+            >
+              {text}
+            </RawButton>
+            <RawButton {...props} sdsStyle="square" sdsType="secondary">
+              {text}
+            </RawButton>
+            <RawButton
+              {...props}
+              startIcon={
+                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+              }
+              sdsStyle="square"
+              sdsType="secondary"
+            >
+              {text}
+            </RawButton>
+          </div>
+        </div>
+      );
+    }
   },
 };
 
@@ -172,24 +188,38 @@ export const MinimalLivePreview = {
   },
   render: (props: Args): JSX.Element => {
     return (
-      <div style={minimalPlacementStyles as React.CSSProperties}>
-        <RawButton {...props} sdsStyle="minimal" sdsType="primary">
-          {text}
-        </RawButton>
-
-        <RawButton
-          {...props}
-          startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
-          sdsStyle="minimal"
-          sdsType="primary"
-        >
-          {text}
-        </RawButton>
-        <RawButton {...props} sdsStyle="minimal" sdsType="secondary">
-          {text}
-        </RawButton>
-      </div>
+      <>
+        {PSEUDO_STATES.map((state) => {
+          return <ButtonRowMinimal state={state} />;
+        })}
+      </>
     );
+    function ButtonRowMinimal({ state = "default" }) {
+      return (
+        <div id={state} className={`pseudo-${state}`}>
+          <h5>{state}</h5>
+          <div style={minimalPlacementStyles as React.CSSProperties}>
+            <RawButton {...props} sdsStyle="minimal" sdsType="primary">
+              {text}
+            </RawButton>
+
+            <RawButton
+              {...props}
+              startIcon={
+                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
+              }
+              sdsStyle="minimal"
+              sdsType="primary"
+            >
+              {text}
+            </RawButton>
+            <RawButton {...props} sdsStyle="minimal" sdsType="secondary">
+              {text}
+            </RawButton>
+          </div>
+        </div>
+      );
+    }
   },
 };
 

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -4,9 +4,15 @@ import React from "react";
 import Icon from "../Icon";
 import RawButton from "./index";
 
-const text = "Label";
 const SDS_STYLES = ["rounded", "square", "minimal"];
 const SDS_TYPES = ["primary", "secondary"];
+const ICON_OPTIONS = [
+  undefined,
+  <Icon sdsSize="l" sdsIcon="download" sdsType="button" />,
+];
+const DISABLED_OPTIONS = [false, true];
+const PSEUDO_STATES = ["default", "hover", "active", "focus-visible"];
+const TEXT = "Label";
 
 const actions = {
   onClick: action("onClick"),
@@ -16,7 +22,7 @@ const Button = (props: Args): JSX.Element => {
   const { sdsType, sdsStyle } = props;
   return (
     <RawButton sdsType={sdsType} sdsStyle={sdsStyle} {...props}>
-      {text}
+      {TEXT}
     </RawButton>
   );
 };
@@ -56,23 +62,58 @@ export const Default = {
 
 // Live Preview
 
-const buttonPlacementStyles = {
-  display: "grid",
-  gridColumnGap: "10px",
-  gridRowGap: "0px",
-  gridTemplateColumns: "repeat(4, 120px)",
-  gridTemplateRows: "1fr",
+const styleLevel = {
+  fontFamily: "sans-serif",
+  display: "inline-grid",
+  gridColumnTemplate:
+    "min-content min-content min-content min-content min-content",
+  columnGap: "20px",
+  marginRight: "50px",
+};
+const displayContents = {
+  display: "contents",
+};
+const disabledLevel = {
+  display: "contents",
+};
+const stateLevel = {
+  marginBottom: 10,
 };
 
-const sectionPlacementStyles = {
-  display: "inline-block",
-  marginBottom: "60px",
-  marginRight: "60px",
-  verticalAlign: "text-top",
-  alignItems: "stretch",
+const styleLabel = {
+  fontWeight: "normal",
+  gridColumn: "2 / 6",
+  marginBottom: 0,
 };
-
-const PSEUDO_STATES = ["default", "hover", "active", "focus-visible"];
+const typeLabel = {
+  fontWeight: "normal",
+  gridColumn: "2 / 6",
+  borderStyle: "solid none none none",
+  borderWidth: "2px",
+  justifySelf: "stretch",
+  margin: "20px 0",
+  paddingTop: 10,
+};
+const iconLabel = {
+  fontWeight: "normal",
+  gridColumn: "2 / 6",
+  borderStyle: "solid none none none",
+  borderWidth: "1px",
+  justifySelf: "stretch",
+  alignSelf: "end",
+  margin: "0 0 5px 0",
+  paddingTop: 10,
+};
+const disabledLabel = {
+  fontWeight: "normal",
+  gridColumn: "1 / 2",
+  alignSelf: "end",
+  marginTop: 0,
+};
+const stateLabel = {
+  fontWeight: "normal",
+  margin: "10px 0",
+};
 
 export const LivePreview = {
   parameters: {
@@ -81,70 +122,131 @@ export const LivePreview = {
     },
   },
   render: (props: Args): JSX.Element => {
+    // loop through all SDS_STYLES
     return (
       <>
         {SDS_STYLES.map((sdsStyle) => {
-          return <ButtonStyle sdsStyle={sdsStyle} key={sdsStyle} />;
+          return <ButtonStyleOption sdsStyle={sdsStyle} key={sdsStyle} />;
         })}
       </>
     );
 
-    function ButtonStyle({ sdsStyle }) {
+    // loop through all SDS_TYPES + create headers for SDS_STYLES
+    function ButtonStyleOption({ sdsStyle }) {
       return (
-        <div style={sectionPlacementStyles}>
-          <h3>{sdsStyle}</h3>
-          {PSEUDO_STATES.map((state) => {
+        <div style={styleLevel}>
+          <h1 style={styleLabel}>
+            Style: <b>{sdsStyle}</b>
+          </h1>
+          {SDS_TYPES.map((type) => {
             return (
-              <ButtonState state={state} sdsStyle={sdsStyle} key={state} />
+              <ButtonTypeOption sdsStyle={sdsStyle} type={type} key={type} />
             );
           })}
         </div>
       );
     }
 
-    function ButtonState({ sdsStyle, state = "default" }) {
+    // loop through all ICON_OPTIONS + create headers for SDS_TYPES
+    function ButtonTypeOption({ sdsStyle, type }) {
       return (
-        <>
-          <h5>{state}</h5>
-          <div
-            style={buttonPlacementStyles as React.CSSProperties}
-            id={state}
-            className={`pseudo-${state}`}
-          >
-            {SDS_TYPES.map((sdsType) => {
+        <div style={displayContents}>
+          <h3 style={typeLabel}>
+            Type: <b>{type}</b>
+          </h3>
+          {type === "primary" ? (
+            ICON_OPTIONS.map((icon) => {
               return (
-                <ButtonType
-                  state={state}
+                <ButtonIconOption
                   sdsStyle={sdsStyle}
-                  sdsType={sdsType}
-                  key={sdsType}
+                  type={type}
+                  icon={icon}
+                  key={icon}
                 />
               );
-            })}
-          </div>
-        </>
+            })
+          ) : (
+            <ButtonIconOption
+              sdsStyle={sdsStyle}
+              type={type}
+              icon={ICON_OPTIONS[0]}
+              key={ICON_OPTIONS[0]}
+            />
+          )}
+          {/* {ICON_OPTIONS.map((icon) => {
+            return <ButtonIconOption
+              sdsStyle={sdsStyle}
+              type={type}
+              icon={icon} 
+              key={icon}
+            />;
+          })} */}
+        </div>
       );
     }
 
-    function ButtonType({ sdsStyle, sdsType }) {
+    // loop through all DISABLED_OPTIONS + create headers for ICON_OPTIONS
+    function ButtonIconOption({ sdsStyle, type, icon }) {
       return (
-        <>
-          <RawButton {...props} sdsStyle={sdsStyle} sdsType={sdsType}>
-            {text}
-          </RawButton>
-          {(sdsStyle !== "minimal" || sdsType === "primary") && (
-            <RawButton
-              {...props}
-              startIcon={
-                <Icon sdsIcon="download" sdsSize="s" sdsType="button" />
-              }
-              sdsStyle={sdsStyle}
-              sdsType={sdsType}
-            >
-              {text}
-            </RawButton>
-          )}
-        </>
+        <div style={displayContents}>
+          <h5 style={iconLabel}>
+            Icon: <b>{icon ? "yes" : "no"}</b>
+          </h5>
+          {DISABLED_OPTIONS.map((disabled, disabledIndex) => {
+            return (
+              <ButtonDisabledOption
+                sdsStyle={sdsStyle}
+                type={type}
+                icon={icon}
+                disabled={disabled}
+                key={disabled}
+                disabledIndex={disabledIndex}
+              />
+            );
+          })}
+        </div>
+      );
+    }
+
+    // loop through all PSEUDO_STATES + create headers for DISABLED_OPTIONS, PSEUDO_STATES
+    function ButtonDisabledOption({
+      sdsStyle,
+      type,
+      icon,
+      disabled,
+      disabledIndex,
+    }) {
+      return (
+        <div style={disabledLevel}>
+          <h6 style={disabledLabel}>
+            Disabled: <b>{disabled ? "true" : "false"}</b>
+          </h6>
+          {PSEUDO_STATES.map((state) => {
+            return (
+              <div style={stateLevel}>
+                {disabledIndex % 2 ? (
+                  false
+                ) : (
+                  <h6 style={stateLabel}>
+                    State: <b>{state}</b>
+                  </h6>
+                )}
+                <RawButton
+                  {...props}
+                  data-testid="button"
+                  sdsStyle={sdsStyle}
+                  sdsType={type}
+                  startIcon={icon}
+                  disabled={disabled}
+                  className={`pseudo-${state}`}
+                  key={state}
+                >
+                  {TEXT}
+                </RawButton>
+              </div>
+            );
+          })}
+        </div>
       );
     }
   },

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -63,11 +63,11 @@ export const Default = {
 // Live Preview
 
 const styleLevel = {
-  fontFamily: "sans-serif",
+  columnGap: "20px",
   display: "inline-grid",
+  fontFamily: "sans-serif",
   gridColumnTemplate:
     "min-content min-content min-content min-content min-content",
-  columnGap: "20px",
   marginRight: "50px",
 };
 const displayContents = {
@@ -81,33 +81,35 @@ const stateLevel = {
 };
 
 const styleLabel = {
+  fontSize: "2em",
   fontWeight: "normal",
   gridColumn: "2 / 6",
   marginBottom: 0,
 };
 const typeLabel = {
-  fontWeight: "normal",
-  gridColumn: "2 / 6",
   borderStyle: "solid none none none",
   borderWidth: "2px",
+  fontSize: "1.17em",
+  fontWeight: "normal",
+  gridColumn: "2 / 6",
   justifySelf: "stretch",
   margin: "20px 0",
   paddingTop: 10,
 };
 const iconLabel = {
-  fontWeight: "normal",
-  gridColumn: "2 / 6",
+  alignSelf: "end",
   borderStyle: "solid none none none",
   borderWidth: "1px",
+  fontWeight: "normal",
+  gridColumn: "2 / 6",
   justifySelf: "stretch",
-  alignSelf: "end",
   margin: "0 0 5px 0",
   paddingTop: 10,
 };
 const disabledLabel = {
+  alignSelf: "end",
   fontWeight: "normal",
   gridColumn: "1 / 2",
-  alignSelf: "end",
   marginTop: 0,
 };
 const stateLabel = {
@@ -135,9 +137,9 @@ export const LivePreview = {
     function ButtonStyleOption({ sdsStyle }) {
       return (
         <div style={styleLevel}>
-          <h1 style={styleLabel}>
+          <h3 style={styleLabel}>
             Style: <b>{sdsStyle}</b>
-          </h1>
+          </h3>
           {SDS_TYPES.map((type) => {
             return (
               <ButtonTypeOption sdsStyle={sdsStyle} type={type} key={type} />
@@ -151,9 +153,9 @@ export const LivePreview = {
     function ButtonTypeOption({ sdsStyle, type }) {
       return (
         <div style={displayContents}>
-          <h3 style={typeLabel}>
+          <h4 style={typeLabel}>
             Type: <b>{type}</b>
-          </h3>
+          </h4>
           {type === "primary" ? (
             ICON_OPTIONS.map((icon) => {
               return (

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -173,14 +173,6 @@ export const LivePreview = {
               key={ICON_OPTIONS[0]}
             />
           )}
-          {/* {ICON_OPTIONS.map((icon) => {
-            return <ButtonIconOption
-              sdsStyle={sdsStyle}
-              type={type}
-              icon={icon} 
-              key={icon}
-            />;
-          })} */}
         </div>
       );
     }

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -66,8 +66,6 @@ const styleLevel = {
   columnGap: "20px",
   display: "inline-grid",
   fontFamily: "sans-serif",
-  gridColumnTemplate:
-    "min-content min-content min-content min-content min-content",
   marginRight: "50px",
 };
 const displayContents = {
@@ -134,7 +132,11 @@ export const LivePreview = {
     );
 
     // loop through all SDS_TYPES + create headers for SDS_STYLES
-    function ButtonStyleOption({ sdsStyle }) {
+    function ButtonStyleOption({
+      sdsStyle,
+    }: {
+      sdsStyle: (typeof SDS_STYLES)[number];
+    }) {
       return (
         <div style={styleLevel}>
           <h3 style={styleLabel}>
@@ -150,37 +152,52 @@ export const LivePreview = {
     }
 
     // loop through all ICON_OPTIONS + create headers for SDS_TYPES
-    function ButtonTypeOption({ sdsStyle, type }) {
+    function ButtonTypeOption({
+      sdsStyle,
+      type,
+    }: {
+      sdsStyle: (typeof SDS_STYLES)[number];
+      type: (typeof SDS_TYPES)[number];
+    }) {
       return (
         <div style={displayContents}>
           <h4 style={typeLabel}>
             Type: <b>{type}</b>
           </h4>
-          {type === "primary" ? (
+          {/* Minimal Secondary doesn't have icon button option */}
+          {sdsStyle === "minimal" && type === "secondary" ? (
+            <ButtonIconOption
+              sdsStyle={sdsStyle}
+              type={type}
+              icon={ICON_OPTIONS[0]}
+              key={String(ICON_OPTIONS[0])}
+            />
+          ) : (
             ICON_OPTIONS.map((icon) => {
               return (
                 <ButtonIconOption
                   sdsStyle={sdsStyle}
                   type={type}
                   icon={icon}
-                  key={icon}
+                  key={String(icon)}
                 />
               );
             })
-          ) : (
-            <ButtonIconOption
-              sdsStyle={sdsStyle}
-              type={type}
-              icon={ICON_OPTIONS[0]}
-              key={ICON_OPTIONS[0]}
-            />
           )}
         </div>
       );
     }
 
     // loop through all DISABLED_OPTIONS + create headers for ICON_OPTIONS
-    function ButtonIconOption({ sdsStyle, type, icon }) {
+    function ButtonIconOption({
+      sdsStyle,
+      type,
+      icon,
+    }: {
+      sdsStyle: (typeof SDS_STYLES)[number];
+      type: (typeof SDS_TYPES)[number];
+      icon: (typeof ICON_OPTIONS)[number];
+    }) {
       return (
         <div style={displayContents}>
           <h5 style={iconLabel}>
@@ -193,7 +210,7 @@ export const LivePreview = {
                 type={type}
                 icon={icon}
                 disabled={disabled}
-                key={disabled}
+                key={String(disabled)}
                 disabledIndex={disabledIndex}
               />
             );
@@ -209,6 +226,12 @@ export const LivePreview = {
       icon,
       disabled,
       disabledIndex,
+    }: {
+      sdsStyle: (typeof SDS_STYLES)[number];
+      type: (typeof SDS_TYPES)[number];
+      icon: (typeof ICON_OPTIONS)[number];
+      disabled: (typeof DISABLED_OPTIONS)[number];
+      disabledIndex: number;
     }) {
       return (
         <div style={disabledLevel}>

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -26,16 +26,16 @@ export default {
     // https://storybook.js.org/docs/react/essentials/actions#action-argtype-annotation
     onClick: { action: actions.onClick },
     sdsStyle: {
-      control: { sdsType: "select" },
+      control: { type: "select" },
       options: SDS_STYLES,
     },
     sdsType: {
-      control: { sdsType: "select" },
+      control: { type: "select" },
       options: SDS_TYPES,
     },
     text: {
       control: {
-        sdsType: "text",
+        type: "text",
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15171,6 +15171,11 @@ storybook-addon-emotion-theme@^2.1.1:
     immutable "^3.8.2"
     recompose "^0.27.1"
 
+storybook-addon-pseudo-states@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-2.0.1.tgz#3c2f7219eb1c9aa125a33fe7d7570957dbc81578"
+  integrity sha512-k7btLopDyoZELDSvVYMzNhEInf+IWns8NGJbvCPBrZxkukhnYmzQ9aLxjPDwjBTfLxSewu9Yfx2qKGzKDj+/ng==
+
 storybook@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.0.5.tgz#079540e985832d1a2bc81fecdfbc11b9f6931caf"


### PR DESCRIPTION
## Updates Button component's Live Preview to show all styles, states, types in single view

**Updates for Chromatic tests**

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible (Lia: not sure...)
- [ ] If updating an existing component, depreciate flag has been used where necessary (Lia: I think not applicable...)
- [ ] Chromatic build verified by @chanzuckerberg/sds-design (Lia: don't know how to do this yet, but this PR by definition will change the existing previous Chromatic screenshot for Live Preview)

Now the Button component has a single Live Preview story page that houses: 
- all the button styles (rounded, square, minimal) 
- × all the button types (primary, primary with icon, secondary, secondary with icon (except minimal style doesn't have this last one)
- × whether the button has an icon or not
- ×  whether the button is disabled or not (added May 3)
- × all their states (default, hover, active, focus-visible)

This will make it simpler for Chromatic testing: there will just need to be a single screenshot of this story page to compare every possible button permutation against in one go.

**Update (May 3):** 
I have updated the Button Live Preview to be more similar to the Tag's Live Preview (PR #445 ), which I worked on right after this Button story initially. Now the Button Live Preview story includes permutations for whether it is disabled or not, as well as labels for each of the permutations' dimensions. The way the icon is called or not is also more "DRY".

![new live preview layout](https://user-images.githubusercontent.com/17435353/236053104-51e1cca8-fa84-44b9-af45-309b898a8a78.png)
