### PR TITLE
test(link): link screenshot test

### DIFF
--- a/packages/components/src/core/Link/index.stories.tsx
+++ b/packages/components/src/core/Link/index.stories.tsx
@@ -74,3 +74,73 @@ export const LivePreview = {
   },
   render: (args: Args) => <LivePreviewDemo {...args} />,
 };
+
+// Screenshot test
+const ScreenshotTestDemo = (): JSX.Element => {
+  const SDS_STYLES = ["default", "dashed"];
+  const PSEUDO_STATES = ["default", "hover", "active", "focus"];
+
+  // loop through all SDS_STYLES
+  return (
+    <>
+      {SDS_STYLES.map((sdsStyle) => {
+        return <LinkStyle sdsStyle={sdsStyle} key={sdsStyle} />;
+      })}
+    </>
+  );
+
+  // loop through all PSEUDO_STATES + create headers for SDS_STYLES, PSEUDO_STATES
+  function LinkStyle({ sdsStyle }: { sdsStyle: (typeof SDS_STYLES)[number] }) {
+    const STYLE_LEVEL: React.CSSProperties = {
+      columnGap: "20px",
+      display: "inline-grid",
+      fontFamily: "sans-serif",
+      marginRight: 50,
+    };
+    const STYLE_LABEL: React.CSSProperties = {
+      fontSize: "2em",
+      gridColumn: "1 / 5",
+      marginBottom: 10,
+    };
+    const PSEUDO_STATE_LABEL: React.CSSProperties = {
+      fontSize: "0.67em",
+      marginBottom: 15,
+    };
+    return (
+      <div style={STYLE_LEVEL}>
+        <p style={STYLE_LABEL}>
+          Style: <b>{sdsStyle}</b>
+        </p>
+        {PSEUDO_STATES.map((state) => {
+          return (
+            <div>
+              <p style={PSEUDO_STATE_LABEL}>
+                State: <b>{state}</b>
+              </p>
+              <RawLink
+                href="/"
+                sdsStyle={sdsStyle}
+                className={`pseudo-${state}`}
+                key={state}
+              >
+                Link text
+              </RawLink>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+};
+
+export const ScreenshotTest = {
+  parameters: {
+    controls: {
+      exclude: ["sdsStyle"],
+    },
+    snapshot: {
+      skip: true,
+    },
+  },
+  render: (args: Args) => <ScreenshotTestDemo {...args} />,
+};


### PR DESCRIPTION
Chromatic screenshot test for Link component, iterates through its sdsStyle's and pseudo-states
re #494

## Summary

**Link**
Github issue: #494

### Permutation dimensions to include
- [x] **sdsStyle:** default, dashed
- [x] **pseudo-state:** default, hover, active, focus

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [ ] Test Story in Storybook // liaprins: This one does not seem to exist yet
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary // liaprins: N/A
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
