### PR TITLE
docs(dropdownmenu): add @deprecated tag to comment

### DIFF
--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -22,11 +22,11 @@ import {
 } from "./style";
 
 /**
+ * @deprecated
  * (masoudmanson): We've replaced DefaultDropdownMenuOption with DefaultAutocompleteOption
  * as the preferred choice. However, for backward compatibility, we've exported this line to
  * prevent potential TypeScript type issues for product teams using previous versions.
  */
-
 export type DefaultDropdownMenuOption = DefaultAutocompleteOption;
 
 // (masoudmanson): Represents the minimum width defined by design specifications


### PR DESCRIPTION
## Summary

**DropdownMenu**

prefix the deprecation comment with a @deprecated tag so we get the strikethrough text to encourage users to migrate to the new type.

```javascript
/**
 * @deprecated
 * (masoudmanson): We've replaced DefaultDropdownMenuOption with DefaultAutocompleteOption
 * as the preferred choice. However, for backward compatibility, we've exported this line to
 * prevent potential TypeScript type issues for product teams using previous versions.
 */
export type DefaultDropdownMenuOption = DefaultAutocompleteOption;
```
