### PR TITLE
fix(autocomplete): fix controlled open state

### DIFF
--- a/packages/components/src/core/Autocomplete/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/Autocomplete/__storybook__/index.stories.tsx
@@ -10,6 +10,7 @@ import { Autocomplete } from "./stories/default";
 import { AutocompleteSingleColumnDemo } from "./stories/singleColumn";
 import { AutocompleteMultiColumnDemo } from "./stories/multiColumn";
 import { TestDemo } from "./stories/test";
+import { ControlledOpenDemo } from "./stories/controlledOpen";
 
 export default {
   argTypes: {
@@ -119,6 +120,25 @@ export const MultiColumn = {
     },
   },
   render: (args: Args) => <AutocompleteMultiColumnDemo {...args} />,
+};
+
+// Controlled Open
+
+export const ControlledOpen = {
+  args: {
+    groupBy: AUTOCOMPLETE_GROUP_BY_OPTIONS[1],
+    keepSearchOnSelect: true,
+    label: AUTOCOMPLETE_LABEL,
+    multiple: true,
+    options: AUTOCOMPLETE_DATA_OPTIONS[1],
+    search: true,
+  },
+  parameters: {
+    controls: {
+      exclude: ["search"],
+    },
+  },
+  render: (args: Args) => <ControlledOpenDemo {...args} />,
 };
 
 // Test

--- a/packages/components/src/core/Autocomplete/__storybook__/stories/controlledOpen.tsx
+++ b/packages/components/src/core/Autocomplete/__storybook__/stories/controlledOpen.tsx
@@ -1,0 +1,242 @@
+import { Args } from "@storybook/react";
+import { DefaultAutocompleteOption } from "src/core/Autocomplete/components/AutocompleteBase";
+import { AUTOCOMPLETE_SINGLE_COLUMN_OPTIONS } from "src/common/storybook/AUTOCOMPLETE_SINGLE_COLUMN_OPTIONS";
+import { SyntheticEvent, useEffect, useState } from "react";
+import RawAutocomplete, {
+  AutocompleteMultiColumnValue,
+  SDSAutocompleteValue,
+} from "src/core/Autocomplete";
+import TagFilter from "src/core/TagFilter";
+import { AutocompleteValue } from "@mui/base";
+import {
+  AUTOCOMPLETE_DIV_MARGIN,
+  AUTOCOMPLETE_WRAPPER_STYLES,
+} from "../constants";
+
+export const ControlledOpenDemo = <
+  T extends DefaultAutocompleteOption,
+  Multiple extends boolean | undefined,
+>(
+  props: Args
+): JSX.Element => {
+  const {
+    label,
+    multiple,
+    options = AUTOCOMPLETE_SINGLE_COLUMN_OPTIONS,
+    search,
+    value: propValue,
+    keepSearchOnSelect,
+  } = props;
+
+  type DisableClearable = false;
+  type FreeSolo = false;
+
+  const isControlled = propValue !== undefined;
+  const [value, setValue] = useState<
+    SDSAutocompleteValue<T, Multiple, DisableClearable, FreeSolo>
+  >(
+    (multiple ? [] : null) as SDSAutocompleteValue<
+      T,
+      Multiple,
+      DisableClearable,
+      FreeSolo
+    >
+  );
+
+  const [selection, setSelection] = useState<string[]>([]);
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (isControlled) {
+      setValue(propValue);
+    }
+  }, [isControlled, propValue]);
+
+  useEffect(() => {
+    setSelection([]);
+    setValue(
+      (multiple ? [] : null) as SDSAutocompleteValue<
+        T,
+        Multiple,
+        DisableClearable,
+        FreeSolo
+      >
+    );
+  }, [multiple, options]);
+
+  return (
+    <>
+      <div style={AUTOCOMPLETE_WRAPPER_STYLES}>
+        <RawAutocomplete
+          onClickAway={() => {
+            setOpen(false);
+          }}
+          onClick={() => {
+            if (open) {
+              setOpen(false);
+            } else {
+              setOpen(true);
+            }
+          }}
+          open={open}
+          id="autocomplete-demo"
+          disableCloseOnSelect={multiple}
+          label={label}
+          multiple={multiple}
+          onChange={handleChange}
+          keepSearchOnSelect={keepSearchOnSelect}
+          options={options}
+          search={search}
+          value={value}
+          getOptionDisabled={(option: T) => {
+            return option.name === "Type: feature request";
+          }}
+          {...props}
+        />
+      </div>
+
+      <div style={{ margin: AUTOCOMPLETE_DIV_MARGIN }}>
+        {selection.length
+          ? selection.map((item) => {
+              return (
+                <TagFilter
+                  key={item}
+                  label={item}
+                  onDelete={() => handleTagDelete(item)}
+                  onClick={() => handleTagDelete(item)}
+                />
+              );
+            })
+          : null}
+      </div>
+    </>
+  );
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  function handleChange(
+    _: SyntheticEvent<Element, Event>,
+    newValue: SDSAutocompleteValue<T, Multiple, DisableClearable, FreeSolo>
+  ) {
+    setValue(newValue);
+    const newSelection: string[] = [];
+
+    if (
+      (newValue as T)?.name ||
+      (Array.isArray(newValue) && (newValue as T[])[0].name)
+    ) {
+      if (multiple) {
+        setSelection(
+          Array.isArray(newValue) ? newValue?.map((item) => item.name) : []
+        );
+      } else {
+        if (newValue && !Array.isArray(newValue) && newValue.name) {
+          setSelection([(newValue as T).name]);
+        }
+      }
+    } else {
+      if (multiple) {
+        if (newValue) {
+          Object.values(newValue).forEach((items) => {
+            (items as T[])?.map(({ name }: { name: string }) => {
+              newSelection.push(name);
+            });
+          });
+          setSelection(newSelection);
+        }
+      } else {
+        if (newValue) {
+          Object.values(newValue).forEach((item) => {
+            newSelection.push((item as T).name);
+          });
+        }
+        setSelection(newSelection);
+      }
+    }
+  }
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  function handleTagDeleteMultiColumn(tag: string) {
+    if (multiple) {
+      if (value) {
+        Object.entries(value).forEach(([key, values]) => {
+          const index = (values as T[])?.findIndex(
+            (item: T) => item.name === tag
+          );
+          if (index > -1) {
+            const newValue = [...(values as T[])];
+            newValue.splice(index, 1);
+            setValue((prev) => {
+              return {
+                ...prev,
+                [key]: newValue as AutocompleteValue<
+                  T,
+                  Multiple,
+                  DisableClearable,
+                  FreeSolo
+                >,
+              };
+            });
+
+            const newSelection = [...selection];
+            const deleteIndex = newSelection.indexOf(tag);
+            newSelection.splice(deleteIndex, 1);
+            setSelection(newSelection);
+          }
+        });
+      }
+    } else {
+      if (value) {
+        Object.entries(value).forEach(([key, val]) => {
+          if ((val as T).name === tag) {
+            const finalValue = { ...value } as AutocompleteMultiColumnValue<
+              T,
+              Multiple,
+              DisableClearable,
+              FreeSolo
+            >;
+            if (finalValue) delete finalValue[key];
+            setValue(finalValue);
+
+            const newSelection = [...selection];
+            const deleteIndex = newSelection.indexOf(tag);
+            newSelection.splice(deleteIndex, 1);
+            setSelection(newSelection);
+          }
+        });
+      }
+    }
+  }
+
+  function handleTagDelete(tag: string) {
+    if (
+      (value && (value as T).name) ||
+      (Array.isArray(value) && (value as T[])[0].name)
+    ) {
+      if (multiple && Array.isArray(value)) {
+        const index = value?.findIndex((item) => item.name === tag);
+        const newValue = [...value];
+        newValue.splice(index, 1);
+        setValue(
+          newValue as SDSAutocompleteValue<
+            T,
+            Multiple,
+            DisableClearable,
+            FreeSolo
+          >
+        );
+
+        const newSelection = [...selection];
+        const deleteIndex = newSelection.indexOf(tag);
+        newSelection.splice(deleteIndex, 1);
+        setSelection(newSelection);
+      } else {
+        setValue(
+          null as SDSAutocompleteValue<T, Multiple, DisableClearable, FreeSolo>
+        );
+        setSelection([]);
+      }
+    } else {
+      handleTagDeleteMultiColumn(tag);
+    }
+  }
+};

--- a/packages/components/src/core/Autocomplete/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,959 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
+<div
+  style="margin: 16px 0px 0px 24px; width: 274px;"
+>
+  <div>
+    <label
+      class="css-l5xdrx"
+      for="location-search"
+    >
+      Search by label
+    </label>
+    <div
+      class="MuiFormControl-root MuiTextField-root css-1crfn7w-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-2ehmn7-MuiInputBase-root-MuiOutlinedInput-root"
+        inputmode="text"
+      >
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-3b46cg-MuiInputAdornment-root"
+        >
+          <span
+            class="notranslate"
+          >
+            ​
+          </span>
+          <button
+            aria-label="search-button"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1owsdxw-MuiButtonBase-root-MuiIconButton-root"
+            icon="Search"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-1ft6wgl"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+                data-file-name="IconSearchSmall"
+                data-testid="IconSearchSmall"
+                fillcontrast="white"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              />
+            </div>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <input
+          aria-invalid="false"
+          autocomplete="one-time-code"
+          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputTypeSearch MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-16slxrv-MuiInputBase-input-MuiOutlinedInput-input"
+          id="location-search"
+          placeholder="Search by label"
+          type="search"
+          value=""
+        />
+        <div
+          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1is7ehy-MuiInputAdornment-root"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+          />
+        </div>
+        <fieldset
+          aria-hidden="true"
+          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            class="css-ihdtdm"
+          >
+            <span
+              class="notranslate"
+            >
+              ​
+            </span>
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+    <div
+      class="base-Popper-root css-1hqzuq8-MuiPopper-root"
+      data-popper-escaped=""
+      data-popper-placement="bottom-start"
+      data-popper-reference-hidden=""
+      role="tooltip"
+      style="position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
+    >
+      <div
+        class="SdsAutocompleteMultiColumn-wrapper css-ov1ktg"
+      >
+        <div
+          class="SdsAutocompleteMultiColumn-column-root css-1451ohq"
+          width="260"
+        >
+          <span
+            class="SdsAutocompleteMultiColumn-column-relation-icon css-19gs2ff"
+          >
+            <div
+              class="css-1ft6wgl"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-25m3b5-MuiSvgIcon-root"
+                data-file-name="IconChevronRightSmall"
+                data-testid="IconChevronRightSmall"
+                fillcontrast="white"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              />
+            </div>
+          </span>
+          <p
+            class="SdsAutocompleteMultiColumn-column-title css-ederv3"
+          >
+            Column One
+          </p>
+          <div
+            aria-owns="autocomplete-demo-listbox"
+            class="MuiAutocomplete-root Mui-expanded MuiAutocomplete-hasPopupIcon css-1r9rja7-MuiAutocomplete-root"
+            label="Search by label"
+          >
+            <div
+              class="css-12r08e9"
+            >
+              <label
+                class="css-l5xdrx"
+                for="location-search"
+              >
+                Search by label
+              </label>
+              <div
+                class="MuiFormControl-root MuiTextField-root css-5o0g6q-MuiFormControl-root-MuiTextField-root"
+              >
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-2ehmn7-MuiInputBase-root-MuiOutlinedInput-root"
+                  inputmode="none"
+                >
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-3b46cg-MuiInputAdornment-root"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                    <button
+                      aria-label="search-button"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1owsdxw-MuiButtonBase-root-MuiIconButton-root"
+                      icon="Search"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="css-1ft6wgl"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+                          data-file-name="IconSearchSmall"
+                          data-testid="IconSearchSmall"
+                          fillcontrast="white"
+                          focusable="false"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        />
+                      </div>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <input
+                    aria-autocomplete="list"
+                    aria-controls="autocomplete-demo-listbox"
+                    aria-expanded="true"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputTypeSearch MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-16slxrv-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="autocomplete-demo"
+                    placeholder="Search by label"
+                    role="combobox"
+                    spellcheck="false"
+                    type="search"
+                    value=""
+                  />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1is7ehy-MuiInputAdornment-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+                    />
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-ihdtdm"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="base-Popper-root MuiAutocomplete-popper MuiAutocomplete-popperDisablePortal css-1rndd9j-MuiPopper-root-MuiAutocomplete-popper"
+            data-popper-escaped=""
+            data-popper-placement="bottom"
+            data-popper-reference-hidden=""
+            role="presentation"
+            style="width: 0px; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAutocomplete-paper css-100c8gn-MuiPaper-root-MuiAutocomplete-paper"
+            >
+              <ul
+                aria-labelledby="autocomplete-demo-label"
+                class="MuiAutocomplete-listbox css-gdh49b-MuiAutocomplete-listbox"
+                id="autocomplete-demo-listbox"
+                role="listbox"
+              >
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="0"
+                  id="autocomplete-demo-option-0"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: can't reproduce
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="1"
+                  id="autocomplete-demo-option-1"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: confirmed
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="2"
+                  id="autocomplete-demo-option-2"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: duplicate
+                      </div>
+                    </span>
+                    <span
+                      class="css-1o15svb"
+                    >
+                      3
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="3"
+                  id="autocomplete-demo-option-3"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: needs information
+                      </div>
+                    </span>
+                    <span
+                      class="css-1o15svb"
+                    >
+                      5
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="4"
+                  id="autocomplete-demo-option-4"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: wont do/fix
+                        <div
+                          class="menuItem-details css-3gjguy"
+                        >
+                          This will not be worked on
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="5"
+                  id="autocomplete-demo-option-5"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Status: work in progress
+                        <div
+                          class="menuItem-details css-3gjguy"
+                        >
+                          This is still in progress
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="SdsAutocompleteMultiColumn-column-root css-1451ohq"
+          width="260"
+        >
+          <span
+            class="SdsAutocompleteMultiColumn-column-relation-icon css-19gs2ff"
+          >
+            <div
+              class="css-1ft6wgl"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-25m3b5-MuiSvgIcon-root"
+                data-file-name="IconChevronRightSmall"
+                data-testid="IconChevronRightSmall"
+                fillcontrast="white"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              />
+            </div>
+          </span>
+          <p
+            class="SdsAutocompleteMultiColumn-column-title css-ederv3"
+          >
+            Column Two
+          </p>
+          <div
+            aria-owns="autocomplete-demo-listbox"
+            class="MuiAutocomplete-root Mui-expanded MuiAutocomplete-hasPopupIcon css-1r9rja7-MuiAutocomplete-root"
+            label="Search by label"
+          >
+            <div
+              class="css-12r08e9"
+            >
+              <label
+                class="css-l5xdrx"
+                for="location-search"
+              >
+                Search by label
+              </label>
+              <div
+                class="MuiFormControl-root MuiTextField-root css-5o0g6q-MuiFormControl-root-MuiTextField-root"
+              >
+                <div
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-2ehmn7-MuiInputBase-root-MuiOutlinedInput-root"
+                  inputmode="none"
+                >
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-3b46cg-MuiInputAdornment-root"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                    <button
+                      aria-label="search-button"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1owsdxw-MuiButtonBase-root-MuiIconButton-root"
+                      icon="Search"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="css-1ft6wgl"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-tr2xv3-MuiSvgIcon-root"
+                          data-file-name="IconSearchSmall"
+                          data-testid="IconSearchSmall"
+                          fillcontrast="white"
+                          focusable="false"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        />
+                      </div>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <input
+                    aria-autocomplete="list"
+                    aria-controls="autocomplete-demo-listbox"
+                    aria-expanded="true"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputTypeSearch MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd MuiAutocomplete-input MuiAutocomplete-inputFocused css-16slxrv-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="autocomplete-demo"
+                    placeholder="Search by label"
+                    role="combobox"
+                    spellcheck="false"
+                    type="search"
+                    value=""
+                  />
+                  <div
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1is7ehy-MuiInputAdornment-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-1pnmrwp-MuiTypography-root"
+                    />
+                  </div>
+                  <fieldset
+                    aria-hidden="true"
+                    class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                  >
+                    <legend
+                      class="css-ihdtdm"
+                    >
+                      <span
+                        class="notranslate"
+                      >
+                        ​
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="base-Popper-root MuiAutocomplete-popper MuiAutocomplete-popperDisablePortal css-1rndd9j-MuiPopper-root-MuiAutocomplete-popper"
+            data-popper-escaped=""
+            data-popper-placement="bottom"
+            data-popper-reference-hidden=""
+            role="presentation"
+            style="width: 0px; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 0px);"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAutocomplete-paper css-100c8gn-MuiPaper-root-MuiAutocomplete-paper"
+            >
+              <ul
+                aria-labelledby="autocomplete-demo-label"
+                class="MuiAutocomplete-listbox css-gdh49b-MuiAutocomplete-listbox"
+                id="autocomplete-demo-listbox"
+                role="listbox"
+              >
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="0"
+                  id="autocomplete-demo-option-0"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: bug
+                        <div
+                          class="menuItem-details css-3gjguy"
+                        >
+                          This will be worked on
+                        </div>
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="1"
+                  id="autocomplete-demo-option-1"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: discussion
+                      </div>
+                    </span>
+                    <span
+                      class="css-1o15svb"
+                    >
+                      4
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="2"
+                  id="autocomplete-demo-option-2"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: documentation
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="3"
+                  id="autocomplete-demo-option-3"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: enhancement
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="4"
+                  id="autocomplete-demo-option-4"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: epic
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+                <li
+                  aria-disabled="true"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root Mui-disabled MuiMenuItem-gutters Mui-disabled MuiMenuItem-root Mui-disabled MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="5"
+                  id="autocomplete-demo-option-5"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      disabled=""
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1wkj2yd"
+                      disabled=""
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: feature request
+                      </div>
+                    </span>
+                  </span>
+                </li>
+                <li
+                  aria-disabled="false"
+                  aria-selected="false"
+                  class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters MuiAutocomplete-option css-pelx1i-MuiButtonBase-root-MuiMenuItem-root"
+                  data-option-index="6"
+                  id="autocomplete-demo-option-6"
+                  role="option"
+                  tabindex="-1"
+                >
+                  <span
+                    class="css-1715doo"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium check-icon css-4wl0oy-MuiSvgIcon-root"
+                      data-testid="CheckIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="css-bv5fko"
+                  >
+                    <span
+                      class="primary-text css-1k1xg99"
+                    >
+                      <div
+                        class="css-1iyoj2o"
+                      >
+                        Type: question
+                      </div>
+                    </span>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Autocomplete /> Default story renders snapshot 1`] = `
 <div
   style="margin: 16px 0px 0px 24px; width: 274px;"

--- a/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
@@ -243,21 +243,6 @@ const AutocompleteMultiColumn = <
              * mobile keyboard
              */
             inputMode: "text",
-            /**
-             * (masoudmanson): This is to handle the Escape key to close the dropdown.
-             * If the dropdown is controlled, we call the onClick prop to allow the parent
-             * to handle the closing of the dropdown.
-             */
-            onKeyDown: (event: React.KeyboardEvent) => {
-              if (event.key === "Escape") {
-                if (isOpenControlled) {
-                  onClick?.();
-                  return;
-                }
-
-                setPopperOpen(false);
-              }
-            },
             startAdornment: (
               <StyledInputAdornment position="start">
                 <Button
@@ -399,9 +384,31 @@ const AutocompleteMultiColumn = <
   }
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-    // (masoudmanson): This prevents Backspace from deselecting selected dropdown options.
-    if (event.key === "Backspace") {
-      event.stopPropagation();
+    /**
+     * (masoudmanson): Because the Autocomplete component overrides the
+     * InputSearch's onKeyDown, we must also include the user defined onKeyDown here.
+     */
+    if (props?.onKeyDown) {
+      props?.onKeyDown?.(event);
+    } else {
+      // (masoudmanson): This prevents Backspace from deselecting selected dropdown options.
+      if (event.key === "Backspace") {
+        event.stopPropagation();
+      }
+
+      /**
+       * (masoudmanson): This is to handle the Escape key to close the dropdown.
+       * If the dropdown is controlled, we call the onClick prop to allow the parent
+       * to handle the closing of the dropdown.
+       */
+      if (event.key === "Escape") {
+        if (isOpenControlled) {
+          onClick?.();
+          return;
+        }
+
+        setPopperOpen(false);
+      }
     }
   }
 };

--- a/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
@@ -1,6 +1,7 @@
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
+  AutocompleteCloseReason,
   AutocompleteInputChangeReason,
   AutocompleteRenderInputParams,
   AutocompleteValue,
@@ -50,7 +51,11 @@ interface ExtraAutocompleteMultiColumnProps<
   PopperComponent?: React.JSXElementConstructor<PopperProps>;
   PopperPlacement?: "bottom-start" | "top-start" | "bottom-end" | "top-end";
   children?: JSX.Element | null;
-  onClickAway?: (event: MouseEvent | TouchEvent) => void;
+  onClickAway?: (
+    event?: MouseEvent | TouchEvent,
+    reason?: AutocompleteCloseReason
+  ) => void;
+  onClick?: (event?: TouchEvent | MouseEvent) => void;
   ClickAwayListenerProps?: Partial<MUIClickAwayListenerProps>;
   options: AutocompleteMultiColumnOption<
     T,
@@ -108,12 +113,13 @@ const AutocompleteMultiColumn = <
 ): JSX.Element => {
   const {
     InputBaseProps,
-    open = false,
+    open,
     PopperPlacement = "bottom-start",
     PopperBaseProps,
     search = false,
     label = "Search",
-    onClickAway = defaultOnClickAway,
+    onClickAway,
+    onClick,
     ClickAwayListenerProps,
     options,
     onInputChange,
@@ -124,9 +130,24 @@ const AutocompleteMultiColumn = <
     PopperComponent = StyledPopper,
     ...rest
   } = props;
+
   const theme: SDSTheme = useTheme();
+
+  const isOpenControlled = open !== undefined;
   const [inputValue, setInputValue] = useState("");
-  const [popperOpen, setPopperOpen] = useState<boolean>(open);
+  const [popperOpen, setPopperOpen] = useState<boolean>(
+    isOpenControlled ? open : false
+  );
+
+  /**
+   * (masoudmanson): This useEffect is used to update the popperOpen state
+   * when the open prop is controlled.
+   */
+  useEffect(() => {
+    if (isOpenControlled) {
+      setPopperOpen(open);
+    }
+  }, [isOpenControlled, open]);
 
   const anchorRef = useRef(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -172,7 +193,10 @@ const AutocompleteMultiColumn = <
   };
 
   return (
-    <ClickAwayListener onClickAway={onClickAway} {...ClickAwayListenerProps}>
+    <ClickAwayListener
+      onClickAway={defaultOnClickAway}
+      {...ClickAwayListenerProps}
+    >
       <div>
         <StyledAutocompleteInput
           id="location-search"
@@ -219,6 +243,21 @@ const AutocompleteMultiColumn = <
              * mobile keyboard
              */
             inputMode: "text",
+            /**
+             * (masoudmanson): This is to handle the Escape key to close the dropdown.
+             * If the dropdown is controlled, we call the onClick prop to allow the parent
+             * to handle the closing of the dropdown.
+             */
+            onKeyDown: (event: React.KeyboardEvent) => {
+              if (event.key === "Escape") {
+                if (isOpenControlled) {
+                  onClick?.();
+                  return;
+                }
+
+                setPopperOpen(false);
+              }
+            },
             startAdornment: (
               <StyledInputAdornment position="start">
                 <Button
@@ -293,7 +332,24 @@ const AutocompleteMultiColumn = <
     );
   }
 
-  function handleInputClick(_: React.SyntheticEvent) {
+  function handleInputClick(event: React.MouseEvent<HTMLInputElement>) {
+    /**
+     * (masoudmanson): Because the Autocomplete component overrides the
+     * InputSearch's onClick, we must also include the parent onClick here.
+     */
+    onClick?.(event);
+
+    /**
+     * (masoudmanson): If the dropdown is controlled, we call the onClick prop to allow the parent
+     * to handle the opening and closing of the dropdown.
+     */
+    if (isOpenControlled) {
+      return;
+    }
+
+    /**
+     * (masoudmanson): If the dropdown is not controlled, we toggle the dropdown open and closed.
+     */
     if (popperOpen) {
       setPopperOpen(false);
     } else {
@@ -317,8 +373,29 @@ const AutocompleteMultiColumn = <
     onBlur?.(event);
   }
 
-  function defaultOnClickAway() {
-    setPopperOpen(false);
+  /**
+   * (masoudmanson): This is the default onClickAway handler for the Autocomplete component.
+   * It is used to close the dropdown when the user clicks away from the dropdown. It also
+   * calls the parent onClickAway prop if it is provided.
+   */
+  function defaultOnClickAway(event: MouseEvent | TouchEvent) {
+    /**
+     * (masoudmanson): We only want to close the dropdown if it is open.
+     * This may sound unnecessary, but it is to prevent the dropdown from
+     * calling the parent onClickAway prop when the dropdown is closed.
+     */
+    if (popperOpen) {
+      onClickAway?.(event, "blur");
+
+      /**
+       * (masoudmanson): If the dropdown is controlled, we call the onClickAway prop to allow the parent
+       * to handle the closing of the dropdown.
+       */
+      if (isOpenControlled) return;
+
+      // (masoudmanson): If the dropdown is not controlled, we close the dropdown.
+      setPopperOpen(false);
+    }
   }
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -1,6 +1,7 @@
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,
+  AutocompleteCloseReason,
   AutocompleteValue,
 } from "@mui/base";
 import { PopperProps } from "@mui/material";
@@ -121,7 +122,11 @@ interface ExtraAutocompleteProps<
   options: SDSAutocompleteOptions<T, Multiple, DisableClearable, FreeSolo>;
   PopperBaseProps?: Partial<PopperProps>;
   value?: SDSAutocompleteValue<T, Multiple, DisableClearable, FreeSolo>;
-  onClickAway?: (event: MouseEvent | TouchEvent) => void;
+  onClickAway?: (
+    event?: MouseEvent | TouchEvent,
+    reason?: AutocompleteCloseReason
+  ) => void;
+  onClick?: (event?: TouchEvent | MouseEvent) => void;
   onChange?: SDSAutocompleteOnChange<T, Multiple, DisableClearable, FreeSolo>;
   count?: number;
   icon?: ReactElement;
@@ -198,7 +203,6 @@ const Autocomplete = <
           {...rest}
           // (masoudmanson): groupBy option is disabled on MultiColumn dropdowns
           groupBy={undefined}
-          open
         />
       );
     } else {

--- a/packages/components/src/core/Dropdown/index.tsx
+++ b/packages/components/src/core/Dropdown/index.tsx
@@ -101,6 +101,7 @@ const Dropdown = <
     isTriggerChangeOnOptionClick = false,
     disabled = false,
     value: propValue,
+    onClick,
     ...rest
   } = props;
 
@@ -251,6 +252,8 @@ const Dropdown = <
   }
 
   function handleClick(event: React.MouseEvent<HTMLElement>) {
+    onClick?.(event as React.MouseEvent<HTMLDivElement, MouseEvent>);
+
     if (open) {
       if (!shouldShowButtons) {
         if (multiple) {

--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -169,6 +169,7 @@ const DropdownMenu = <
                 PopperBaseProps={DEFAULT_POPPER_BASE_PROPS}
                 disablePortal
                 onClickAway={noop}
+                onClick={noop}
                 {...rest}
                 InputBaseProps={DefaultInputBaseProps}
               />


### PR DESCRIPTION
## Summary

**Autocomplete**
Github issue: #766 

This PR addresses issue #766 by fixing the controlled open state behavior of the Autocomplete component for both single and multi-column Autocompletes.

### Changes Made
- Implemented a fix for the controlled open state behavior.
- Added handlers for both opening and closing the Autocomplete component.
- Demonstrated the usage of controlled open state with a simple example in the storybook (`Autocomplete/Controlled Open` Story)

### Usage Example

A controlled open state for an Autocomplete that is opened by default can be demonstrated as follows:

```javascript
const [open, setOpen] = React.useState(true);

<Autocomplete
  // Handles Autocomplete close
  onClickAway={() => {
    setOpen(false);
  }}
  
  // Handles Autocomplete Open
  onClick={() => {
    if (open) {
      setOpen(false);
    } else {
      setOpen(true);
    }
  }}
  
  // The controlled open state
  open={open}
  
  // ... Rest of the Autocomplete Props
/>
```