### PR TITLE
test(button): update Button Chromatic test's disabled iterations

### DIFF
--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -199,56 +199,204 @@ export const MinimalLivePreview = {
 
 // Screenshot Test
 
-const topLevel: React.CSSProperties = {
-  columnGap: "20px",
-  display: "inline-grid",
-  fontFamily: "sans-serif",
-  marginRight: "50px",
-};
-const displayContents: React.CSSProperties = {
-  display: "contents",
-};
-const penultimateLevel: React.CSSProperties = {
-  display: "contents",
-};
-const bottomLevel: React.CSSProperties = {
-  marginBottom: 10,
-};
-const fontWeightNormal: React.CSSProperties = {
-  fontWeight: "normal",
-};
-const topLabel: React.CSSProperties = {
-  ...fontWeightNormal,
-  fontSize: "2em",
-  gridColumn: "1 / 6",
-  marginBottom: 0,
-};
-const midLabel: React.CSSProperties = {
-  ...fontWeightNormal,
-  borderStyle: "solid none none none",
-  gridColumn: "1 / 6",
-  justifySelf: "stretch",
-  paddingTop: 10,
-};
-const secondLabel: React.CSSProperties = {
-  ...midLabel,
-  borderWidth: "2px",
-  fontSize: "1.17em",
-  margin: "20px 0",
-};
-const thirdLabel: React.CSSProperties = {
-  ...midLabel,
-  alignSelf: "end",
-  borderWidth: "1px",
-  fontWeight: "normal",
-  margin: "0 0 5px 0",
-};
-const bottomLabel: React.CSSProperties = {
-  ...fontWeightNormal,
-  margin: "10px 0",
+const ScreenshotTestDemo = (props: Args): JSX.Element => {
+  const topLevel: React.CSSProperties = {
+    columnGap: "20px",
+    display: "inline-grid",
+    fontFamily: "sans-serif",
+    marginRight: "50px",
+  };
+  const displayContents: React.CSSProperties = {
+    display: "contents",
+  };
+  const penultimateLevel: React.CSSProperties = {
+    display: "contents",
+  };
+  const bottomLevel: React.CSSProperties = {
+    marginBottom: 10,
+  };
+  const fontWeightNormal: React.CSSProperties = {
+    fontWeight: "normal",
+  };
+  const topLabel: React.CSSProperties = {
+    ...fontWeightNormal,
+    fontSize: "2em",
+    gridColumn: "1 / 6",
+    marginBottom: 0,
+  };
+  const midLabel: React.CSSProperties = {
+    ...fontWeightNormal,
+    borderStyle: "solid none none none",
+    gridColumn: "1 / 6",
+    justifySelf: "stretch",
+    paddingTop: 10,
+  };
+  const secondLabel: React.CSSProperties = {
+    ...midLabel,
+    borderWidth: "2px",
+    fontSize: "1.17em",
+    margin: "20px 0",
+  };
+  const thirdLabel: React.CSSProperties = {
+    ...midLabel,
+    alignSelf: "end",
+    borderWidth: "1px",
+    fontWeight: "normal",
+    margin: "0 0 5px 0",
+  };
+  const bottomLabel: React.CSSProperties = {
+    ...fontWeightNormal,
+    margin: "10px 0",
+  };
+
+  // loop through all SDS_STYLES
+  return (
+    <>
+      {SDS_STYLES.map((sdsStyle) => {
+        return <ButtonStyleOption sdsStyle={sdsStyle} key={sdsStyle} />;
+      })}
+    </>
+  );
+
+  // loop through all SDS_TYPES + create headers for SDS_STYLES
+  function ButtonStyleOption({
+    sdsStyle,
+  }: {
+    sdsStyle: (typeof SDS_STYLES)[number];
+  }) {
+    return (
+      <div style={topLevel}>
+        <h3 style={topLabel}>
+          Style: <b>{sdsStyle}</b>
+        </h3>
+        {SDS_TYPES.map((type) => {
+          return (
+            <ButtonTypeOption sdsStyle={sdsStyle} type={type} key={type} />
+          );
+        })}
+      </div>
+    );
+  }
+
+  // loop through all ICON_OPTIONS + create headers for SDS_TYPES
+  function ButtonTypeOption({
+    sdsStyle,
+    type,
+  }: {
+    sdsStyle: (typeof SDS_STYLES)[number];
+    type: (typeof SDS_TYPES)[number];
+  }) {
+    return (
+      <div style={displayContents}>
+        <h4 style={secondLabel}>
+          Type: <b>{type}</b>
+        </h4>
+        {/* Minimal Secondary doesn't have icon button option */}
+        {sdsStyle === "minimal" && type === "secondary" ? (
+          <ButtonIconOption
+            sdsStyle={sdsStyle}
+            type={type}
+            icon={ICON_OPTIONS[0]}
+            key={String(ICON_OPTIONS[0])}
+          />
+        ) : (
+          ICON_OPTIONS.map((icon) => {
+            return (
+              <ButtonIconOption
+                sdsStyle={sdsStyle}
+                type={type}
+                icon={icon}
+                key={String(icon)}
+              />
+            );
+          })
+        )}
+      </div>
+    );
+  }
+
+  // loop through all DISABLED_OPTIONS + create headers for ICON_OPTIONS
+  function ButtonIconOption({
+    sdsStyle,
+    type,
+    icon,
+  }: {
+    sdsStyle: (typeof SDS_STYLES)[number];
+    type: (typeof SDS_TYPES)[number];
+    icon: (typeof ICON_OPTIONS)[number];
+  }) {
+    return (
+      <div style={displayContents}>
+        <h5 style={thirdLabel}>
+          Icon: <b>{icon ? "yes" : "no"}</b>
+        </h5>
+        {DISABLED_OPTIONS.map((disabled) => {
+          return (
+            <ButtonDisabledOption
+              sdsStyle={sdsStyle}
+              type={type}
+              icon={icon}
+              disabled={disabled}
+              key={String(disabled)}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  // loop through all PSEUDO_STATES + create headers for DISABLED_OPTIONS, PSEUDO_STATES
+  function ButtonDisabledOption({
+    sdsStyle,
+    type,
+    icon,
+    disabled,
+  }: {
+    sdsStyle: (typeof SDS_STYLES)[number];
+    type: (typeof SDS_TYPES)[number];
+    icon: (typeof ICON_OPTIONS)[number];
+    disabled: (typeof DISABLED_OPTIONS)[number];
+  }) {
+    return (
+      <div style={penultimateLevel}>
+        {PSEUDO_STATES.map((state) => {
+          return (
+            <div style={bottomLevel}>
+              {/* removes irrelevant disabled iterations: when combined with all pseudo-states except default, `disabled=false` is impossible */}
+              {(disabled === false ||
+                (disabled === true && state === "default")) && (
+                <>
+                  <h6 style={bottomLabel}>
+                    {disabled === false ? "State: " : "Disabled: "}
+                    <br />
+                    <b>{disabled === false ? state : "true"}</b>
+                  </h6>
+                  <RawButton
+                    {...props}
+                    data-testid="button"
+                    sdsStyle={sdsStyle}
+                    sdsType={type}
+                    startIcon={icon}
+                    disabled={disabled}
+                    className={`pseudo-${state}`}
+                    key={state}
+                  >
+                    {TEXT}
+                  </RawButton>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 };
 
 export const ScreenshotTest = {
+  args: {
+    label: "Label",
+  },
   parameters: {
     controls: {
       exclude: ["onClick", "sdsStyle", "sdsType", "text"],
@@ -257,151 +405,7 @@ export const ScreenshotTest = {
       skip: true,
     },
   },
-  render: (props: Args): JSX.Element => {
-    // loop through all SDS_STYLES
-    return (
-      <>
-        {SDS_STYLES.map((sdsStyle) => {
-          return <ButtonStyleOption sdsStyle={sdsStyle} key={sdsStyle} />;
-        })}
-      </>
-    );
-
-    // loop through all SDS_TYPES + create headers for SDS_STYLES
-    function ButtonStyleOption({
-      sdsStyle,
-    }: {
-      sdsStyle: (typeof SDS_STYLES)[number];
-    }) {
-      return (
-        <div style={topLevel}>
-          <h3 style={topLabel}>
-            Style: <b>{sdsStyle}</b>
-          </h3>
-          {SDS_TYPES.map((type) => {
-            return (
-              <ButtonTypeOption sdsStyle={sdsStyle} type={type} key={type} />
-            );
-          })}
-        </div>
-      );
-    }
-
-    // loop through all ICON_OPTIONS + create headers for SDS_TYPES
-    function ButtonTypeOption({
-      sdsStyle,
-      type,
-    }: {
-      sdsStyle: (typeof SDS_STYLES)[number];
-      type: (typeof SDS_TYPES)[number];
-    }) {
-      return (
-        <div style={displayContents}>
-          <h4 style={secondLabel}>
-            Type: <b>{type}</b>
-          </h4>
-          {/* Minimal Secondary doesn't have icon button option */}
-          {sdsStyle === "minimal" && type === "secondary" ? (
-            <ButtonIconOption
-              sdsStyle={sdsStyle}
-              type={type}
-              icon={ICON_OPTIONS[0]}
-              key={String(ICON_OPTIONS[0])}
-            />
-          ) : (
-            ICON_OPTIONS.map((icon) => {
-              return (
-                <ButtonIconOption
-                  sdsStyle={sdsStyle}
-                  type={type}
-                  icon={icon}
-                  key={String(icon)}
-                />
-              );
-            })
-          )}
-        </div>
-      );
-    }
-
-    // loop through all DISABLED_OPTIONS + create headers for ICON_OPTIONS
-    function ButtonIconOption({
-      sdsStyle,
-      type,
-      icon,
-    }: {
-      sdsStyle: (typeof SDS_STYLES)[number];
-      type: (typeof SDS_TYPES)[number];
-      icon: (typeof ICON_OPTIONS)[number];
-    }) {
-      return (
-        <div style={displayContents}>
-          <h5 style={thirdLabel}>
-            Icon: <b>{icon ? "yes" : "no"}</b>
-          </h5>
-          {DISABLED_OPTIONS.map((disabled) => {
-            return (
-              <ButtonDisabledOption
-                sdsStyle={sdsStyle}
-                type={type}
-                icon={icon}
-                disabled={disabled}
-                key={String(disabled)}
-              />
-            );
-          })}
-        </div>
-      );
-    }
-
-    // loop through all PSEUDO_STATES + create headers for DISABLED_OPTIONS, PSEUDO_STATES
-    function ButtonDisabledOption({
-      sdsStyle,
-      type,
-      icon,
-      disabled,
-    }: {
-      sdsStyle: (typeof SDS_STYLES)[number];
-      type: (typeof SDS_TYPES)[number];
-      icon: (typeof ICON_OPTIONS)[number];
-      disabled: (typeof DISABLED_OPTIONS)[number];
-    }) {
-      return (
-        <div style={penultimateLevel}>
-          {PSEUDO_STATES.map((state) => {
-            return (
-              <div style={bottomLevel}>
-                {/* removes irrelevant disabled iterations: when combined with all pseudo-states except default, `disabled=false` is impossible */}
-                {(disabled === false ||
-                  (disabled === true && state === "default")) && (
-                  <>
-                    <h6 style={bottomLabel}>
-                      {disabled === false ? "State: " : "Disabled: "}
-                      <br />
-                      <b>{disabled === false ? state : "true"}</b>
-                    </h6>
-
-                    <RawButton
-                      {...props}
-                      data-testid="button"
-                      sdsStyle={sdsStyle}
-                      sdsType={type}
-                      startIcon={icon}
-                      disabled={disabled}
-                      className={`pseudo-${state}`}
-                      key={state}
-                    >
-                      {TEXT}
-                    </RawButton>
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      );
-    }
-  },
+  render: (args: Args) => <ScreenshotTestDemo {...args} />,
 };
 
 // Test

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -62,61 +62,60 @@ export const Default = {
 
 // Live Preview
 
-const styleLevel = {
+const topLevel: React.CSSProperties = {
   columnGap: "20px",
   display: "inline-grid",
   fontFamily: "sans-serif",
   marginRight: "50px",
 };
-const displayContents = {
+const displayContents: React.CSSProperties = {
   display: "contents",
 };
-const disabledLevel = {
+const penultimateLevel: React.CSSProperties = {
   display: "contents",
 };
-const stateLevel = {
+const bottomLevel: React.CSSProperties = {
   marginBottom: 10,
 };
-
-const styleLabel = {
-  fontSize: "2em",
+const fontWeightNormal: React.CSSProperties = {
   fontWeight: "normal",
-  gridColumn: "2 / 6",
+};
+const topLabel: React.CSSProperties = {
+  ...fontWeightNormal,
+  fontSize: "2em",
+  gridColumn: "1 / 6",
   marginBottom: 0,
 };
-const typeLabel = {
+const midLabel: React.CSSProperties = {
+  ...fontWeightNormal,
   borderStyle: "solid none none none",
+  gridColumn: "1 / 6",
+  justifySelf: "stretch",
+  paddingTop: 10,
+};
+const secondLabel: React.CSSProperties = {
+  ...midLabel,
   borderWidth: "2px",
   fontSize: "1.17em",
-  fontWeight: "normal",
-  gridColumn: "2 / 6",
-  justifySelf: "stretch",
   margin: "20px 0",
-  paddingTop: 10,
 };
-const iconLabel = {
+const thirdLabel: React.CSSProperties = {
+  ...midLabel,
   alignSelf: "end",
-  borderStyle: "solid none none none",
   borderWidth: "1px",
   fontWeight: "normal",
-  gridColumn: "2 / 6",
-  justifySelf: "stretch",
   margin: "0 0 5px 0",
-  paddingTop: 10,
 };
-const disabledLabel = {
-  alignSelf: "end",
-  fontWeight: "normal",
-  gridColumn: "1 / 2",
-  marginTop: 0,
-};
-const stateLabel = {
-  fontWeight: "normal",
+const bottomLabel: React.CSSProperties = {
+  ...fontWeightNormal,
   margin: "10px 0",
 };
 
 export const LivePreview = {
   parameters: {
+    controls: {
+      exclude: ["onClick", "sdsStyle", "sdsType", "text"],
+    },
     snapshot: {
       skip: true,
     },
@@ -138,8 +137,8 @@ export const LivePreview = {
       sdsStyle: (typeof SDS_STYLES)[number];
     }) {
       return (
-        <div style={styleLevel}>
-          <h3 style={styleLabel}>
+        <div style={topLevel}>
+          <h3 style={topLabel}>
             Style: <b>{sdsStyle}</b>
           </h3>
           {SDS_TYPES.map((type) => {
@@ -161,7 +160,7 @@ export const LivePreview = {
     }) {
       return (
         <div style={displayContents}>
-          <h4 style={typeLabel}>
+          <h4 style={secondLabel}>
             Type: <b>{type}</b>
           </h4>
           {/* Minimal Secondary doesn't have icon button option */}
@@ -200,10 +199,10 @@ export const LivePreview = {
     }) {
       return (
         <div style={displayContents}>
-          <h5 style={iconLabel}>
+          <h5 style={thirdLabel}>
             Icon: <b>{icon ? "yes" : "no"}</b>
           </h5>
-          {DISABLED_OPTIONS.map((disabled, disabledIndex) => {
+          {DISABLED_OPTIONS.map((disabled) => {
             return (
               <ButtonDisabledOption
                 sdsStyle={sdsStyle}
@@ -211,7 +210,6 @@ export const LivePreview = {
                 icon={icon}
                 disabled={disabled}
                 key={String(disabled)}
-                disabledIndex={disabledIndex}
               />
             );
           })}
@@ -225,41 +223,40 @@ export const LivePreview = {
       type,
       icon,
       disabled,
-      disabledIndex,
     }: {
       sdsStyle: (typeof SDS_STYLES)[number];
       type: (typeof SDS_TYPES)[number];
       icon: (typeof ICON_OPTIONS)[number];
       disabled: (typeof DISABLED_OPTIONS)[number];
-      disabledIndex: number;
     }) {
       return (
-        <div style={disabledLevel}>
-          <h6 style={disabledLabel}>
-            Disabled: <b>{disabled ? "true" : "false"}</b>
-          </h6>
+        <div style={penultimateLevel}>
           {PSEUDO_STATES.map((state) => {
             return (
-              <div style={stateLevel}>
-                {disabledIndex % 2 ? (
-                  false
-                ) : (
-                  <h6 style={stateLabel}>
-                    State: <b>{state}</b>
-                  </h6>
+              <div style={bottomLevel}>
+                {(disabled === false ||
+                  (disabled === true && state === "default")) && (
+                  <>
+                    <h6 style={bottomLabel}>
+                      {disabled === false ? "State: " : "Disabled: "}
+                      <br />
+                      <b>{disabled === false ? state : "true"}</b>
+                    </h6>
+
+                    <RawButton
+                      {...props}
+                      data-testid="button"
+                      sdsStyle={sdsStyle}
+                      sdsType={type}
+                      startIcon={icon}
+                      disabled={disabled}
+                      className={`pseudo-${state}`}
+                      key={state}
+                    >
+                      {TEXT}
+                    </RawButton>
+                  </>
                 )}
-                <RawButton
-                  {...props}
-                  data-testid="button"
-                  sdsStyle={sdsStyle}
-                  sdsType={type}
-                  startIcon={icon}
-                  disabled={disabled}
-                  className={`pseudo-${state}`}
-                  key={state}
-                >
-                  {TEXT}
-                </RawButton>
               </div>
             );
           })}

--- a/packages/components/src/core/Button/index.stories.tsx
+++ b/packages/components/src/core/Button/index.stories.tsx
@@ -60,7 +60,144 @@ export const Default = {
   },
 };
 
-// Live Preview
+// Rounded Live Preview
+
+const placementStyles: React.CSSProperties = {
+  display: "grid",
+  gridColumnGap: "10px",
+  gridRowGap: "0px",
+  gridTemplateColumns: "repeat(6, 120px)",
+  gridTemplateRows: "1fr",
+};
+
+const RoundedLivePreviewDemo = (props: Args): JSX.Element => {
+  return (
+    <div style={placementStyles}>
+      <RawButton {...props} sdsStyle="rounded" sdsType="primary">
+        {TEXT}
+      </RawButton>
+      <RawButton
+        {...props}
+        startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
+        sdsStyle="rounded"
+        sdsType="primary"
+      >
+        {TEXT}
+      </RawButton>
+      <RawButton {...props} sdsStyle="rounded" sdsType="secondary">
+        {TEXT}
+      </RawButton>
+      <RawButton
+        {...props}
+        startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
+        sdsStyle="rounded"
+        sdsType="secondary"
+      >
+        {TEXT}
+      </RawButton>
+    </div>
+  );
+};
+
+export const RoundedLivePreview = {
+  args: {
+    label: "Label",
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+  render: (args: Args) => <RoundedLivePreviewDemo {...args} />,
+};
+
+// Square Live Preview
+
+const SquareLivePreviewDemo = (props: Args): JSX.Element => {
+  return (
+    <div style={placementStyles as React.CSSProperties}>
+      <RawButton {...props} sdsStyle="square" sdsType="primary">
+        {TEXT}
+      </RawButton>
+      <RawButton
+        {...props}
+        startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
+        sdsStyle="square"
+        sdsType="primary"
+      >
+        {TEXT}
+      </RawButton>
+      <RawButton {...props} sdsStyle="square" sdsType="secondary">
+        {TEXT}
+      </RawButton>
+      <RawButton
+        {...props}
+        startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
+        sdsStyle="square"
+        sdsType="secondary"
+      >
+        {TEXT}
+      </RawButton>
+    </div>
+  );
+};
+
+export const SquareLivePreview = {
+  args: {
+    label: "Label",
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+  render: (args: Args) => <SquareLivePreviewDemo {...args} />,
+};
+
+// Minimal Live Preview
+
+const MinimalLivePreviewDemo = (props: Args): JSX.Element => {
+  const minimalPlacementStyles: React.CSSProperties = {
+    display: "grid",
+    gridColumnGap: "24px",
+    gridRowGap: "0px",
+    gridTemplateColumns: "repeat(3, min-content)",
+    gridTemplateRows: "1fr",
+  };
+
+  return (
+    <div style={minimalPlacementStyles}>
+      <RawButton {...props} sdsStyle="minimal" sdsType="primary">
+        {TEXT}
+      </RawButton>
+      <RawButton
+        {...props}
+        startIcon={<Icon sdsIcon="download" sdsSize="s" sdsType="button" />}
+        sdsStyle="minimal"
+        sdsType="primary"
+      >
+        {TEXT}
+      </RawButton>
+      <RawButton {...props} sdsStyle="minimal" sdsType="secondary">
+        {TEXT}
+      </RawButton>
+    </div>
+  );
+};
+
+export const MinimalLivePreview = {
+  args: {
+    label: "Label",
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+  render: (args: Args) => <MinimalLivePreviewDemo {...args} />,
+};
+
+// Screenshot Test
 
 const topLevel: React.CSSProperties = {
   columnGap: "20px",
@@ -111,7 +248,7 @@ const bottomLabel: React.CSSProperties = {
   margin: "10px 0",
 };
 
-export const LivePreview = {
+export const ScreenshotTest = {
   parameters: {
     controls: {
       exclude: ["onClick", "sdsStyle", "sdsType", "text"],
@@ -234,6 +371,7 @@ export const LivePreview = {
           {PSEUDO_STATES.map((state) => {
             return (
               <div style={bottomLevel}>
+                {/* removes irrelevant disabled iterations: when combined with all pseudo-states except default, `disabled=false` is impossible */}
                 {(disabled === false ||
                   (disabled === true && state === "default")) && (
                   <>


### PR DESCRIPTION
## Summary
**Button**
Github issue: N/A

I updated the Live Preview story for Button so that the disabled iteration is in the same row, visually, as the pseudo-states. Disabled elements cannot be interacted with so cannot ever have any pseudo-state other than default, so it does not make sense to loop the `disabled = true` status through every pseudo-state iteration, only through the default state. Furthermore, the Storybook addon we use to simulate pseudo states does not properly render the states when `disabled=true` (it shows them as having hover, active, and focus statues visually which is not actually possible). So I removed every permutation of the Button for `disabled=true`, except for the case where pseudo-state is default. Then I put this instance in the same row in the UI as the other pseudo-state iterations of ButtonIcon; this matches how components are shown in Zeroheight as well.

This update makes more sense because it's not actually possible to have disabled x hover, disabled x active, or disabled x focus states, however these had been rendered in the Live Preview story, which was misleading.

More about the disabled attribute for context:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
- https://johnsweetaccessibility.com/2020/07/can-i-focus-disabled-controls/

Other updates:
- Changed the names of the style `const`s to be more generic, for potential reuse and / or adoption of reusable styles for across multiple Live Preview stories
- Removed control panel options since changing them didn't actually do anything, and this story page already shows every possible relevant combination of options anyway

**New layout, with single disabled component per iteration:**
![Screenshot 2023-05-12 at 3 42 04 PM](https://github.com/chanzuckerberg/sci-components/assets/17435353/ea38b14b-c0b8-4c22-8532-62a235e32dd8)

**Old layout, with false focus state shown upon disabled components:**
![old-layout](https://github.com/chanzuckerberg/sci-components/assets/17435353/3f4f6663-bc8e-462b-a17a-93b9e06d4b53)



## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
