### PR TITLE
fix(defaulttheme): fix typo in fontWeights, medium = 500

### DIFF
--- a/packages/components/src/core/styles/common/defaultTheme.ts
+++ b/packages/components/src/core/styles/common/defaultTheme.ts
@@ -13,7 +13,7 @@ const { common } = colors;
 enum FontWeight {
   bold = 700,
   light = 300,
-  medium = 800,
+  medium = 500,
   regular = 400,
   semibold = 600,
 }


### PR DESCRIPTION
## Summary

**DefaultTheme**
Github issue: #686

Typo fixed in `defaultTheme` FontWeights object. Medium font-weight is equal to `500` now.

