### PR TITLE
refactor(dropdownmenu): refactor DropdownMenu to use SDS Autocomplete

### DIFF
--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
   style="margin: 16px 0px 0px 24px; width: 300px;"
 >
   <div
-    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-41tour-MuiAutocomplete-root"
+    class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon css-t46og2-MuiAutocomplete-root"
     label="Search by label"
   >
     <div

--- a/packages/components/src/core/Autocomplete/index.stories.tsx
+++ b/packages/components/src/core/Autocomplete/index.stories.tsx
@@ -146,9 +146,6 @@ export default {
     multiple: {
       control: { type: "boolean" },
     },
-    search: {
-      control: { type: "boolean" },
-    },
   },
   component: Autocomplete,
   // (masoudmanson) For the purpose of storybook, the button is removed
@@ -181,6 +178,11 @@ export const Default = {
     label: "Search by label",
     multiple: true,
     search: true,
+  },
+  parameters: {
+    controls: {
+      exclude: ["search"],
+    },
   },
 };
 
@@ -231,6 +233,9 @@ export const Test = {
     search: true,
   },
   parameters: {
+    controls: {
+      exclude: ["search"],
+    },
     snapshot: {
       skip: true,
     },

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -8,7 +8,7 @@ import {
   Popper,
   PopperProps,
 } from "@mui/material";
-import React, { ReactNode, SyntheticEvent, useState } from "react";
+import React, { ReactNode, SyntheticEvent, useCallback, useState } from "react";
 import { noop } from "src/common/utils";
 import ButtonIcon from "../ButtonIcon";
 import { IconProps } from "../Icon";
@@ -101,13 +101,29 @@ const Autocomplete = <
     noOptionsText = "No options",
     onInputChange = noop,
     PaperComponent = StyledPaper,
-    PopperComponent = defaultPopperComponent,
     renderOption = defaultRenderOption,
     renderTags = defaultRenderTags,
     search = false,
   } = props;
 
   const [inputValue, setInputValue] = useState("");
+
+  const defaultPopperComponent = useCallback((popperProps: PopperProps) => {
+    return (
+      <Popper
+        modifiers={[
+          {
+            enabled: true,
+            name: "offset",
+            options: {
+              offset: [0, 8],
+            },
+          },
+        ]}
+        {...popperProps}
+      />
+    );
+  }, []);
 
   return (
     <StyledAutocomplete
@@ -119,7 +135,7 @@ const Autocomplete = <
       loadingText={loadingText}
       noOptionsText={noOptionsText}
       PaperComponent={PaperComponent}
-      PopperComponent={PopperComponent}
+      PopperComponent={defaultPopperComponent}
       renderOption={renderOption}
       getOptionLabel={getOptionLabel}
       isOptionEqualToValue={isOptionEqualToValue}
@@ -210,23 +226,6 @@ const Autocomplete = <
 
   function defaultRenderTags() {
     return null;
-  }
-
-  function defaultPopperComponent(popperProps: PopperProps) {
-    return (
-      <Popper
-        modifiers={[
-          {
-            enabled: true,
-            name: "offset",
-            options: {
-              offset: [0, 8],
-            },
-          },
-        ]}
-        {...popperProps}
-      />
-    );
   }
 
   function defaultRenderOption(

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -108,6 +108,10 @@ const Autocomplete = <
 
   const [inputValue, setInputValue] = useState("");
 
+  /**
+   * (masoudmanson): Using a custom Popper or Paper with the Autocomplete
+   * without a useCalback results in scroll jumps while selecting an option!
+   */
   const defaultPopperComponent = useCallback((popperProps: PopperProps) => {
     return (
       <Popper

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -5,6 +5,8 @@ import {
   AutocompleteRenderOptionState,
   InputAdornment,
   AutocompleteProps as MuiAutocompleteProps,
+  Popper,
+  PopperProps,
 } from "@mui/material";
 import React, { ReactNode, SyntheticEvent, useState } from "react";
 import { noop } from "src/common/utils";
@@ -99,6 +101,7 @@ const Autocomplete = <
     noOptionsText = "No options",
     onInputChange = noop,
     PaperComponent = StyledPaper,
+    PopperComponent = defaultPopperComponent,
     renderOption = defaultRenderOption,
     renderTags = defaultRenderTags,
     search = false,
@@ -116,6 +119,7 @@ const Autocomplete = <
       loadingText={loadingText}
       noOptionsText={noOptionsText}
       PaperComponent={PaperComponent}
+      PopperComponent={PopperComponent}
       renderOption={renderOption}
       getOptionLabel={getOptionLabel}
       isOptionEqualToValue={isOptionEqualToValue}
@@ -206,6 +210,23 @@ const Autocomplete = <
 
   function defaultRenderTags() {
     return null;
+  }
+
+  function defaultPopperComponent(popperProps: PopperProps) {
+    return (
+      <Popper
+        modifiers={[
+          {
+            enabled: true,
+            name: "offset",
+            options: {
+              offset: [0, 8],
+            },
+          },
+        ]}
+        {...popperProps}
+      />
+    );
   }
 
   function defaultRenderOption(

--- a/packages/components/src/core/Autocomplete/style.ts
+++ b/packages/components/src/core/Autocomplete/style.ts
@@ -15,7 +15,6 @@ import {
 
 export interface StyleProps extends CommonThemeProps {
   count?: number;
-  hasSections?: boolean;
   icon?: ReactElement;
   search?: boolean;
 }
@@ -25,7 +24,6 @@ const doNotForwardProps = [
   "keepSearchOnSelect",
   "search",
   "InputBaseProps",
-  "hasSections",
 ];
 
 export const StyledAutocomplete = styled(Autocomplete, {
@@ -38,7 +36,7 @@ export const StyledAutocomplete = styled(Autocomplete, {
   }
 
   ${(props: StyleProps) => {
-    const { search, hasSections } = props;
+    const { search } = props;
     const spacings = getSpaces(props);
     const colors = getColors(props);
     const borders = getBorders(props);
@@ -55,60 +53,56 @@ export const StyledAutocomplete = styled(Autocomplete, {
       }
 
       & + .MuiAutocomplete-popper > .MuiAutocomplete-paper {
+        ${search ? `padding-left: ${spacings?.s}px !important;` : ""}
 
-      ${
-        search || hasSections
-          ? `padding-left: ${spacings?.s}px !important;`
-          : ""
-      }
+        .MuiAutocomplete-listbox {
+          max-height: 40vh;
+          padding-top: 0;
+          padding-bottom: 0;
+          padding-right: ${spacings?.s}px;
 
-      .MuiAutocomplete-listbox {
-        max-height: 40vh;
-        padding-top: 0;
-        padding-bottom: 0;
-        padding-right: ${spacings?.s}px;
+          .MuiAutocomplete-option {
+            min-height: unset;
+          }
 
-        .MuiAutocomplete-option {
-          min-height: unset;
+          .MuiAutocomplete-option.Mui-focused {
+            background-color: ${colors?.gray[100]};
+          }
+
+          .MuiAutocomplete-option[aria-selected="true"] {
+            background-color: white;
+          }
+
+          .MuiAutocomplete-option[aria-disabled="true"] {
+            opacity: 1;
+          }
+
+          .MuiAutocomplete-option[aria-selected="true"].Mui-focused {
+            background-color: ${colors?.gray[100]};
+          }
+
+          & > li:last-child .MuiAutocomplete-groupUl {
+            border-bottom: none;
+            margin-bottom: 0;
+          }
         }
 
-        .MuiAutocomplete-option.Mui-focused {
-          background-color: ${colors?.gray[100]};
+        .MuiAutocomplete-groupLabel {
+          top: 0;
+          color: ${colors?.gray[500]};
+          padding: ${spacings?.xxs}px 0 ${spacings?.xxs}px 0;
         }
 
-        .MuiAutocomplete-option[aria-selected="true"] {
-          background-color: white;
-        }
-
-        .MuiAutocomplete-option[aria-disabled="true"] {
-          opacity: 1;
-        }
-
-        .MuiAutocomplete-option[aria-selected="true"].Mui-focused {
-          background-color: ${colors?.gray[100]};
-        }
-
-        & > li:last-child .MuiAutocomplete-groupUl {
-          border-bottom: none;
-          margin-bottom: 0;
-        }
-      }
-
-      .MuiAutocomplete-groupLabel {
-        top: 0;
-        color: ${colors?.gray[500]};
-        padding: ${spacings?.xxs}px 0 ${spacings?.xxs}px 0;
-      }
-
-      .MuiAutocomplete-groupUl {
-        margin-bottom: ${spacings?.m}px;
-        position: relative;
-        padding: 0 0 ${spacings?.xs}px 0 0;
-        border-bottom: ${borders?.gray[200]};
-
-        & li:last-of-type {
+        .MuiAutocomplete-groupUl {
+          margin-bottom: ${spacings?.m}px;
           position: relative;
-          margin-bottom: ${spacings?.xxs}px;
+          padding: 0 0 ${spacings?.xs}px 0 0;
+          border-bottom: ${borders?.gray[200]};
+
+          & li:last-of-type {
+            position: relative;
+            margin-bottom: ${spacings?.xxs}px;
+          }
         }
       }
     `;

--- a/packages/components/src/core/Dropdown/index.tsx
+++ b/packages/components/src/core/Dropdown/index.tsx
@@ -111,13 +111,13 @@ const Dropdown = <Multiple extends boolean | undefined = false>({
 
   useEffect(() => {
     onChange(value);
-  }, [value]);
+  }, [onChange, value]);
 
   useEffect(() => {
     if (isControlled) {
       setValue(propValue);
     }
-  }, [propValue]);
+  }, [isControlled, propValue]);
 
   const [open, setOpen] = useState(false);
 

--- a/packages/components/src/core/DropdownMenu/index.stories.tsx
+++ b/packages/components/src/core/DropdownMenu/index.stories.tsx
@@ -284,7 +284,6 @@ const LivePreviewDemo = (): JSX.Element => {
             }}
             search={false}
             multiple={false}
-            hasSections={false}
             value={value1}
             onClickAway={handleClickAway1}
           />
@@ -369,7 +368,6 @@ const LivePreviewDemo = (): JSX.Element => {
             open={!!open4}
             search={false}
             multiple
-            hasSections
             groupBy={(option) => option.section as string}
             onChange={handleChange4}
             disableCloseOnSelect
@@ -638,7 +636,6 @@ const ScreenshotTestDemo = (props: Args): JSX.Element => {
                 </p>
                 <DropdownMenu
                   {...props}
-                  hasSections
                   groupBy={
                     groupBy &&
                     ((option: (typeof SCREENSHOT_TEST_OPTIONS)[number]) =>

--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -7,9 +7,8 @@ import {
   PaperProps,
   PopperProps,
 } from "@mui/material";
-import { DefaultAutocompleteOption } from "dist/index.cjs";
 import React, { SyntheticEvent } from "react";
-import Autocomplete from "../Autocomplete";
+import Autocomplete, { DefaultAutocompleteOption } from "../Autocomplete";
 import { InputSearchProps } from "../InputSearch";
 import {
   StyleProps,

--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -7,7 +7,7 @@ import {
   PaperProps,
   PopperProps,
 } from "@mui/material";
-import React, { SyntheticEvent } from "react";
+import React, { SyntheticEvent, useCallback } from "react";
 import Autocomplete, { DefaultAutocompleteOption } from "../Autocomplete";
 import { InputSearchProps } from "../InputSearch";
 import {
@@ -93,6 +93,10 @@ const DropdownMenu = <
     ...rest
   } = props;
 
+  const defaultPopperComponent = useCallback((popperProps: PopperProps) => {
+    return <StyledAutocompletePopper {...popperProps} />;
+  }, []);
+
   return (
     <PopperComponent
       id={id}
@@ -119,16 +123,19 @@ const DropdownMenu = <
             label={label}
             search={search}
             InputBaseProps={InputBaseProps}
-            PaperComponent={(paperComponentProps: PaperProps) => (
-              <PaperComponent
-                search={search}
-                title={title}
-                {...paperComponentProps}
-              />
+            PaperComponent={useCallback(
+              (paperComponentProps: PaperProps) => (
+                <PaperComponent
+                  search={search}
+                  title={title}
+                  {...paperComponentProps}
+                />
+              ),
+              [PaperComponent, search, title]
             )}
             open={open}
             {...rest}
-            PopperComponent={StyledAutocompletePopper}
+            PopperComponent={defaultPopperComponent}
           />
           {children}
         </div>

--- a/packages/components/src/core/DropdownMenu/style.ts
+++ b/packages/components/src/core/DropdownMenu/style.ts
@@ -1,14 +1,10 @@
-import { Autocomplete, Paper, Popper } from "@mui/material";
+import { Paper, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";
-import InputSearch from "../InputSearch";
 import {
   CommonThemeProps,
-  fontBodyXxs,
-  fontCapsXxxxs,
   fontHeaderXs,
   getBorders,
-  getColors,
   getCorners,
   getShadows,
   getSpaces,
@@ -17,7 +13,6 @@ import {
 
 export interface StyleProps extends CommonThemeProps {
   count?: number;
-  hasSections?: boolean;
   icon?: ReactElement;
   search?: boolean;
   title?: string;
@@ -29,152 +24,22 @@ const doNotForwardProps = [
   "keepSearchOnSelect",
   "search",
   "InputBaseProps",
-  "hasSections",
   "title",
   "PopperBaseProps",
   "onClickAway",
   "ClickAwayListenerProps",
 ];
 
-export const StyledAutocomplete = styled(Autocomplete, {
-  shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
-})`
-  + .MuiAutocomplete-popper
-    > .MuiAutocomplete-paper
-    .MuiAutocomplete-groupLabel {
-    ${fontCapsXxxxs}
-  }
+// export const StyledAutocomplete = styled(Autocomplete, {
+//   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
+// })`
+//   ${(props: StyleProps) => {
+//     const spacings = getSpaces(props);
 
-  ${(props: StyleProps) => {
-    const { search, title, hasSections } = props;
-    const spacings = getSpaces(props);
-    const colors = getColors(props);
-    const borders = getBorders(props);
-
-    return `
-      ${!search && `height: 0`};
-
-      .MuiOutlinedInput-root.MuiInputBase-formControl.MuiInputBase-adornedEnd {
-        padding: 0 ${spacings?.l}px 0 0;
-
-        .MuiAutocomplete-input {
-          padding: ${spacings?.xs}px ${spacings?.l}px;
-        }
-      }
-
-      & + .MuiAutocomplete-popper {
-        position: relative !important;
-        transform: none !important;
-        width: 100% !important;
-      }
-
-      & + .MuiAutocomplete-popper > .MuiAutocomplete-paper {
-
-      ${
-        search || title || hasSections
-          ? `padding-left: ${spacings?.s}px !important;`
-          : ""
-      }
-
-      .MuiAutocomplete-listbox {
-        max-height: 40vh;
-        padding-top: 0;
-        padding-bottom: 0;
-
-        ${
-          search || title || hasSections
-            ? `padding-right: ${spacings?.s}px;`
-            : ""
-        }
-
-        .MuiAutocomplete-option {
-          min-height: unset;
-        }
-
-        .MuiAutocomplete-option.Mui-focused {
-          background-color: ${colors?.gray[100]};
-        }
-
-        .MuiAutocomplete-option[aria-selected="true"] {
-          background-color: white;
-        }
-
-        .MuiAutocomplete-option[aria-disabled="true"] {
-          opacity: 1;
-        }
-
-        .MuiAutocomplete-option[aria-selected="true"].Mui-focused {
-          background-color: ${colors?.gray[100]};
-        }
-
-        & > li:last-child .MuiAutocomplete-groupUl {
-          border-bottom: none;
-          margin-bottom: 0;
-        }
-      }
-
-      .MuiAutocomplete-groupLabel {
-        top: 0;
-        color: ${colors?.gray[500]};
-        padding: ${spacings?.xxs}px 0 ${spacings?.xxs}px 0;
-      }
-
-      .MuiAutocomplete-groupUl {
-        margin-bottom: ${spacings?.m}px;
-        position: relative;
-        padding: 0 0 ${spacings?.xs}px 0 0;
-        border-bottom: ${borders?.gray[200]};
-
-        & li:last-of-type {
-          position: relative;
-          margin-bottom: ${spacings?.xxs}px;
-        }
-      }
-    `;
-  }}
-` as typeof Autocomplete;
-
-export const InputBaseWrapper = styled("div", {
-  shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
-})`
-  ${(props: StyleProps) => {
-    const { search } = props;
-
-    if (!search) {
-      // (thuang): We cannot use `display: none;` here, since
-      // the component needs to be in the DOM to handle backdrop
-      // click to close the menu
-      return `
-        border: 0;
-        padding: 0;
-
-        white-space: nowrap;
-
-        clip-path: inset(100%);
-        clip: rect(0 0 0 0);
-        overflow: hidden;
-        margin: 0;
-      `;
-    }
-
-    const spacings = getSpaces(props);
-
-    return `
-      margin: ${spacings?.s}px;
-    `;
-  }}
-`;
-
-export const StyledMenuInputSearch = styled(InputSearch, {
-  shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
-})<{ search: boolean }>`
-  margin: 0;
-  .MuiInputBase-root {
-    width: 100%;
-  }
-  /* (thuang): Works with attribute inputMode: "none" to hide mobile keyboard */
-  caret-color: ${({ search }) => (search ? "auto" : "transparent")};
-`;
+//     return `
+//     `;
+//   }}
+// ` as typeof Autocomplete;
 
 export const StyledHeaderTitle = styled("div", {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
@@ -228,27 +93,29 @@ export const StyledPopper = styled(Popper, {
   }}
 `;
 
-export const StyledPaper = styled(Paper)`
-  box-shadow: none;
-  margin: 0;
-  border-radius: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-`;
-
-export const StyledMenuItemDetails = styled("div")`
-  ${fontBodyXxs}
-  ${(props) => {
-    const colors = getColors(props);
+export const StyledPaper = styled(Paper, {
+  shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
+})`
+  ${(props: StyleProps) => {
+    const { title } = props;
+    const spacings = getSpaces(props);
 
     return `
-      color: ${colors?.gray[500]};
-      white-space: pre-wrap;
+      box-shadow: none;
+      margin: 0;
+      border-radius: 0;
+      padding-top: 0;
+      padding-bottom: 0;
+      ${title ? `padding-left: ${spacings?.s}px !important;` : ``}
     `;
   }}
 `;
 
-export const StyledMenuItemText = styled("div")`
-  display: flex;
-  flex-direction: column;
+export const StyledAutocompletePopper = styled(Popper)`
+  position: relative !important;
+  transform: none !important;
+  width: 100% !important;
+  box-shadow: none;
+  padding: 0;
+  border: none;
 `;


### PR DESCRIPTION
## Summary

**DropdownMenu**
Github issue: #563 

We need to refactor the DropdownMenu component to utilize the new Autocomplete component instead of the MUI's Autocomplete.

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
