### PR TITLE
fix(inputdropdown): fix UserInput and Open state styles

### DIFF
--- a/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-um4hlk-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1son5kg-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"

--- a/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ComplexFilter/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
   class="css-1x0reya"
 >
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1son5kg-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1k5fys6-MuiButtonBase-root-MuiButton-root"
     label="Click Target"
     tabindex="0"
     type="button"

--- a/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-um4hlk-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1son5kg-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"

--- a/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dropdown/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <button
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1son5kg-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1k5fys6-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"

--- a/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<InputDropdown /> Default story renders snapshot 1`] = `
     If you set sdsType="value" and multiple="true", the component will revert to displaying a label and a counter.
   </p>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-fbd7s3-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-pbaak-MuiButtonBase-root-MuiButton-root"
     data-testid="InputDropdown"
     label="Label"
     tabindex="0"

--- a/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -2,11 +2,6 @@
 
 exports[`<InputDropdown /> Default story renders snapshot 1`] = `
 <div>
-  <p>
-    The "Value" variant of InputDropdown cannot be set to "multiple". 
-    <br />
-    If you set sdsType="value" and multiple="true", the component will revert to displaying a label and a counter.
-  </p>
   <button
     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-pbaak-MuiButtonBase-root-MuiButton-root"
     data-testid="InputDropdown"

--- a/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<InputDropdown /> Default story renders snapshot 1`] = `
     If you set sdsType="value" and multiple="true", the component will revert to displaying a label and a counter.
   </p>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-yez6a5-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-fbd7s3-MuiButtonBase-root-MuiButton-root"
     data-testid="InputDropdown"
     label="Label"
     tabindex="0"

--- a/packages/components/src/core/InputDropdown/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/index.stories.tsx
@@ -3,7 +3,7 @@ import { Args, Meta } from "@storybook/react";
 import React, { useEffect, useState } from "react";
 import { noop } from "src/common/utils";
 import DropdownMenu, { DefaultDropdownMenuOption } from "../DropdownMenu";
-import RawInputDropdown from "./index";
+import RawInputDropdown, { InputDropdownProps } from "./index";
 
 const StyledInputDropdown = styled(RawInputDropdown)`
   ${({ width }: Args) => {
@@ -17,7 +17,6 @@ const StyledInputDropdown = styled(RawInputDropdown)`
 const InputDropdown = (props: Args): JSX.Element => {
   const {
     disabled,
-    fullWidth,
     label,
     sdsStyle,
     multiple,
@@ -27,6 +26,8 @@ const InputDropdown = (props: Args): JSX.Element => {
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [open, setOpen] = useState(false);
+  const [sdsStage, setSdsStage] =
+    useState<InputDropdownProps["sdsStage"]>("default");
   const [details, setDetials] = useState<string>();
   const [counter, setCounter] = useState<string>();
   const [inputDropdownValue, setInputDropdownValue] = useState<string>();
@@ -44,9 +45,11 @@ const InputDropdown = (props: Args): JSX.Element => {
     if (isControlled) {
       setValue(propValue);
     }
-  }, [propValue]);
+  }, [propValue, isControlled]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setSdsStage("userInput");
+
     if (open) {
       setOpen(false);
 
@@ -90,6 +93,9 @@ const InputDropdown = (props: Args): JSX.Element => {
   const handleClickAway = () => {
     if (open) {
       setOpen(false);
+      if (!value || (Array.isArray(value) && value.length === 0)) {
+        setSdsStage("default");
+      }
     }
     if (multiple) {
       setValue(pendingValue);
@@ -126,35 +132,21 @@ const InputDropdown = (props: Args): JSX.Element => {
         If you set sdsType=&quot;value&quot; and multiple=&quot;true&quot;, the
         component will revert to displaying a label and a counter.
       </p>
-      {fullWidth ? (
-        <RawInputDropdown
-          disabled={disabled}
-          label={label}
-          onClick={handleClick}
-          sdsStage={open ? "userInput" : "default"}
-          sdsStyle={sdsStyle}
-          multiple={multiple}
-          details={details}
-          value={inputDropdownValue}
-          counter={counter}
-          data-testid="InputDropdown"
-          {...rest}
-        />
-      ) : (
-        <StyledInputDropdown
-          disabled={disabled}
-          label={label}
-          onClick={handleClick}
-          sdsStage={open ? "userInput" : "default"}
-          sdsStyle={sdsStyle}
-          multiple={multiple}
-          details={details}
-          value={inputDropdownValue}
-          counter={counter}
-          data-testid="InputDropdown"
-          {...rest}
-        />
-      )}
+
+      <StyledInputDropdown
+        disabled={disabled}
+        label={label}
+        onClick={handleClick}
+        state={open ? "open" : "default"}
+        sdsStage={sdsStage}
+        sdsStyle={sdsStyle}
+        multiple={multiple}
+        details={details}
+        value={inputDropdownValue}
+        counter={counter}
+        data-testid="InputDropdown"
+        {...rest}
+      />
 
       <DropdownMenu
         open={open}

--- a/packages/components/src/core/InputDropdown/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/index.stories.tsx
@@ -2,6 +2,8 @@ import { styled } from "@mui/material/styles";
 import { Args, Meta } from "@storybook/react";
 import React, { useEffect, useState } from "react";
 import { noop } from "src/common/utils";
+import Callout from "../Callout";
+import CalloutTitle from "../Callout/components/CalloutTitle";
 import DropdownMenu, { DefaultDropdownMenuOption } from "../DropdownMenu";
 import RawInputDropdown, { InputDropdownProps } from "./index";
 
@@ -21,6 +23,7 @@ const InputDropdown = (props: Args): JSX.Element => {
     sdsStyle,
     multiple,
     value: propValue,
+    sdsType,
     ...rest
   } = props;
 
@@ -31,6 +34,8 @@ const InputDropdown = (props: Args): JSX.Element => {
   const [details, setDetials] = useState<string>();
   const [counter, setCounter] = useState<string>();
   const [inputDropdownValue, setInputDropdownValue] = useState<string>();
+  const [invalid, setInvalid] = useState(false);
+  const [storybookLabel, setStorybookLabel] = useState("Label");
 
   const [value, setValue] = useState<
     DefaultDropdownMenuOption | DefaultDropdownMenuOption[] | null
@@ -46,6 +51,22 @@ const InputDropdown = (props: Args): JSX.Element => {
       setValue(propValue);
     }
   }, [propValue, isControlled]);
+
+  useEffect(() => {
+    if (sdsType === "value" && multiple) {
+      setInvalid(true);
+    } else {
+      setInvalid(false);
+    }
+  }, [multiple, sdsType]);
+
+  useEffect(() => {
+    if (sdsType === "value") {
+      setStorybookLabel("Value");
+    } else {
+      setStorybookLabel(label);
+    }
+  }, [label, sdsType]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setSdsStage("userInput");
@@ -126,27 +147,30 @@ const InputDropdown = (props: Args): JSX.Element => {
 
   return (
     <div>
-      <p>
-        The &quot;Value&quot; variant of InputDropdown cannot be set to
-        &quot;multiple&quot;. <br />
-        If you set sdsType=&quot;value&quot; and multiple=&quot;true&quot;, the
-        component will revert to displaying a label and a counter.
-      </p>
-
-      <StyledInputDropdown
-        disabled={disabled}
-        label={label}
-        onClick={handleClick}
-        state={open ? "open" : "default"}
-        sdsStage={sdsStage}
-        sdsStyle={sdsStyle}
-        multiple={multiple}
-        details={details}
-        value={inputDropdownValue}
-        counter={counter}
-        data-testid="InputDropdown"
-        {...rest}
-      />
+      {invalid ? (
+        <Callout autoDismiss={false} intent="error">
+          <CalloutTitle>Invalid props!</CalloutTitle>
+          When using the InputDropdown component, please note that the
+          combination of setting the sdsType prop to &quot;value&quot; and the
+          multiple prop to &quot;true&quot; is not allowed.
+        </Callout>
+      ) : (
+        <StyledInputDropdown
+          disabled={disabled}
+          label={storybookLabel}
+          onClick={handleClick}
+          state={open ? "open" : "default"}
+          sdsStage={sdsStage}
+          sdsStyle={sdsStyle}
+          sdsType={sdsType}
+          multiple={multiple}
+          details={details}
+          value={inputDropdownValue}
+          counter={counter}
+          data-testid="InputDropdown"
+          {...rest}
+        />
+      )}
 
       <DropdownMenu
         open={open}

--- a/packages/components/src/core/InputDropdown/index.tsx
+++ b/packages/components/src/core/InputDropdown/index.tsx
@@ -20,7 +20,6 @@ export type InputDropdownProps = SdsInputDropdownProps &
 const InputDropdown = (props: InputDropdownProps): JSX.Element => {
   const {
     label,
-    open,
     multiple = false,
     sdsStyle,
     sdsType = "label",
@@ -32,13 +31,6 @@ const InputDropdown = (props: InputDropdownProps): JSX.Element => {
   } = props;
 
   const isMinimal = sdsStyle === "minimal";
-
-  if (open !== undefined) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "Warning: InputDropdown prop `open` has been replaced by `sdsStage` and will be deprecated."
-    );
-  }
 
   const shouldRenderDetails = !multiple && (details || value) && !isMinimal;
   const shouldRenderInlineMinimalDetails =

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -431,7 +431,7 @@ function labelStyle(props: InputDropdownProps): SerializedStyles {
   const colors = getColors(props);
   const palette = getPalette(props);
   const labelColor =
-    props.sdsType === "label" ? colors?.gray[500] : palette?.text?.primary;
+    props.sdsType === "value" ? palette?.text?.primary : colors?.gray[500];
 
   return css`
     &.MuiButton-text {

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -40,6 +40,8 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
   const borders = getBorders(props);
 
   return css`
+    ${labelStyle(props)}
+
     border: ${borders?.gray[400]};
     color: ${palette?.text?.primary};
     cursor: pointer;
@@ -100,6 +102,7 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
 const minimal = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
   const spacings = getSpaces(props);
+  const palette = getPalette(props);
 
   return css`
     ${labelStyle(props)}
@@ -128,6 +131,15 @@ const minimal = (props: InputDropdownProps): SerializedStyles => {
     &:hover {
       background-color: ${colors?.gray[100]};
       border: none;
+      color: ${palette?.text?.primary};
+
+      path {
+        fill: black;
+      }
+
+      .styled-label {
+        color: #000;
+      }
     }
 
     &:active {
@@ -176,10 +188,18 @@ const rounded = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const userInput = (): SerializedStyles => {
+const userInput = (props: InputDropdownProps): SerializedStyles => {
+  const palette = getPalette(props);
+
   return css`
     & .styled-label {
-      color: black;
+      color: ${palette?.text?.primary};
+    }
+
+    &.MuiButton-text {
+      .styled-label {
+        color: ${palette?.text?.primary};
+      }
     }
   `;
 };
@@ -290,7 +310,7 @@ export const StyledInputDropdown = styled(Button, {
       ${sdsStyle === "square" && square(props)}
       ${sdsStyle === "rounded" && rounded(props)}
       ${state === "open" && isOpen(props)}
-      ${sdsStage === "userInput" && userInput()}
+      ${sdsStage === "userInput" && userInput(props)}
       ${intent === "warning" && warning(props)}
       ${intent === "error" && error(props)}
       ${disabled && isDisabled(props)}
@@ -410,9 +430,8 @@ export const IconWrapper = styled("span", {
 function labelStyle(props: InputDropdownProps): SerializedStyles {
   const colors = getColors(props);
   const palette = getPalette(props);
-  const labelColor = props.disabled
-    ? colors?.gray[300]
-    : palette?.text?.primary;
+  const labelColor =
+    props.sdsType === "label" ? colors?.gray[500] : palette?.text?.primary;
 
   return css`
     &.MuiButton-text {

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -18,7 +18,7 @@ export interface InputDropdownProps extends CommonThemeProps {
   intent?: "default" | "error" | "warning";
   label: ReactNode;
   onClick: (event: React.MouseEvent<HTMLElement>) => void;
-  open?: boolean;
+  state?: "default" | "open";
   sdsStage: "default" | "userInput";
   sdsStyle?: "minimal" | "square" | "rounded";
   sdsType?: "label" | "value";
@@ -176,7 +176,15 @@ const rounded = (props: InputDropdownProps): SerializedStyles => {
   `;
 };
 
-const userInput = (props: InputDropdownProps): SerializedStyles => {
+const userInput = (): SerializedStyles => {
+  return css`
+    & .styled-label {
+      color: black;
+    }
+  `;
+};
+
+const isOpen = (props: InputDropdownProps): SerializedStyles => {
   const colors = getColors(props);
   const palette = getPalette(props);
 
@@ -253,7 +261,7 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
 
 const doNotForwardProps = [
   "intent",
-  "open",
+  "state",
   "sdsStage",
   "sdsType",
   "isMinimal",
@@ -274,15 +282,15 @@ export const StyledInputDropdown = styled(Button, {
   justify-content: space-between;
 
   ${(props: InputDropdownProps) => {
-    const { disabled, intent, open, sdsStage, sdsStyle } = props;
+    const { disabled, intent, state, sdsStage, sdsStyle } = props;
 
     return css`
       ${inputDropdownStyles(props)}
       ${sdsStyle === "minimal" && minimal(props)}
       ${sdsStyle === "square" && square(props)}
       ${sdsStyle === "rounded" && rounded(props)}
-      ${open && userInput(props)}
-      ${sdsStage === "userInput" && userInput(props)}
+      ${state === "open" && isOpen(props)}
+      ${sdsStage === "userInput" && userInput()}
       ${intent === "warning" && warning(props)}
       ${intent === "error" && error(props)}
       ${disabled && isDisabled(props)}

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -273,6 +273,12 @@ const isDisabled = (props: InputDropdownProps): SerializedStyles => {
       color: ${colors?.gray[300]};
     }
 
+    &.MuiButton-text {
+      .styled-label {
+        color: ${colors?.gray[300]};
+      }
+    }
+
     path {
       fill: ${colors?.gray[300]};
     }


### PR DESCRIPTION
## Summary

**InputDropdown**
Github issue: #562 

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
