### PR TITLE
fix: add focused stylign to tabs

### DIFF
--- a/packages/components/src/core/Tabs/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Tabs/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
     >
       <button
         aria-selected="true"
-        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-17rzz1x-MuiButtonBase-root-MuiTab-root"
+        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected css-1jnyyyh-MuiButtonBase-root-MuiTab-root"
         role="tab"
         tabindex="0"
         type="button"
@@ -26,7 +26,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
       </button>
       <button
         aria-selected="false"
-        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-17rzz1x-MuiButtonBase-root-MuiTab-root"
+        class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary css-1jnyyyh-MuiButtonBase-root-MuiTab-root"
         role="tab"
         tabindex="-1"
         type="button"

--- a/packages/components/src/core/Tabs/style.tsx
+++ b/packages/components/src/core/Tabs/style.tsx
@@ -94,6 +94,11 @@ export const StyledTab = styled(RawTab, {
         color: black;
       }
 
+      &.Mui-focusVisible {
+        outline: 5px auto Highlight;
+        outline: 5px auto -webkit-focus-ring-color;
+      }
+
       &.Mui-selected {
         color: black;
 


### PR DESCRIPTION
This PR adds a focus outline to the tabs component, for the [SDS accessibility hackday project](https://docs.google.com/spreadsheets/d/1NrbRZ4vTfeYtKU3GXrsmeS6QSHsNSwiV_ITLvo251WA/edit#gid=915097901).

<img width="443" alt="Screenshot 2023-11-29 at 12 56 57 PM" src="https://github.com/chanzuckerberg/sci-components/assets/2503289/180e3db3-c711-4c8f-b889-d4fd112e6433">

[See it live on Chromatic](https://www.chromatic.com/component?appId=616981d9028812003ade73f3&csfId=tabs&buildNumber=1592&k=65677c0a9bbad7e409e35add-1200px-interactive-true&h=8&b=-1)

Keyboard usage of the tabs is actually working as expected:
- Tab onto and off of the active tab
- When focused on the active tab, left and right arrows changes the active tab
- Space changes to the selected tab