### PR TITLE
feat(navigationjumpto): emit the index of the navigation tab on scroll

### DIFF
--- a/packages/components/src/core/NavigationJumpTo/NavigationJumpTo.namespace-test.tsx
+++ b/packages/components/src/core/NavigationJumpTo/NavigationJumpTo.namespace-test.tsx
@@ -1,5 +1,4 @@
 import { NavigationJumpTo, NavigationJumpToProps } from "@czi-sds/components";
-import React from "react";
 
 const NavigationJumpToNameSpaceTest = (props: NavigationJumpToProps) => {
   return (
@@ -12,7 +11,7 @@ const NavigationJumpToNameSpaceTest = (props: NavigationJumpToProps) => {
         { elementRef: { current: null }, title: "Item 4" },
         { elementRef: { current: null }, title: "Item 5" },
       ]}
-      onChange={(event: React.SyntheticEvent, value: number) => {}}
+      onChange={(value: number) => {}}
       offsetTop={0}
     />
   );

--- a/packages/components/src/core/NavigationJumpTo/index.tsx
+++ b/packages/components/src/core/NavigationJumpTo/index.tsx
@@ -18,7 +18,7 @@ export interface NavigationJumpToProps extends NavigationJumpToExtraProps {
     elementRef: React.MutableRefObject<HTMLElement | null>;
   }>;
   offsetTop?: number;
-  onChange?: (event: React.SyntheticEvent, value: number) => void;
+  onChange?: (value: number) => void;
 }
 
 const NavigationJumpTo = forwardRef<HTMLButtonElement, NavigationJumpToProps>(
@@ -26,6 +26,7 @@ const NavigationJumpTo = forwardRef<HTMLButtonElement, NavigationJumpToProps>(
     const { items, indicatorColor, offsetTop = 0, onChange, ...rest } = props;
     const [navItemClicked, setNavItemClicked] = useState(false);
     const [firstTabIndexInview, setFirstTabIndexInview] = useState(0);
+    const [emittedValue, setEmittedValue] = useState(-1);
     const sectionIsInView = useInView(items);
 
     useEffect(() => {
@@ -61,6 +62,14 @@ const NavigationJumpTo = forwardRef<HTMLButtonElement, NavigationJumpToProps>(
       };
     };
 
+    // Emit changes only once
+    const handleOnChange = (value: number) => {
+      if (value !== emittedValue) {
+        onChange?.(value);
+        setEmittedValue(value);
+      }
+    };
+
     const handleChange = (event: React.SyntheticEvent, newValue: number) => {
       // Set navItemClicked to true to disable changing the tab value
       // while scrolling. Once the scrolling ends, it is changed back to false.
@@ -88,7 +97,7 @@ const NavigationJumpTo = forwardRef<HTMLButtonElement, NavigationJumpToProps>(
       setFirstTabIndexInview(newValue);
 
       // Envoke the custom onChange prop
-      onChange?.(event, newValue);
+      handleOnChange(newValue);
     };
 
     // Observe changes in the sectionIsInView object to update the tabs value
@@ -102,8 +111,12 @@ const NavigationJumpTo = forwardRef<HTMLButtonElement, NavigationJumpToProps>(
       // Update the tabs value only if a section is present in the viewport
       // and no navigation item has been clicked, preventing updates during window scroll
       // and unnecessary movement of the tabs indicator.
-      if (sectionInView > -1 && !navItemClicked)
+      if (sectionInView > -1 && !navItemClicked) {
         setFirstTabIndexInview(sectionInView);
+
+        // Envoke the custom onChange prop
+        handleOnChange(sectionInView);
+      }
     }, [sectionIsInView]);
 
     // Set navItemClicked to false to re-enable the option

--- a/packages/components/src/core/NavigationJumpTo/style.ts
+++ b/packages/components/src/core/NavigationJumpTo/style.ts
@@ -5,7 +5,13 @@ import { CommonThemeProps, fontBodyXs, getColors, getSpaces } from "../styles";
 export interface NavigationJumpToExtraProps
   extends Omit<
       TabsProps,
-      "indicatorColor" | "nonce" | "rev" | "rel" | "autoFocus" | "content"
+      | "indicatorColor"
+      | "nonce"
+      | "rev"
+      | "rel"
+      | "autoFocus"
+      | "content"
+      | "onChange"
     >,
     CommonThemeProps {
   sdsIndicatorColor?:


### PR DESCRIPTION
## Summary

**NavigationJumpTo**
Github issue: #529 

For the new NavigationJumpTo component, is there a way to retrieve the current section? Or some onChange listener for when the user scrolls and the section changes?
We have a requirement to send an analytic event when a user scrolls into different sections using their mouse, and onChange didn’t seem to do anything when I tried it.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
