### PR TITLE
fix(callout): fix callout expand in production

### DIFF
--- a/packages/components/src/core/Callout/components/CalloutTitle/index.tsx
+++ b/packages/components/src/core/Callout/components/CalloutTitle/index.tsx
@@ -1,4 +1,5 @@
 import { AlertTitleProps } from "@mui/material/AlertTitle";
+import { CALLOUT_TITLE_DISPLAY_NAME } from "../../constants";
 import { StyledCalloutTitle } from "./style";
 
 const CalloutTitle = ({ children }: AlertTitleProps): JSX.Element => {
@@ -6,6 +7,6 @@ const CalloutTitle = ({ children }: AlertTitleProps): JSX.Element => {
 };
 
 // Display name required to ensure Callout expand works correctly.
-CalloutTitle.displayName = "CalloutTitle";
+CalloutTitle.displayName = CALLOUT_TITLE_DISPLAY_NAME;
 
 export default CalloutTitle;

--- a/packages/components/src/core/Callout/constants.ts
+++ b/packages/components/src/core/Callout/constants.ts
@@ -1,0 +1,1 @@
+export const CALLOUT_TITLE_DISPLAY_NAME = "CalloutTitle";

--- a/packages/components/src/core/Callout/index.tsx
+++ b/packages/components/src/core/Callout/index.tsx
@@ -3,6 +3,7 @@ import { Grow } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import ButtonIcon from "../ButtonIcon";
 import Icon from "../Icon";
+import { CALLOUT_TITLE_DISPLAY_NAME } from "./constants";
 import { StyledCallout } from "./style";
 
 const SDS_STAGE_OPEN = "open";
@@ -101,7 +102,7 @@ const Callout = ({
 
   const firstChildIsCalloutTitle =
     Array.isArray(children) &&
-    children[0]?.type?.displayName === "CalloutTitle";
+    children[0]?.type?.displayName === CALLOUT_TITLE_DISPLAY_NAME;
 
   if (firstChildIsCalloutTitle) {
     [calloutTitle, ...calloutContent] = children;


### PR DESCRIPTION
## Summary

Fixes issue where the Callout component content was not expanding correctly in prdouction. This is because the property `name` is obfuscated in production for some environments. Setting and checking for `displayName` should fix the issue because it is not obfuscated in production.

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
