### PR TITLE
chore: Update ComplexFilter 'label' type from string to ReactNode

### DIFF
--- a/packages/components/src/core/ComplexFilter/index.tsx
+++ b/packages/components/src/core/ComplexFilter/index.tsx
@@ -2,7 +2,7 @@ import {
   AutocompleteCloseReason,
   AutocompleteValue,
 } from "@mui/material/useAutocomplete";
-import React, { useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { Value } from "../Dropdown";
 import DropdownMenu, { DefaultDropdownMenuOption } from "../DropdownMenu";
 import { StyledPopper } from "../DropdownMenu/style";
@@ -17,7 +17,7 @@ export {
   InputDropdown as ComplexFilterInputDropdown,
 };
 export interface ComplexFilterProps<Multiple> {
-  label: string;
+  label: ReactNode;
   options: DefaultDropdownMenuOption[];
   multiple?: Multiple;
   search?: boolean;


### PR DESCRIPTION
## Summary
Changes ComplexFilter 'label' type from `string` to `ReactNode`. The Dropdown has label defined as ReactNode so I expected the ComplexFilter to also be a ReactNode -- https://github.com/chanzuckerberg/sci-components/blob/main/packages/components/src/core/Dropdown/index.tsx#L46
