### PR TITLE
fix(navigationjumpto): fix window object issue in nodejs env

### DIFF
--- a/packages/components/src/core/NavigationJumpTo/useIntersection.ts
+++ b/packages/components/src/core/NavigationJumpTo/useIntersection.ts
@@ -12,9 +12,10 @@ export default function useInView(
     elementRef: React.MutableRefObject<HTMLElement | null>;
   }>
 ) {
-  // If IntersectionObserver is not available (e.g., in a test environment),
+  // If the window object is not available (e.g., in a node environment) or
+  // If the IntersectionObserver is not available (e.g., in a test environment),
   // return a default result indicating that all elements are not in view
-  if (!window.IntersectionObserver) {
+  if (typeof window === "undefined" || !window.IntersectionObserver) {
     return items.map((item) => {
       return {
         el: item.elementRef,


### PR DESCRIPTION
## Summary

**NavigationJumpTo**
Github issue: #513 

[Slack Issue](https://czi-sci.slack.com/archives/C032S43KKFV/p1686348140674099)

Server Side Rendering in Node doesn't have access to the window object, so it throws a runtime error ReferenceError: window is not defined.