### PR TITLE
fix: Use named import for MUI components

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -11,11 +11,14 @@ const config = [
   {
     external: [
       ...Object.keys(pkg.peerDependencies || {}),
-      "@mui/material/Popper",
-      "@mui/material/ToggleButton",
       "@mui/material/styles",
-      "@mui/material/Autocomplete",
-      "@mui/material/ToggleButtonGroup",
+      /**
+       * (thuang): Do NOT import MUI components from their component directory directly, since
+       * it breaks the ts to js transpilation. Instead, import from "@mui/material"
+       * For example:
+       * BAD: import Autocomplete from "@mui/material/Autocomplete";
+       * GOOD: import { Autocomplete } from "@mui/material";
+       */
     ],
     input: "src/index.ts",
     output: [

--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
   style="margin: 16px 0px 0px 24px; width: 300px;"
 >
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-1crjeuu-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-41tour-MuiAutocomplete-root"
     label="Search by label"
   >
     <div

--- a/packages/components/src/core/Autocomplete/style.ts
+++ b/packages/components/src/core/Autocomplete/style.ts
@@ -1,5 +1,4 @@
-import { Paper } from "@mui/material";
-import Autocomplete from "@mui/material/Autocomplete";
+import { Autocomplete, Paper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";
 import InputSearch from "../InputSearch";
@@ -66,7 +65,7 @@ export const StyledAutocomplete = styled(Autocomplete, {
       .MuiAutocomplete-listbox {
         max-height: 40vh;
         padding-top: 0;
-        padding-bottom: 0;  
+        padding-bottom: 0;
         padding-right: ${spacings?.s}px;
 
         .MuiAutocomplete-option {
@@ -111,7 +110,7 @@ export const StyledAutocomplete = styled(Autocomplete, {
           position: relative;
           margin-bottom: ${spacings?.xxs}px;
         }
-      } 
+      }
     `;
   }}
 ` as typeof Autocomplete;

--- a/packages/components/src/core/DropdownMenu/style.ts
+++ b/packages/components/src/core/DropdownMenu/style.ts
@@ -1,5 +1,4 @@
-import { Paper, Popper } from "@mui/material";
-import Autocomplete from "@mui/material/Autocomplete";
+import { Autocomplete, Paper, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";
 import InputSearch from "../InputSearch";
@@ -81,7 +80,7 @@ export const StyledAutocomplete = styled(Autocomplete, {
         max-height: 40vh;
         padding-top: 0;
         padding-bottom: 0;
-        
+
         ${
           search || title || hasSections
             ? `padding-right: ${spacings?.s}px;`
@@ -130,7 +129,7 @@ export const StyledAutocomplete = styled(Autocomplete, {
           position: relative;
           margin-bottom: ${spacings?.xxs}px;
         }
-      } 
+      }
     `;
   }}
 ` as typeof Autocomplete;
@@ -193,7 +192,7 @@ export const StyledHeaderTitle = styled("div", {
       color: black;
       padding-top: ${spacings?.xxs}px;
       padding-right: ${spacings?.s}px;
-      padding-left: ${spacings?.s}px; 
+      padding-left: ${spacings?.s}px;
       ${search ? `padding-bottom: 0px;` : `padding-bottom: ${spacings?.xs}px;`}
     `;
   }}

--- a/packages/components/src/core/MenuSelect/index.stories.tsx
+++ b/packages/components/src/core/MenuSelect/index.stories.tsx
@@ -1,6 +1,5 @@
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ButtonBase from "@mui/material/ButtonBase";
-import Popper from "@mui/material/Popper";
+import { ButtonBase, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {
   AutocompleteCloseReason,

--- a/packages/components/src/core/MenuSelect/index.tsx
+++ b/packages/components/src/core/MenuSelect/index.tsx
@@ -1,13 +1,11 @@
 import {
   AutocompleteFreeSoloValueMapping,
-  InputAdornment,
-} from "@mui/material";
-import {
   AutocompleteInputChangeReason,
   AutocompleteProps,
   AutocompleteRenderInputParams,
   AutocompleteRenderOptionState,
-} from "@mui/material/Autocomplete";
+  InputAdornment,
+} from "@mui/material";
 import React, { useState } from "react";
 import { noop } from "src/common/utils";
 import {

--- a/packages/components/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/SegmentedControl/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
 <div
-  class="MuiToggleButtonGroup-root css-g1e6pw-MuiToggleButtonGroup-root"
+  class="MuiToggleButtonGroup-root css-9w2fqw-MuiToggleButtonGroup-root"
   role="group"
 >
   <button

--- a/packages/components/src/core/SegmentedControl/index.tsx
+++ b/packages/components/src/core/SegmentedControl/index.tsx
@@ -1,5 +1,4 @@
-import ToggleButton from "@mui/material/ToggleButton";
-import { ToggleButtonGroupProps } from "@mui/material/ToggleButtonGroup";
+import { ToggleButton, ToggleButtonGroupProps } from "@mui/material";
 import React from "react";
 import Icon, { IconNameToSizes } from "../Icon";
 import Tooltip from "../Tooltip";

--- a/packages/components/src/core/SegmentedControl/style.ts
+++ b/packages/components/src/core/SegmentedControl/style.ts
@@ -1,5 +1,5 @@
+import { ToggleButtonGroup } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import { CommonThemeProps, getColors, getCorners, getSpaces } from "../styles";
 
 const doNotForwardProps = ["color", "buttonDefinition"];
@@ -14,12 +14,12 @@ export const StyledSegmentedControl = styled(ToggleButtonGroup, {
 
     return `
     height: 26px;
-    
+
     .Mui-selected.MuiToggleButton-root {
         background-color: ${colors?.gray[100]};
         color: ${colors?.primary[400]};
         border-color: ${colors?.gray[300]};
-        
+
         &:hover {
           background-color: ${colors?.gray[100]};
         }

--- a/packages/data-viz/rollup.config.mjs
+++ b/packages/data-viz/rollup.config.mjs
@@ -12,11 +12,14 @@ const config = [
   {
     external: [
       ...Object.keys(pkg.peerDependencies || {}),
-      "@mui/material/Popper",
-      "@mui/material/ToggleButton",
       "@mui/material/styles",
-      "@mui/material/Autocomplete",
-      "@mui/material/ToggleButtonGroup",
+      /**
+       * (thuang): Do NOT import MUI components from their component directory directly, since
+       * it breaks the ts to js transpilation. Instead, import from "@mui/material"
+       * For example:
+       * BAD: import Autocomplete from "@mui/material/Autocomplete";
+       * GOOD: import { Autocomplete } from "@mui/material";
+       */
     ],
     input: "src/index.ts",
     output: [


### PR DESCRIPTION
## Summary

Fix breaking imports

Single Cell Team noticed that importing SDS Autocomplete throws the following error:

`Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`

<img width="1109" alt="Screenshot 2023-08-30 at 9 00 00 AM" src="https://github.com/chanzuckerberg/sci-components/assets/6309723/b5609527-e406-4fca-bcd2-14eb0e55118c">

And the root cause seems to be SDS TS -> JS transpiler didn't take ESM syntax into account when transpiled the code to CJS, so it resulted in importing the whole module instead of the intended module default export. 

For example,

```ts
// packages/components/dist/index.cjs.js
var Autocomplete = require('@mui/material/Autocomplete');
```

`Autocomplete` is the whole module object, when we just want `Autocomplete.default`

```
// we got the whole export module
Autocomplete {
  autocompleteClasses: [Getter],
  createFilterOptions: [Getter],
  default: [Getter],  // <--------------- we just want this, which is what ESM syntax does, but not for CJS
  getAutocompleteUtilityClass: [Getter]
}
```

The solution is to avoid importing MUI components through their component directories and use `import { Autocomplete } from '@mui/material'` instead, like so:

```ts
import { Autocomplete } from "@mui/material";
```

This way the transpiled cjs file will have the correct export:

```ts
var material = require('@mui/material');
var Autocomplete = material.Autocomplete; // This is the default export component we want
```




## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
