### PR TITLE
test(notification): notification screenshot test

### DIFF
--- a/packages/components/src/core/Notification/index.stories.tsx
+++ b/packages/components/src/core/Notification/index.stories.tsx
@@ -3,7 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { Args, Meta } from "@storybook/react";
 import React from "react";
 import Button from "../Button";
-import RawNotification from "./index";
+import RawNotification, { NotificationProps } from "./index";
 
 const Notification = (props: Args): JSX.Element => {
   const {
@@ -182,6 +182,138 @@ export const LivePreview = {
     },
   },
   render: (args: Args) => <LivePreviewDemo {...args} />,
+};
+
+// Screenshot test
+const ScreenshotTestDemo = (): JSX.Element => {
+  const INTENT_OPTIONS: NotificationProps["intent"][] = [
+    "info",
+    "error",
+    "success",
+    "warning",
+  ];
+  const EXTRA_CONTENT_OPTIONS = [false, true];
+  const BUTTON_ON_CLICK_OPTIONS: NotificationProps["buttonOnClick"][] = [
+    undefined,
+    action("onClick"),
+  ];
+
+  // loop through all INTENT_OPTIONS
+  return (
+    <>
+      {INTENT_OPTIONS.map((intent) => {
+        return <NotificationIntent intent={intent} key={intent} />;
+      })}
+    </>
+  );
+
+  // loop through all EXTRA_CONTENT_OPTIONS + create headers for INTENT_OPTIONS
+  function NotificationIntent({
+    intent,
+  }: {
+    intent: (typeof INTENT_OPTIONS)[number];
+  }) {
+    const LEVEL_STYLE: React.CSSProperties = {
+      columnGap: "25px",
+      display: "inline-grid",
+      fontFamily: "sans-serif",
+      marginLeft: "50px",
+    };
+    const LABEL_STYLE: React.CSSProperties = {
+      fontSize: "2em",
+      gridColumn: "1 / 3",
+      marginBottom: 0,
+    };
+    return (
+      <div style={LEVEL_STYLE}>
+        <p style={LABEL_STYLE}>
+          Intent: <b>{intent}</b>
+        </p>
+        {EXTRA_CONTENT_OPTIONS.map((extraContent) => {
+          return (
+            <NotificationExtraContent
+              intent={intent}
+              extraContent={extraContent}
+              key={String(extraContent)}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  // loop through all BUTTON_ON_CLICK_OPTIONS + create headers for EXTRA_CONTENT_OPTIONS, BUTTON_ON_CLICK_OPTIONS
+  function NotificationExtraContent({
+    intent,
+    extraContent,
+  }: {
+    intent: (typeof INTENT_OPTIONS)[number];
+    extraContent: boolean;
+  }) {
+    const EXTRA_CONTENT_LABEL_STYLE: React.CSSProperties = {
+      borderStyle: "solid none none none",
+      fontSize: "1.17em",
+      gridColumn: "1 / 3",
+      justifySelf: "stretch",
+      marginBottom: 10,
+      paddingTop: 10,
+    };
+    const BUTTON_ON_CLICK_LABEL_STYLE: React.CSSProperties = {
+      fontSize: "0.67em",
+      margin: "10px 0",
+    };
+    return (
+      <div style={{ display: "contents" }}>
+        <p style={EXTRA_CONTENT_LABEL_STYLE}>
+          Extra content: <b>{extraContent ? "yes" : "no"}</b>
+        </p>
+        {BUTTON_ON_CLICK_OPTIONS.map((buttonOnClick) => {
+          return (
+            <div>
+              <>
+                <p style={BUTTON_ON_CLICK_LABEL_STYLE}>
+                  Button: <b>{buttonOnClick ? "yes" : "no"}</b>
+                </p>
+                <RawNotification
+                  slideDirection="left"
+                  data-testid="notification"
+                  intent={intent}
+                  extraContent={extraContent}
+                  buttonOnClick={buttonOnClick}
+                  buttonText="click me"
+                  key={String(buttonOnClick)}
+                >
+                  Notification test text
+                  {extraContent && (
+                    <div>
+                      Lorem ipsum, dolor sit amet consectetur adipisicing elit.
+                      Amet eveniet sapiente, officiis aut possimus suscipit
+                      assumenda non?
+                    </div>
+                  )}
+                </RawNotification>
+              </>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+};
+
+export const ScreenshotTest = {
+  args: {
+    label: "Label",
+  },
+  parameters: {
+    // controls: {
+    //   exclude: ["onClick", "sdsStyle", "sdsType", "text"],
+    // },
+    snapshot: {
+      skip: true,
+    },
+  },
+  render: (args: Args) => <ScreenshotTestDemo {...args} />,
 };
 
 // Test

--- a/packages/components/src/core/Notification/index.stories.tsx
+++ b/packages/components/src/core/Notification/index.stories.tsx
@@ -306,9 +306,17 @@ export const ScreenshotTest = {
     label: "Label",
   },
   parameters: {
-    // controls: {
-    //   exclude: ["onClick", "sdsStyle", "sdsType", "text"],
-    // },
+    controls: {
+      exclude: [
+        "label",
+        "autoDismiss",
+        "buttonOnClick",
+        "extraContent",
+        "intent",
+        "onClose",
+        "slideDirection",
+      ],
+    },
     snapshot: {
       skip: true,
     },

--- a/packages/components/src/core/Notification/index.stories.tsx
+++ b/packages/components/src/core/Notification/index.stories.tsx
@@ -269,31 +269,29 @@ const ScreenshotTestDemo = (): JSX.Element => {
         </p>
         {BUTTON_ON_CLICK_OPTIONS.map((buttonOnClick) => {
           return (
-            <div>
-              <>
-                <p style={BUTTON_ON_CLICK_LABEL_STYLE}>
-                  Button: <b>{buttonOnClick ? "yes" : "no"}</b>
-                </p>
-                <RawNotification
-                  slideDirection="left"
-                  data-testid="notification"
-                  intent={intent}
-                  extraContent={extraContent}
-                  buttonOnClick={buttonOnClick}
-                  buttonText="click me"
-                  key={String(buttonOnClick)}
-                >
-                  Notification test text
-                  {extraContent && (
-                    <div>
-                      Lorem ipsum, dolor sit amet consectetur adipisicing elit.
-                      Amet eveniet sapiente, officiis aut possimus suscipit
-                      assumenda non?
-                    </div>
-                  )}
-                </RawNotification>
-              </>
-            </div>
+            <>
+              <p style={BUTTON_ON_CLICK_LABEL_STYLE}>
+                Button: <b>{buttonOnClick ? "yes" : "no"}</b>
+              </p>
+              <RawNotification
+                slideDirection="left"
+                data-testid="notification"
+                intent={intent}
+                extraContent={extraContent}
+                buttonOnClick={buttonOnClick}
+                buttonText="click me"
+                key={String(buttonOnClick)}
+              >
+                Notification test text
+                {extraContent && (
+                  <div>
+                    Lorem ipsum, dolor sit amet consectetur adipisicing elit.
+                    Amet eveniet sapiente, officiis aut possimus suscipit
+                    assumenda non?
+                  </div>
+                )}
+              </RawNotification>
+            </>
           );
         })}
       </div>


### PR DESCRIPTION
Chromatic screenshot test for Notification component, which iterates through all permutations of its intent x extraContent x buttonOnClick props

re #497

## Summary

**Notification**
Github issue: #497 
### Permutation dimensions to include
- [x] **intent:** info, error, success, warning
- [x] **extraContent:** [sample extra content], undefined
- [x] **buttonOnClick:** [yes], [no]

_Here's a screenshot of the UI:_
<img width="1044" alt="Screenshot 2023-06-05 at 3 27 51 PM" src="https://github.com/chanzuckerberg/sci-components/assets/17435353/3401158e-17c0-4ac7-a4fb-9ef56f53ba71">

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
