### PR TITLE
style(inputsearch): change default html clear icon

### DIFF
--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
         Search by label
       </label>
       <div
-        class="MuiFormControl-root MuiTextField-root css-zhsnsf-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root css-1yyp8n-MuiFormControl-root-MuiTextField-root"
       >
         <div
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"

--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
         Search by label
       </label>
       <div
-        class="MuiFormControl-root MuiTextField-root css-csl8fy-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root css-10tk5kr-MuiFormControl-root-MuiTextField-root"
       >
         <div
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
@@ -53,7 +53,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q6hio5-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
                   data-file-name="IconSearchSmall"
                   data-testid="IconSearchSmall"
                   fillcontrast="white"

--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
         Search by label
       </label>
       <div
-        class="MuiFormControl-root MuiTextField-root css-10tk5kr-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root css-1rjsjzb-MuiFormControl-root-MuiTextField-root"
       >
         <div
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"

--- a/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
         Search by label
       </label>
       <div
-        class="MuiFormControl-root MuiTextField-root css-1yyp8n-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root css-csl8fy-MuiFormControl-root-MuiTextField-root"
       >
         <div
           class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedEnd css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
@@ -39,9 +39,11 @@ exports[`<Autocomplete /> Default story renders snapshot 1`] = `
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-g8kzra-MuiInputAdornment-root"
           >
+            
             <button
+              aria-label="search-button"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1fqpm4w-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -3,7 +3,6 @@ import {
   AutocompleteInputChangeReason,
   AutocompleteRenderInputParams,
   AutocompleteRenderOptionState,
-  InputAdornment,
   AutocompleteProps as MuiAutocompleteProps,
 } from "@mui/material";
 import React, { ReactNode, SyntheticEvent, useState } from "react";
@@ -11,6 +10,7 @@ import { noop } from "src/common/utils";
 import ButtonIcon from "../ButtonIcon";
 import { IconProps } from "../Icon";
 import { InputSearchProps } from "../InputSearch";
+import { StyledInputAdornment } from "../InputSearch/style";
 import MenuItem, { IconNameToSmallSizes } from "../MenuItem";
 import {
   InputBaseWrapper,
@@ -147,13 +147,27 @@ const Autocomplete = <
                */
               ...params.InputProps.ref,
               endAdornment: (
-                <InputAdornment position="end">
+                <StyledInputAdornment position="end">
+                  {inputValue && (
+                    <ButtonIcon
+                      aria-label="clear-button"
+                      className="input-search-clear-icon"
+                      onClick={clearInput}
+                      sdsType="primary"
+                      sdsSize="small"
+                      sdsIconProps={{
+                        sdsType: "iconButton",
+                      }}
+                      sdsIcon="xMark"
+                    />
+                  )}
                   <ButtonIcon
+                    aria-label="search-button"
                     sdsType="secondary"
                     sdsSize="small"
                     sdsIcon="search"
                   />
-                </InputAdornment>
+                </StyledInputAdornment>
               ),
               inputProps: params.inputProps,
             }}
@@ -192,6 +206,10 @@ const Autocomplete = <
       }}
     />
   );
+
+  function clearInput() {
+    setInputValue("");
+  }
 
   function defaultGetOptionLabel(
     option: T | AutocompleteFreeSoloValueMapping<FreeSolo>

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -148,6 +148,10 @@ const Autocomplete = <
               ...params.InputProps.ref,
               endAdornment: (
                 <StyledInputAdornment position="end">
+                  {/**
+                   * (masoudmansdon): Because the Autocomplete component overrides the
+                   * InputSearch's endAdornment, we must also include the clear IconButton here.
+                   */}
                   {inputValue && (
                     <ButtonIcon
                       aria-label="clear-button"
@@ -209,6 +213,10 @@ const Autocomplete = <
 
   function clearInput() {
     setInputValue("");
+    /**
+     * (masoudmanson): Because we are manually firing this event,
+     * we must build a onChange event to transmit the updated value to onChange listeners.
+     */
     if (onInputChange)
       onInputChange(
         { target: { value: "" } } as React.ChangeEvent<HTMLInputElement>,

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -193,6 +193,9 @@ const Autocomplete = <
                     aria-label="search-button"
                     sdsType="secondary"
                     sdsSize="small"
+                    sdsIconProps={{
+                      sdsType: "interactive",
+                    }}
                     sdsIcon="search"
                   />
                 </StyledInputAdornment>

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -209,6 +209,12 @@ const Autocomplete = <
 
   function clearInput() {
     setInputValue("");
+    if (onInputChange)
+      onInputChange(
+        { target: { value: "" } } as React.ChangeEvent<HTMLInputElement>,
+        "",
+        "clear"
+      );
   }
 
   function defaultGetOptionLabel(

--- a/packages/components/src/core/Autocomplete/style.ts
+++ b/packages/components/src/core/Autocomplete/style.ts
@@ -153,7 +153,7 @@ export const StyledPaper = styled(Paper)`
     const shadows = getShadows(props);
 
     return `
-      padding: ${spacings?.s}px 0 0 ${spacings?.s}px ;
+      padding: ${spacings?.s}px 0 0 ${spacings?.s}px;
       background-color: white;
       border: ${borders?.gray[100]};
       border-radius: ${corners?.m}px;

--- a/packages/components/src/core/Dropdown/index.stories.tsx
+++ b/packages/components/src/core/Dropdown/index.stories.tsx
@@ -15,6 +15,9 @@ const Dropdown = (props: Args): JSX.Element => {
       onChange={noop}
       options={GITHUB_LABELS}
       DropdownMenuProps={{
+        PopperBaseProps: {
+          sx: { width: "300px" },
+        },
         groupBy: (option: DefaultDropdownMenuOption) =>
           option.section as string,
       }}
@@ -150,7 +153,7 @@ export const InsideModal = {
       skip: true,
     },
   },
-  render: function InsideModalComponent(): JSX.Element {
+  render: function InsideModalComponent(props: Args): JSX.Element {
     const [value, setValue] = useState<
       DefaultDropdownMenuOption | DefaultDropdownMenuOption[] | null
     >([GITHUB_LABELS[0], GITHUB_LABELS[1]]);
@@ -168,6 +171,7 @@ export const InsideModal = {
           value={value}
           multiple
           InputDropdownProps={{ sdsStyle: "square" }}
+          {...props}
         />
       </Dialog>
     );
@@ -206,6 +210,9 @@ const ControlledDropdownDemo = (props: Args): JSX.Element => {
         onChange={handleChange}
         data-testid="dropdown"
         DropdownMenuProps={{
+          PopperBaseProps: {
+            sx: { width: "300px" },
+          },
           groupBy: (option: DefaultDropdownMenuOption) =>
             option.section as string,
           title: "Github Labels",
@@ -244,6 +251,11 @@ const TestDemo = (props: Args): JSX.Element => {
       label="Click Target"
       onChange={noop}
       options={GITHUB_LABELS}
+      DropdownMenuProps={{
+        PopperBaseProps: {
+          sx: { width: "300px" },
+        },
+      }}
       {...props}
       data-testid="dropdown"
     />

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -58,6 +58,10 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
 
       if (handleSubmit) handleSubmit("");
 
+      /**
+       * (masoudmanson): Because we are manually firing this event,
+       * we must build a onChange event to transmit the updated value to onChange listeners.
+       */
       if (onChange) {
         onChange({
           target: { value: "" },
@@ -130,6 +134,10 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
           onChange={handleChange}
           onKeyDown={handleKeyPress}
           intent={intent}
+          /**
+           * (masoudmanson): This prevents the browser's default auto completion
+           * menu from being displayed for the InputSearch.
+           */
           autoComplete="off"
           {...rest}
         />

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -1,10 +1,12 @@
-import {
-  InputAdornment,
-  TextFieldProps as RawTextFieldSearchProps,
-} from "@mui/material";
+import { TextFieldProps as RawTextFieldSearchProps } from "@mui/material";
 import React, { forwardRef, useState } from "react";
 import ButtonIcon from "../ButtonIcon";
-import { InputSearchExtraProps, StyledLabel, StyledSearchBase } from "./style";
+import {
+  InputSearchExtraProps,
+  StyledInputAdornment,
+  StyledLabel,
+  StyledSearchBase,
+} from "./style";
 
 export interface AccessibleInputSearchProps {
   label: string;
@@ -50,6 +52,11 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
       if (onChange) onChange(event);
     };
 
+    const clearInput = () => {
+      setValue("");
+      setHasValue(false);
+    };
+
     const localHandleSubmit = () => {
       if (handleSubmit) handleSubmit(value);
     };
@@ -77,7 +84,20 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
           // passed to mui Input
           InputProps={{
             endAdornment: (
-              <InputAdornment position="end">
+              <StyledInputAdornment position="end">
+                {value && (
+                  <ButtonIcon
+                    aria-label="clear-button"
+                    className="input-search-clear-icon"
+                    onClick={clearInput}
+                    sdsType="primary"
+                    sdsSize="small"
+                    sdsIconProps={{
+                      sdsType: "iconButton",
+                    }}
+                    sdsIcon="xMark"
+                  />
+                )}
                 <ButtonIcon
                   aria-label="search-button"
                   onClick={localHandleSubmit}
@@ -88,7 +108,7 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
                   }}
                   sdsIcon="search"
                 />
-              </InputAdornment>
+              </StyledInputAdornment>
             ),
           }}
           type="search"

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -100,8 +100,9 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
           sdsStyle={sdsStyle}
           sdsStage={hasValue ? "userInput" : "default"}
           onChange={handleChange}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyPress}
           intent={intent}
+          autoComplete="off"
           {...rest}
         />
       </>

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -97,19 +97,17 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
           InputProps={{
             endAdornment: (
               <StyledInputAdornment position="end">
-                {value && (
-                  <ButtonIcon
-                    aria-label="clear-button"
-                    className="input-search-clear-icon"
-                    onClick={clearInput}
-                    sdsType="primary"
-                    sdsSize="small"
-                    sdsIconProps={{
-                      sdsType: "iconButton",
-                    }}
-                    sdsIcon="xMark"
-                  />
-                )}
+                <ButtonIcon
+                  aria-label="clear-button"
+                  className="input-search-clear-icon"
+                  onClick={clearInput}
+                  sdsType="primary"
+                  sdsSize="small"
+                  sdsIconProps={{
+                    sdsType: "iconButton",
+                  }}
+                  sdsIcon="xMark"
+                />
                 <ButtonIcon
                   aria-label="search-button"
                   onClick={localHandleSubmit}

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -55,6 +55,14 @@ const InputSearch = forwardRef<HTMLDivElement, InputSearchProps>(
     const clearInput = () => {
       setValue("");
       setHasValue(false);
+
+      if (handleSubmit) handleSubmit("");
+
+      if (onChange) {
+        onChange({
+          target: { value: "" },
+        } as React.ChangeEvent<HTMLInputElement>);
+      }
     };
 
     const localHandleSubmit = () => {

--- a/packages/components/src/core/InputSearch/style.ts
+++ b/packages/components/src/core/InputSearch/style.ts
@@ -1,12 +1,12 @@
 import { css, SerializedStyles } from "@emotion/react";
 import {
+  InputAdornment,
   inputAdornmentClasses,
   inputBaseClasses,
   outlinedInputClasses,
   TextField,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import xMark from "../../common/svgs/IconXMarkSmall.svg";
 import {
   CommonThemeProps,
   fontBodyM,
@@ -120,23 +120,27 @@ export const StyledSearchBase = styled(TextField, {
       [type="search"]::-webkit-search-cancel-button {
         -webkit-appearance: none;
         appearance: none;
-        height: 14px;
-        width: 14px;
-        background-color: ${colors?.primary[400]};
-        -webkit-mask-image: url(${xMark});
-        mask-image: url(${xMark});
-        background-size: 14px 14px;
-        cursor: pointer;
+      }
+
+      & .input-search-clear-icon {
+        display: none;
+        position: absolute;
+        right: 20px;
       }
 
       .${outlinedInputClasses.root} {
         .${outlinedInputClasses.notchedOutline} {
           border: ${borders?.gray[400]};
         }
+
+        &:hover .input-search-clear-icon,
+        &:focus-within .input-search-clear-icon {
+          display: inline-flex;
+        }
       }
 
       .${inputBaseClasses.inputSizeSmall} {
-        padding: ${spacings?.xs}px 0 ${spacings?.xs}px ${spacings?.l}px;
+        padding: ${spacings?.xs}px ${spacings?.l}px;
         height: 34px;
         box-sizing: border-box;
         background-color: #fff;
@@ -163,4 +167,8 @@ export const StyledSearchBase = styled(TextField, {
       ${disabled && disabledStyled(props)}
     `;
   }}
+`;
+
+export const StyledInputAdornment = styled(InputAdornment)`
+  position: relative;
 `;

--- a/packages/components/src/core/InputSearch/style.ts
+++ b/packages/components/src/core/InputSearch/style.ts
@@ -6,6 +6,7 @@ import {
   TextField,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import xMark from "../../common/svgs/IconXMarkSmall.svg";
 import {
   CommonThemeProps,
   fontBodyM,
@@ -115,6 +116,18 @@ export const StyledSearchBase = styled(TextField, {
       margin-right: ${spacings?.xl}px;
       min-width: 120px;
       display: block;
+
+      [type="search"]::-webkit-search-cancel-button {
+        -webkit-appearance: none;
+        appearance: none;
+        height: 14px;
+        width: 14px;
+        background-color: ${colors?.primary[400]};
+        -webkit-mask-image: url(${xMark});
+        mask-image: url(${xMark});
+        background-size: 14px 14px;
+        cursor: pointer;
+      }
 
       .${outlinedInputClasses.root} {
         .${outlinedInputClasses.notchedOutline} {

--- a/packages/components/src/core/InputSearch/style.ts
+++ b/packages/components/src/core/InputSearch/style.ts
@@ -1,5 +1,6 @@
 import { css, SerializedStyles } from "@emotion/react";
 import {
+  buttonBaseClasses,
   InputAdornment,
   inputAdornmentClasses,
   inputBaseClasses,
@@ -22,6 +23,7 @@ export interface InputSearchExtraProps extends CommonThemeProps {
   intent?: "default" | "error" | "warning";
   sdsStyle?: "rounded" | "square";
   sdsStage?: "default" | "userInput";
+  value?: string;
 }
 
 const sdsPropNames = ["sdsStyle", "sdsStage", "intent", "handleSubmit"];
@@ -105,7 +107,7 @@ export const StyledSearchBase = styled(TextField, {
   },
 })`
   ${(props: InputSearchExtraProps) => {
-    const { intent, disabled, sdsStyle } = props;
+    const { intent, disabled, sdsStyle, value } = props;
     const spacings = getSpaces(props);
     const borders = getBorders(props);
     const colors = getColors(props);
@@ -123,9 +125,8 @@ export const StyledSearchBase = styled(TextField, {
       }
 
       & .input-search-clear-icon {
-        display: none;
-        position: absolute;
-        right: 20px;
+        opacity: 0;
+        margin-right: ${spacings?.s}px;
       }
 
       .${outlinedInputClasses.root} {
@@ -135,7 +136,7 @@ export const StyledSearchBase = styled(TextField, {
 
         &:hover .input-search-clear-icon,
         &:focus-within .input-search-clear-icon {
-          display: inline-flex;
+          opacity: ${value ? 1 : 0};
         }
       }
 
@@ -156,8 +157,11 @@ export const StyledSearchBase = styled(TextField, {
           border: ${borders?.primary[400]};
         }
 
-        .${inputAdornmentClasses.root} svg {
-          color: ${colors?.primary[400]};
+        .${inputAdornmentClasses.root} .${buttonBaseClasses.root}:last-of-type {
+          cursor: default;
+          svg {
+            color: ${colors?.primary[400]};
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

**InputSearch**
Github issue: #606 

When text is entered into the `InputSearch` component, you may have noticed the default HTML clear icon. However, this default icon doesn't align with our SDS iconography. To improve consistency and visual coherence, we need to replace the default clear icon with the SDS `xMark` icon.

**Current InputSearch:** 

<img src="https://github.com/chanzuckerberg/sci-components/assets/927990/07c55c49-0044-4cc1-b686-92484f01507f" width="300"/>

<br/><br/>

**Desired Result:** 

<img src="https://github.com/chanzuckerberg/sci-components/assets/927990/7795af2b-e6a2-4216-ace2-a382439ea5bf" width="300" />

<br/><br/>

**Live demo:**
https://616981d9028812003ade73f3-jouthyttmu.chromatic.com/?path=/story/inputs-inputsearch--default


## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
