### PR TITLE
feat(inputdropdown): implement new redesigned inputdropdown

### DIFF
--- a/packages/components/src/core/Banner/__snapshots__/banner.test.tsx.snap
+++ b/packages/components/src/core/Banner/__snapshots__/banner.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`<Banner /> Default story renders snapshot 1`] = `
   </div>
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-eusci7-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-fkerv1-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >

--- a/packages/components/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ButtonIcon/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ButtonIcon /> Default story renders snapshot 1`] = `
 <button
   aria-label="info"
-  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1x4beu0-MuiButtonBase-root-MuiIconButton-root"
+  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-7000mn-MuiButtonBase-root-MuiIconButton-root"
   tabindex="0"
   type="button"
 >

--- a/packages/components/src/core/ButtonIcon/style.ts
+++ b/packages/components/src/core/ButtonIcon/style.ts
@@ -175,7 +175,7 @@ export const StyledButtonIcon = styled(IconButton, {
 })`
   padding: 0;
 
-  :focus {
+  :focus-visible {
     outline: 5px auto Highlight;
     outline: 5px auto -webkit-focus-ring-color;
   }

--- a/packages/components/src/core/CellHeader/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/CellHeader/__snapshots__/index.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<CellHeader /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-8uz3p0-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-kqv049-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >

--- a/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1c74d6t-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-um4hlk-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"
@@ -15,7 +15,6 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
     >
       <span
         class="styled-label css-1ubkbz8"
-        sdstype="label"
       >
         Click Target
       </span>

--- a/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-150u2e1-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1c74d6t-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"
@@ -14,7 +14,8 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
       class="css-ae1gg6"
     >
       <span
-        class="styled-label css-1wq753n"
+        class="styled-label css-1ubkbz8"
+        sdstype="label"
       >
         Click Target
       </span>

--- a/packages/components/src/core/Dialog/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dialog/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 1`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1pznqzi-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1x5a14m-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -102,7 +102,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 4`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-11j1e9v-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1ct9aux-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -182,7 +182,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 7`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1y75vf0-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-zrciyy-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >
@@ -262,7 +262,7 @@ exports[`<Dialog /> Dialog all sizes match the snapshots 10`] = `
 >
   <button
     aria-label="Close"
-    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1y75vf0-MuiButtonBase-root-MuiIconButton-root"
+    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-zrciyy-MuiButtonBase-root-MuiIconButton-root"
     tabindex="0"
     type="button"
   >

--- a/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-150u2e1-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1c74d6t-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"
@@ -11,7 +11,8 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
     class="css-ae1gg6"
   >
     <span
-      class="styled-label css-1wq753n"
+      class="styled-label css-1ubkbz8"
+      sdstype="label"
     >
       Click Target
     </span>

--- a/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1c74d6t-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-um4hlk-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"
@@ -12,7 +12,6 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
   >
     <span
       class="styled-label css-1ubkbz8"
-      sdstype="label"
     >
       Click Target
     </span>

--- a/packages/components/src/core/DropdownMenu/index.stories.tsx
+++ b/packages/components/src/core/DropdownMenu/index.stories.tsx
@@ -267,7 +267,8 @@ const LivePreviewDemo = (): JSX.Element => {
           onClick={handleClick1}
           label="Click Target"
           sdsStage={open1 ? "userInput" : "default"}
-          sdsType="singleSelect"
+          sdsType="label"
+          multiple={false}
           sdsStyle="minimal"
         />
 
@@ -324,7 +325,8 @@ const LivePreviewDemo = (): JSX.Element => {
           onClick={handleClick3}
           label="Click Target"
           sdsStage={open3 ? "userInput" : "default"}
-          sdsType="multiSelect"
+          sdsType="label"
+          multiple
           sdsStyle="rounded"
         />
 
@@ -351,7 +353,8 @@ const LivePreviewDemo = (): JSX.Element => {
           onClick={handleClick4}
           label="Click Target"
           sdsStage={open4 ? "userInput" : "default"}
-          sdsType="multiSelect"
+          sdsType="label"
+          multiple
           sdsStyle="square"
         />
 

--- a/packages/components/src/core/InputDropdown/InputDropdown.namespace-test.tsx
+++ b/packages/components/src/core/InputDropdown/InputDropdown.namespace-test.tsx
@@ -1,5 +1,4 @@
 import { InputDropdown, InputDropdownProps } from "@czi-sds/components";
-import React from "react";
 import { noop } from "src/common/utils";
 
 const InputDropdownNameSpaceTest = (props: InputDropdownProps) => {
@@ -10,7 +9,8 @@ const InputDropdownNameSpaceTest = (props: InputDropdownProps) => {
       onClick={noop}
       sdsStage="userInput"
       sdsStyle="minimal"
-      sdsType="singleSelect"
+      multiple={false}
+      sdsType="label"
       counter="2"
       details="Details"
       intent="warning"

--- a/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<InputDropdown /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1eacwfg-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-yez6a5-MuiButtonBase-root-MuiButton-root"
   data-testid="InputDropdown"
   label="Label"
   tabindex="0"
@@ -12,7 +12,8 @@ exports[`<InputDropdown /> Default story renders snapshot 1`] = `
     class="css-18dv0oe"
   >
     <span
-      class="styled-label css-1wq753n"
+      class="styled-label css-1ubkbz8"
+      sdstype="label"
     >
       Label
     </span>

--- a/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -1,43 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<InputDropdown /> Default story renders snapshot 1`] = `
-<button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-yez6a5-MuiButtonBase-root-MuiButton-root"
-  data-testid="InputDropdown"
-  label="Label"
-  tabindex="0"
-  type="button"
->
-  <span
-    class="css-18dv0oe"
+<div>
+  <p>
+    The "Value" variant of InputDropdown cannot be set to "multiple". 
+    <br />
+    If you set sdsType="value" and multiple="true", the component will revert to displaying a label and a counter.
+  </p>
+  <button
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-yez6a5-MuiButtonBase-root-MuiButton-root"
+    data-testid="InputDropdown"
+    label="Label"
+    tabindex="0"
+    type="button"
   >
     <span
-      class="styled-label css-1ubkbz8"
-      sdstype="label"
+      class="css-18dv0oe"
     >
-      Label
+      <span
+        class="styled-label css-1ubkbz8"
+      >
+        Label
+      </span>
+      <span
+        class="css-1qt6g1x"
+      >
+        <div
+          class="css-1ft6wgl"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+            data-jest-file-name="IconChevronDownSmall.svg"
+            data-jest-svg-name="IconChevronDownSmall"
+            data-testid="IconChevronDownSmall"
+            fillcontrast="white"
+            focusable="false"
+            viewBox="0 0 14 14"
+          />
+        </div>
+      </span>
     </span>
     <span
-      class="css-1qt6g1x"
-    >
-      <div
-        class="css-1ft6wgl"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
-          data-jest-file-name="IconChevronDownSmall.svg"
-          data-jest-svg-name="IconChevronDownSmall"
-          data-testid="IconChevronDownSmall"
-          fillcontrast="white"
-          focusable="false"
-          viewBox="0 0 14 14"
-        />
-      </div>
-    </span>
-  </span>
-  <span
-    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-  />
-</button>
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+</div>
 `;

--- a/packages/components/src/core/InputDropdown/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/index.stories.tsx
@@ -119,7 +119,13 @@ const InputDropdown = (props: Args): JSX.Element => {
   ];
 
   return (
-    <>
+    <div>
+      <p>
+        The &quot;Value&quot; variant of InputDropdown cannot be set to
+        &quot;multiple&quot;. <br />
+        If you set sdsType=&quot;value&quot; and multiple=&quot;true&quot;, the
+        component will revert to displaying a label and a counter.
+      </p>
       {fullWidth ? (
         <RawInputDropdown
           disabled={disabled}
@@ -162,7 +168,7 @@ const InputDropdown = (props: Args): JSX.Element => {
         value={multiple ? pendingValue : value}
         onClickAway={handleClickAway}
       />
-    </>
+    </div>
   );
 };
 

--- a/packages/components/src/core/InputDropdown/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/index.stories.tsx
@@ -1,6 +1,8 @@
 import { styled } from "@mui/material/styles";
 import { Args, Meta } from "@storybook/react";
-import React, { useState } from "react";
+import { DefaultDropdownMenuOption } from "dist/index.cjs";
+import React, { useEffect, useState } from "react";
+import { noop } from "src/common/utils";
 import DropdownMenu from "../DropdownMenu";
 import RawInputDropdown from "./index";
 
@@ -8,17 +10,42 @@ const StyledInputDropdown = styled(RawInputDropdown)`
   ${({ width }: Args) => {
     return `
       width: fit-content;
-      max-width: ${width || 160}px;
+      max-width: ${width || 250}px;
     `;
   }}
 `;
 
 const InputDropdown = (props: Args): JSX.Element => {
-  const { disabled, fullWidth, label, sdsStyle, sdsType, multiple, ...rest } =
-    props;
+  const {
+    disabled,
+    fullWidth,
+    label,
+    sdsStyle,
+    multiple,
+    value: propValue,
+    ...rest
+  } = props;
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [open, setOpen] = useState(false);
+  const [details, setDetials] = useState<string>();
+  const [counter, setCounter] = useState<string>();
+  const [inputDropdownValue, setInputDropdownValue] = useState<string>();
+
+  const [value, setValue] = useState<
+    DefaultDropdownMenuOption | DefaultDropdownMenuOption[] | null
+  >(getInitialValue());
+  const [pendingValue, setPendingValue] = useState<
+    DefaultDropdownMenuOption | DefaultDropdownMenuOption[] | null
+  >(getInitialValue());
+
+  const isControlled = propValue !== undefined;
+
+  useEffect(() => {
+    if (isControlled) {
+      setValue(propValue);
+    }
+  }, [propValue]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     if (open) {
@@ -35,9 +62,27 @@ const InputDropdown = (props: Args): JSX.Element => {
     }
   };
 
-  const handleChange = () => {
+  const handleChange = (
+    _: React.SyntheticEvent<Element, Event>,
+    newValue: DefaultDropdownMenuOption | DefaultDropdownMenuOption[] | null
+  ) => {
     if (!multiple) {
       setOpen(false);
+      setValue(newValue);
+      setCounter(undefined);
+
+      if (newValue && !Array.isArray(newValue)) {
+        setInputDropdownValue(newValue.name);
+
+        if (newValue?.details) setDetials(newValue?.details);
+        else setDetials(undefined);
+      } else {
+        setDetials(undefined);
+        setInputDropdownValue(undefined);
+      }
+    } else {
+      setPendingValue(newValue);
+      setCounter((newValue as DefaultDropdownMenuOption[])?.length.toString());
     }
   };
 
@@ -47,14 +92,26 @@ const InputDropdown = (props: Args): JSX.Element => {
     if (open) {
       setOpen(false);
     }
+    if (multiple) {
+      setValue(pendingValue);
+    }
   };
+
+  function getInitialValue() {
+    if (isControlled) {
+      return propValue;
+    }
+
+    return multiple ? ([] as unknown) : null;
+  }
 
   const options = [
     {
-      details: "Details for menu item 1",
+      details: "Details",
       name: "Menu Item 1",
     },
     {
+      details: "A very long Details for the second Menu Item",
       name: "Menu Item 2",
     },
     {
@@ -71,7 +128,10 @@ const InputDropdown = (props: Args): JSX.Element => {
           onClick={handleClick}
           sdsStage={open ? "userInput" : "default"}
           sdsStyle={sdsStyle}
-          sdsType={sdsType}
+          multiple={multiple}
+          details={details}
+          value={inputDropdownValue}
+          counter={counter}
           data-testid="InputDropdown"
           {...rest}
         />
@@ -82,7 +142,10 @@ const InputDropdown = (props: Args): JSX.Element => {
           onClick={handleClick}
           sdsStage={open ? "userInput" : "default"}
           sdsStyle={sdsStyle}
-          sdsType={sdsType}
+          multiple={multiple}
+          details={details}
+          value={inputDropdownValue}
+          counter={counter}
           data-testid="InputDropdown"
           {...rest}
         />
@@ -97,6 +160,7 @@ const InputDropdown = (props: Args): JSX.Element => {
         multiple={multiple}
         disableCloseOnSelect={multiple}
         options={options}
+        value={multiple ? pendingValue : value}
         onClickAway={handleClickAway}
       />
     </>
@@ -131,6 +195,11 @@ export default {
         type: "text",
       },
     },
+    multiple: {
+      control: {
+        type: "boolean",
+      },
+    },
     sdsStage: {
       control: {
         type: "radio",
@@ -147,7 +216,7 @@ export default {
       control: {
         type: "radio",
       },
-      options: ["singleSelect", "multiSelect"],
+      options: ["label", "value"],
     },
     shouldPutAColonAfterLabel: {
       control: {
@@ -176,7 +245,6 @@ export const Default = {
     disabled: false,
     label: "Label",
     sdsStyle: "square",
-    sdsType: "singleSelect",
   },
 };
 
@@ -185,38 +253,50 @@ export const Default = {
 const storyRow = {
   // lprins: This prevents InputDropdown component from stretching height in grid
   alignItems: "start",
-  display: "grid",
-  gridColumnGap: "24px",
-  gridTemplateColumns: "repeat(3, 160px)",
-  gridTemplateRows: "1fr",
+  display: "flex",
 };
 
 const LivePreviewDemo = (props: Args): JSX.Element => {
-  const { sdsStyle, ...rest } = props;
+  const { sdsStyle } = props;
 
   return (
     <div style={storyRow as React.CSSProperties}>
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
+      <StyledInputDropdown
+        disabled={false}
         label="Label"
-        {...rest}
+        onClick={noop}
+        sdsStage="default"
+        sdsStyle={sdsStyle}
+        sdsType="label"
+        multiple={false}
+        data-testid="InputDropdown"
       />
 
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
+      <StyledInputDropdown
+        disabled={false}
         label="Label"
+        onClick={noop}
+        sdsStage="default"
+        sdsStyle={sdsStyle}
+        sdsType="value"
+        value="Value"
+        multiple={false}
+        data-testid="InputDropdown"
+        style={{ marginLeft: 80, marginRight: 16 }}
+      />
+
+      <StyledInputDropdown
+        disabled={false}
+        label="Label"
+        onClick={noop}
+        sdsStage="default"
+        sdsStyle={sdsStyle}
+        sdsType="value"
+        value="Value"
         details="Details"
-        {...rest}
-      />
-
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
-        label="Label"
-        multiple
-        {...rest}
+        shouldPutAColonAfterLabel={false}
+        multiple={false}
+        data-testid="InputDropdown"
       />
     </div>
   );
@@ -248,33 +328,31 @@ export const SquareLivePreview = {
   render: (args: Args) => <LivePreviewDemo {...args} />,
 };
 
-const MinimalLivePreviewDemo = (props: Args): JSX.Element => {
-  const { sdsStyle, ...rest } = props;
-
+const MinimalLivePreviewDemo = (): JSX.Element => {
   return (
     <div style={storyRow as React.CSSProperties}>
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
+      <StyledInputDropdown
+        disabled={false}
         label="Label"
-        {...rest}
+        onClick={noop}
+        sdsStage="default"
+        sdsStyle="minimal"
+        sdsType="label"
+        multiple={false}
+        data-testid="InputDropdown"
       />
 
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
+      <StyledInputDropdown
+        disabled={false}
         label="Label"
-        details="Very looooooong details"
-        {...rest}
-      />
-
-      <InputDropdown
-        sdsType="singleSelect"
-        sdsStyle={sdsStyle}
-        label="Label"
-        details="Very looooooong details"
-        shouldTruncateMinimalDetails
-        {...rest}
+        onClick={noop}
+        sdsStage="default"
+        sdsStyle="minimal"
+        sdsType="value"
+        value="Value"
+        multiple={false}
+        data-testid="InputDropdown"
+        style={{ marginLeft: 80, marginRight: 16 }}
       />
     </div>
   );
@@ -298,8 +376,8 @@ export const Test = {
   args: {
     disabled: false,
     label: "Label",
+    multiple: false,
     sdsStyle: "square",
-    sdsType: "singleSelect",
   },
   parameters: {
     snapshot: {

--- a/packages/components/src/core/InputDropdown/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/index.stories.tsx
@@ -1,9 +1,8 @@
 import { styled } from "@mui/material/styles";
 import { Args, Meta } from "@storybook/react";
-import { DefaultDropdownMenuOption } from "dist/index.cjs";
 import React, { useEffect, useState } from "react";
 import { noop } from "src/common/utils";
-import DropdownMenu from "../DropdownMenu";
+import DropdownMenu, { DefaultDropdownMenuOption } from "../DropdownMenu";
 import RawInputDropdown from "./index";
 
 const StyledInputDropdown = styled(RawInputDropdown)`

--- a/packages/components/src/core/InputDropdown/index.tsx
+++ b/packages/components/src/core/InputDropdown/index.tsx
@@ -44,7 +44,8 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
   const shouldRenderInlineMinimalDetails =
     isMinimal && sdsType === "value" && !multiple;
   const shouldRenderMinimalDetails = isMinimal && sdsType === "label";
-  const shouldRenderCounter = multiple && counter !== undefined && !isMinimal;
+  const shouldRenderCounter =
+    multiple && counter !== undefined && counter !== "0" && !isMinimal;
 
   return (
     <StyledInputDropdown {...props}>
@@ -104,34 +105,52 @@ interface RenderLabelTextProps {
   value: InputDropdownProps["value"];
 }
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
-function renderLabelText({
-  counter,
-  details,
+function renderLabelText(props: RenderLabelTextProps) {
+  const { sdsType } = props;
+
+  if (sdsType === "label") {
+    return renderLabelTypeLabelText(props);
+  }
+
+  if (sdsType === "value") {
+    return renderValueTypeLabelText(props);
+  }
+
+  return null;
+}
+
+function renderLabelTypeLabelText({
   isMinimal,
   label,
-  multiple,
-  shouldPutAColonAfterLabel,
-  sdsType,
+  counter,
   value,
+  shouldPutAColonAfterLabel,
 }: RenderLabelTextProps) {
-  if (sdsType === "label") {
+  if (isMinimal) return label;
+
+  return (counter || value) && shouldPutAColonAfterLabel ? `${label}:` : label;
+}
+
+function renderValueTypeLabelText({
+  value,
+  multiple,
+  isMinimal,
+  label,
+  counter,
+  details,
+  shouldPutAColonAfterLabel,
+}: RenderLabelTextProps) {
+  if (!value || multiple) {
     if (isMinimal) return label;
 
-    return (counter || value) && shouldPutAColonAfterLabel
-      ? `${label}:`
-      : label;
-  } else if (sdsType === "value") {
-    if (!value || multiple) {
-      if (isMinimal) return label;
-      return counter && shouldPutAColonAfterLabel ? `${label}:` : label;
-    }
-
-    if (isMinimal) return value;
-    return (counter || details) && shouldPutAColonAfterLabel
-      ? `${value}:`
-      : value;
+    return counter && shouldPutAColonAfterLabel ? `${label}:` : label;
   }
+
+  if (isMinimal) return value;
+
+  return (counter || details) && shouldPutAColonAfterLabel
+    ? `${value}:`
+    : value;
 }
 
 function renderDetailsText({

--- a/packages/components/src/core/InputDropdown/index.tsx
+++ b/packages/components/src/core/InputDropdown/index.tsx
@@ -21,12 +21,14 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
   const {
     label,
     open,
-    sdsType,
+    multiple = false,
     sdsStyle,
+    sdsType = "label",
     details,
     counter,
     shouldTruncateMinimalDetails,
     shouldPutAColonAfterLabel = true,
+    value,
   } = props;
 
   const isMinimal = sdsStyle === "minimal";
@@ -38,11 +40,11 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
     );
   }
 
-  const shouldRenderDetails =
-    sdsType === "singleSelect" && details && !isMinimal;
-
-  const shouldRenderCounter =
-    sdsType === "multiSelect" && counter !== undefined && !isMinimal;
+  const shouldRenderDetails = !multiple && (details || value) && !isMinimal;
+  const shouldRenderInlineMinimalDetails =
+    isMinimal && sdsType === "value" && !multiple;
+  const shouldRenderMinimalDetails = isMinimal && sdsType === "label";
+  const shouldRenderCounter = multiple && counter !== undefined && !isMinimal;
 
   return (
     <StyledInputDropdown {...props}>
@@ -51,53 +53,101 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
           className="styled-label"
           details={details}
           counter={counter}
+          sdsType={sdsType}
         >
           {renderLabelText({
             counter,
             details,
             isMinimal,
             label,
+            multiple,
+            sdsType,
             shouldPutAColonAfterLabel,
+            value,
           })}
         </StyledLabel>
-        {shouldRenderDetails && <StyledDetail>{details}</StyledDetail>}
+        {shouldRenderDetails && (
+          <StyledDetail>
+            {renderDetailsText({ details, sdsType, value })}
+          </StyledDetail>
+        )}
+        {shouldRenderInlineMinimalDetails && (
+          <StyledDetail>
+            {renderDetailsText({ details, sdsType, value })}
+          </StyledDetail>
+        )}
         {shouldRenderCounter && <StyledCounter>{counter}</StyledCounter>}
         <IconWrapper>
           <Icon sdsIcon="chevronDown" sdsSize="s" sdsType="interactive" />
         </IconWrapper>
       </LabelWrapper>
 
-      {isMinimal && (
+      {shouldRenderMinimalDetails && (
         <MinimalDetails
           shouldTruncateMinimalDetails={shouldTruncateMinimalDetails}
         >
-          {details}
+          {renderDetailsText({ details, sdsType, value })}
         </MinimalDetails>
       )}
     </StyledInputDropdown>
   );
 };
 
+interface RenderLabelTextProps {
+  counter: InputDropdownProps["counter"];
+  details: InputDropdownProps["details"];
+  isMinimal: boolean;
+  label: InputDropdownProps["label"];
+  multiple: InputDropdownProps["multiple"];
+  shouldPutAColonAfterLabel: InputDropdownProps["shouldPutAColonAfterLabel"];
+  sdsType: InputDropdownProps["sdsType"];
+  value: InputDropdownProps["value"];
+}
+
+// eslint-disable-next-line sonarjs/cognitive-complexity
 function renderLabelText({
   counter,
   details,
   isMinimal,
   label,
+  multiple,
   shouldPutAColonAfterLabel,
-}: {
-  counter: InputDropdownProps["counter"];
-  details: InputDropdownProps["details"];
-  isMinimal: boolean;
-  label: InputDropdownProps["label"];
-  shouldPutAColonAfterLabel: InputDropdownProps["shouldPutAColonAfterLabel"];
-}) {
-  if (isMinimal) {
-    return label;
-  }
+  sdsType,
+  value,
+}: RenderLabelTextProps) {
+  if (sdsType === "label") {
+    if (isMinimal) return label;
 
-  return (counter !== undefined || details) && shouldPutAColonAfterLabel
-    ? `${label}:`
-    : label;
+    return (counter || value) && shouldPutAColonAfterLabel
+      ? `${label}:`
+      : label;
+  } else if (sdsType === "value") {
+    if (!value || multiple) {
+      if (isMinimal) return label;
+      return counter && shouldPutAColonAfterLabel ? `${label}:` : label;
+    }
+
+    if (isMinimal) return value;
+    return (counter || details) && shouldPutAColonAfterLabel
+      ? `${value}:`
+      : value;
+  }
+}
+
+function renderDetailsText({
+  details,
+  sdsType,
+  value,
+}: {
+  details: InputDropdownProps["details"];
+  sdsType: InputDropdownProps["sdsType"];
+  value: InputDropdownProps["value"];
+}) {
+  if (sdsType === "label" && value) {
+    return value;
+  } else if (sdsType === "value") {
+    return details;
+  }
 }
 
 export default InputDropdown;

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -8,6 +8,7 @@ import {
   getBorders,
   getColors,
   getCorners,
+  getFontWeights,
   getPalette,
   getSpaces,
 } from "../styles";
@@ -20,9 +21,11 @@ export interface InputDropdownProps extends CommonThemeProps {
   open?: boolean;
   sdsStage: "default" | "userInput";
   sdsStyle?: "minimal" | "square" | "rounded";
-  sdsType?: "singleSelect" | "multiSelect";
+  sdsType?: "label" | "value";
+  multiple?: boolean;
   details?: string;
   counter?: string;
+  value?: string;
   shouldTruncateMinimalDetails?: boolean;
   shouldPutAColonAfterLabel?: boolean;
 }
@@ -67,11 +70,11 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 
     &:hover {
       background-color: unset;
-      border: ${borders?.gray[500]};
+      border-color: black;
       color: ${palette?.text?.primary};
 
       path {
-        fill: ${colors?.gray[600]};
+        fill: black;
       }
 
       .styled-label {
@@ -162,8 +165,6 @@ const rounded = (props: InputDropdownProps): SerializedStyles => {
   const corners = getCorners(props);
 
   return css`
-    ${labelStyle(props)}
-
     border-radius: ${corners?.l}px;
     height: 34px;
     min-width: 90px;
@@ -303,21 +304,30 @@ export const StyledDetail = styled("span", {
 interface DetailsAndCounter extends CommonThemeProps {
   details?: string;
   counter?: string;
+  sdsType: InputDropdownProps["sdsType"];
 }
 
 export const StyledLabel = styled("span", {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
   ${(props: DetailsAndCounter) => {
-    const { details, counter } = props;
+    const { details, counter, sdsType } = props;
+
     const colors = getColors(props);
     const palette = getPalette(props);
+    const fontWeights = getFontWeights(props);
+
     const labelColor =
       details || counter !== undefined
         ? palette?.text?.primary
         : colors?.gray[500];
+
     return `
       color: ${labelColor};
+
+      font-weight: ${
+        sdsType === "label" ? fontWeights?.semibold : fontWeights?.regular
+      };
     `;
   }}
 `;
@@ -393,7 +403,6 @@ function labelStyle(props: InputDropdownProps): SerializedStyles {
   return css`
     &.MuiButton-text {
       .styled-label {
-        font-weight: 600;
         color: ${labelColor};
       }
     }

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -23,9 +23,9 @@ export interface InputDropdownProps extends CommonThemeProps {
   sdsStyle?: "minimal" | "square" | "rounded";
   sdsType?: "label" | "value";
   multiple?: boolean;
-  details?: string;
-  counter?: string;
-  value?: string;
+  details?: ReactNode;
+  counter?: ReactNode;
+  value?: ReactNode;
   shouldTruncateMinimalDetails?: boolean;
   shouldPutAColonAfterLabel?: boolean;
 }
@@ -139,6 +139,11 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
       outline: none;
     }
 
+    &:focus-visible {
+      outline: 5px auto Highlight;
+      outline: 5px auto -webkit-focus-ring-color;
+    }
+
     &.MuiButton-root.MuiButton-text > span {
       ${labelFontBodyS(props)}
       margin-left: 0;
@@ -250,6 +255,7 @@ const doNotForwardProps = [
   "intent",
   "open",
   "sdsStage",
+  "sdsType",
   "isMinimal",
   "shouldTruncateMinimalDetails",
   "shouldPutAColonAfterLabel",
@@ -302,8 +308,8 @@ export const StyledDetail = styled("span", {
 `;
 
 interface DetailsAndCounter extends CommonThemeProps {
-  details?: string;
-  counter?: string;
+  details?: InputDropdownProps["details"];
+  counter?: InputDropdownProps["counter"];
   sdsType: InputDropdownProps["sdsType"];
 }
 

--- a/packages/components/src/core/Pagination/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Pagination/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<Pagination /> Default story renders snapshot 1`] = `
   >
     <button
       aria-label="Previous page"
-      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-2pawhs-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-xubuxk-MuiButtonBase-root-MuiIconButton-root"
       data-order="first"
       disabled=""
       tabindex="-1"
@@ -61,7 +61,7 @@ exports[`<Pagination /> Default story renders snapshot 1`] = `
   >
     <button
       aria-label="Go to a page"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1mowwm2-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1hxpqlk-MuiButtonBase-root-MuiIconButton-root"
       tabindex="0"
       type="button"
     >
@@ -94,7 +94,7 @@ exports[`<Pagination /> Default story renders snapshot 1`] = `
   >
     <button
       aria-label="Next page"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-16k5j8f-MuiButtonBase-root-MuiIconButton-root"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1h586y7-MuiButtonBase-root-MuiIconButton-root"
       data-order="last"
       tabindex="0"
       type="button"

--- a/packages/components/src/core/Table/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Table/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<Table /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-uq52cw-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-wcol9m-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
@@ -67,7 +67,7 @@ exports[`<Table /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-8uz3p0-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-kqv049-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
@@ -102,7 +102,7 @@ exports[`<Table /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-8uz3p0-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-kqv049-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >

--- a/packages/components/src/core/TableHeader/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/TableHeader/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`<TableHeader /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-uq52cw-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-wcol9m-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
@@ -54,7 +54,7 @@ exports[`<TableHeader /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-8uz3p0-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-kqv049-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
@@ -89,7 +89,7 @@ exports[`<TableHeader /> Default story renders snapshot 1`] = `
           </span>
           <button
             aria-label="Change sort direction from descending to ascending"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-8uz3p0-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-kqv049-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >


### PR DESCRIPTION
## Summary

**InputDropdown**
Github issue: #437 

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
