### PR TITLE
fix: implement add use client to all sds components

### DIFF
--- a/packages/components/src/common/helpers/scrollStop.ts
+++ b/packages/components/src/common/helpers/scrollStop.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 
 /**

--- a/packages/components/src/common/helpers/userTabbing.ts
+++ b/packages/components/src/common/helpers/userTabbing.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 
 /**

--- a/packages/components/src/common/storybook/AUTOCOMPLETE_MULTI_COLUMN_OPTIONS.tsx
+++ b/packages/components/src/common/storybook/AUTOCOMPLETE_MULTI_COLUMN_OPTIONS.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // (masoudmanson): The unit tests rely on the content in this file; do not alter it!
 
 import Icon from "../../core/Icon";

--- a/packages/components/src/common/storybook/AUTOCOMPLETE_SINGLE_COLUMN_OPTIONS.tsx
+++ b/packages/components/src/common/storybook/AUTOCOMPLETE_SINGLE_COLUMN_OPTIONS.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // (masoudmanson): The unit tests rely on the content in this file; do not alter it!
 
 import Tag from "../../core/Tag";

--- a/packages/components/src/common/storybook/customSdsIcon.tsx
+++ b/packages/components/src/common/storybook/customSdsIcon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Icon, { IconProps } from "../../core/Icon";
 
 /**

--- a/packages/components/src/common/storybook/customSvgIcon.tsx
+++ b/packages/components/src/common/storybook/customSvgIcon.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SvgIcon, SvgIconProps } from "@mui/material";
 
 /**

--- a/packages/components/src/common/storybook/loremIpsum.ts
+++ b/packages/components/src/common/storybook/loremIpsum.ts
@@ -1,3 +1,5 @@
+"use client";
+
 // Extra Short Lorem Ipsum = 1 sentence
 
 export const EXTRA_SHORT_LOREM_IPSUM = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;

--- a/packages/components/src/common/storybook/storybookBadges.ts
+++ b/packages/components/src/common/storybook/storybookBadges.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { BADGE as addonBadge } from "@geometricpanda/storybook-addon-badges";
 
 export const BADGE = {

--- a/packages/components/src/common/storybook/storybookConstants.ts
+++ b/packages/components/src/common/storybook/storybookConstants.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export interface Template {
   args: Record<string, never>;
 }

--- a/packages/components/src/common/utils.ts
+++ b/packages/components/src/common/utils.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export const noop = (): void => {};
 
 export const toKebabCase = (str: string) =>

--- a/packages/components/src/common/warnings.test.ts
+++ b/packages/components/src/common/warnings.test.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   SDSWarningTypes,
   showWarningIfFirstOccurence,

--- a/packages/components/src/common/warnings.ts
+++ b/packages/components/src/common/warnings.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export enum SDSWarningTypes {
   ButtonMinimalIsAllCaps = "buttonMinimalIsAllCaps",
   ButtonMissingSDSProps = "buttonMissingProps",

--- a/packages/components/src/core/Accordion/components/AccordionDetails/index.tsx
+++ b/packages/components/src/core/Accordion/components/AccordionDetails/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AccordionDetailsProps } from "@mui/material";
 import { StyledAccordionDetails } from "./style";
 

--- a/packages/components/src/core/Accordion/components/AccordionDetails/style.ts
+++ b/packages/components/src/core/Accordion/components/AccordionDetails/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/react";
 import { AccordionDetails } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/Accordion/components/AccordionHeader/index.tsx
+++ b/packages/components/src/core/Accordion/components/AccordionHeader/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AccordionSummaryProps as RawAccordionSummaryProps } from "@mui/material";
 import { StyledAccordionHeader, StyledSubtitle } from "./style";
 import Icon from "src/core/Icon";

--- a/packages/components/src/core/Accordion/components/AccordionHeader/style.ts
+++ b/packages/components/src/core/Accordion/components/AccordionHeader/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/react";
 import { AccordionSummary, accordionSummaryClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/Accordion/index.tsx
+++ b/packages/components/src/core/Accordion/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AccordionProps as RawAccordionProps } from "@mui/material";
 import React from "react";
 import AccordionDetails from "./components/AccordionDetails";

--- a/packages/components/src/core/Accordion/style.ts
+++ b/packages/components/src/core/Accordion/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import {
   Accordion,

--- a/packages/components/src/core/Alert/index.tsx
+++ b/packages/components/src/core/Alert/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertProps } from "@mui/lab";
 import { StyledAlert } from "./style";
 

--- a/packages/components/src/core/Alert/style.ts
+++ b/packages/components/src/core/Alert/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Alert, AlertProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { Colors, getColors, getShadows, getSpaces } from "../styles";

--- a/packages/components/src/core/Autocomplete/components/AutocompleteBase/index.tsx
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteBase/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,

--- a/packages/components/src/core/Autocomplete/components/AutocompleteBase/style.ts
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteBase/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Autocomplete, autocompleteClasses, Paper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";

--- a/packages/components/src/core/Autocomplete/components/AutocompleteGroup/index.tsx
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteGroup/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,

--- a/packages/components/src/core/Autocomplete/components/AutocompleteGroup/style.ts
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteGroup/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";
 import {

--- a/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,

--- a/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/style.ts
+++ b/packages/components/src/core/Autocomplete/components/AutocompleteMultiColumn/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { autocompleteClasses, Paper, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";

--- a/packages/components/src/core/Autocomplete/index.tsx
+++ b/packages/components/src/core/Autocomplete/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteChangeDetails,
   AutocompleteChangeReason,

--- a/packages/components/src/core/Banner/index.tsx
+++ b/packages/components/src/core/Banner/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { ForwardedRef, forwardRef, useState } from "react";
 import Icon, { IconNameToSizes, IconProps } from "src/core/Icon";
 import {

--- a/packages/components/src/core/Banner/style.ts
+++ b/packages/components/src/core/Banner/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import Button, { ButtonProps } from "src/core/Button";
 import {

--- a/packages/components/src/core/Button/index.tsx
+++ b/packages/components/src/core/Button/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ButtonProps as RawButtonProps } from "@mui/material";
 import React, { ForwardedRef } from "react";
 import {

--- a/packages/components/src/core/Button/style.ts
+++ b/packages/components/src/core/Button/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button, buttonClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { css, SerializedStyles } from "@emotion/react";

--- a/packages/components/src/core/ButtonDropdown/index.tsx
+++ b/packages/components/src/core/ButtonDropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ButtonProps as RawButtonProps } from "@mui/material";
 import React, { ForwardedRef } from "react";
 import Button from "src/core/Button";

--- a/packages/components/src/core/ButtonIcon/index.tsx
+++ b/packages/components/src/core/ButtonIcon/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { IconButtonProps as RawButtonIconProps } from "@mui/material";
 import { ForwardedRef, forwardRef } from "react";
 import Icon, { IconNameToSizes, IconProps } from "src/core/Icon";

--- a/packages/components/src/core/ButtonIcon/style.ts
+++ b/packages/components/src/core/ButtonIcon/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { IconButton } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/Callout/components/CalloutTitle/index.tsx
+++ b/packages/components/src/core/Callout/components/CalloutTitle/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertTitleProps } from "@mui/material/AlertTitle";
 import { CALLOUT_TITLE_DISPLAY_NAME } from "src/core/Callout/constants";
 import { StyledCalloutTitle } from "./style";

--- a/packages/components/src/core/Callout/components/CalloutTitle/style.ts
+++ b/packages/components/src/core/Callout/components/CalloutTitle/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertTitle } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { fontBodyXs, getSpaces } from "src/core/styles";

--- a/packages/components/src/core/Callout/constants.ts
+++ b/packages/components/src/core/Callout/constants.ts
@@ -1,1 +1,3 @@
+"use client";
+
 export const CALLOUT_TITLE_DISPLAY_NAME = "CalloutTitle";

--- a/packages/components/src/core/Callout/index.tsx
+++ b/packages/components/src/core/Callout/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertProps } from "@mui/lab";
 import { Grow } from "@mui/material";
 import React, { useEffect, useState } from "react";

--- a/packages/components/src/core/Callout/style.ts
+++ b/packages/components/src/core/Callout/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Alert,
   AlertProps,

--- a/packages/components/src/core/CellBasic/index.tsx
+++ b/packages/components/src/core/CellBasic/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef } from "react";
 import Tooltip, { TooltipProps } from "src/core/Tooltip";
 import {

--- a/packages/components/src/core/CellBasic/style.ts
+++ b/packages/components/src/core/CellBasic/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import {
   CommonThemeProps,

--- a/packages/components/src/core/CellComponent/index.tsx
+++ b/packages/components/src/core/CellComponent/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef, ReactNode } from "react";
 import { CellComponentExtraProps, StyledCellComponentData } from "./style";
 

--- a/packages/components/src/core/CellComponent/style.ts
+++ b/packages/components/src/core/CellComponent/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import {
   CommonThemeProps,

--- a/packages/components/src/core/CellHeader/index.tsx
+++ b/packages/components/src/core/CellHeader/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef } from "react";
 import { IconNameToSizes } from "src/core/Icon";
 import Tooltip, { TooltipProps } from "src/core/Tooltip";

--- a/packages/components/src/core/CellHeader/style.ts
+++ b/packages/components/src/core/CellHeader/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import {
   CommonThemeProps,

--- a/packages/components/src/core/Chip/index.tsx
+++ b/packages/components/src/core/Chip/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Clear } from "@mui/icons-material";
 import { ChipProps as RawChipProps } from "@mui/material";
 import {

--- a/packages/components/src/core/Chip/style.ts
+++ b/packages/components/src/core/Chip/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { Chip } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/ComplexFilter/components/Chips/index.tsx
+++ b/packages/components/src/core/ComplexFilter/components/Chips/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AutocompleteValue } from "@mui/base";
 import { DefaultAutocompleteOption } from "src/core/Autocomplete/components/AutocompleteBase";
 import TagFilter from "src/core/TagFilter";

--- a/packages/components/src/core/ComplexFilter/index.tsx
+++ b/packages/components/src/core/ComplexFilter/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteCloseReason,
   AutocompleteValue,

--- a/packages/components/src/core/ComplexFilter/style.ts
+++ b/packages/components/src/core/ComplexFilter/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import { getSpaces } from "src/core/styles";
 

--- a/packages/components/src/core/Dialog/components/DialogActions/index.tsx
+++ b/packages/components/src/core/Dialog/components/DialogActions/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogActionsProps as RawDialogActionsProps } from "@mui/material";
 import { forwardRef } from "react";
 import { DialogActionsExtraProps, StyledDialogActions } from "./style";

--- a/packages/components/src/core/Dialog/components/DialogActions/style.ts
+++ b/packages/components/src/core/Dialog/components/DialogActions/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogActions, dialogActionsClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { CommonThemeProps, getSpaces } from "src/core/styles";

--- a/packages/components/src/core/Dialog/components/DialogContent/index.tsx
+++ b/packages/components/src/core/Dialog/components/DialogContent/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogContentProps as RawDialogContentProps } from "@mui/material";
 import { forwardRef } from "react";
 import { StyledDialogContent } from "./style";

--- a/packages/components/src/core/Dialog/components/DialogContent/style.ts
+++ b/packages/components/src/core/Dialog/components/DialogContent/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogContent } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { fontBodyS } from "src/core/styles";

--- a/packages/components/src/core/Dialog/components/DialogPaper/index.tsx
+++ b/packages/components/src/core/Dialog/components/DialogPaper/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { PaperProps } from "@mui/material";
 import { forwardRef } from "react";
 import { DialogContext } from "../common";

--- a/packages/components/src/core/Dialog/components/DialogPaper/style.ts
+++ b/packages/components/src/core/Dialog/components/DialogPaper/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Paper, PaperProps } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/Dialog/components/DialogTitle/components/CloseButton/index.tsx
+++ b/packages/components/src/core/Dialog/components/DialogTitle/components/CloseButton/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ForwardedRef, forwardRef } from "react";
 import { ButtonProps } from "src/core/Button";
 import { DialogContext } from "src/core/Dialog/components/common";

--- a/packages/components/src/core/Dialog/components/DialogTitle/components/CloseButton/style.ts
+++ b/packages/components/src/core/Dialog/components/DialogTitle/components/CloseButton/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import Button from "src/core/Button";
 import { getSpaces } from "src/core/styles";

--- a/packages/components/src/core/Dialog/components/DialogTitle/index.tsx
+++ b/packages/components/src/core/Dialog/components/DialogTitle/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogTitleProps as RawDialogTitleProps } from "@mui/material";
 import { forwardRef } from "react";
 import CloseButton from "./components/CloseButton";

--- a/packages/components/src/core/Dialog/components/DialogTitle/style.ts
+++ b/packages/components/src/core/Dialog/components/DialogTitle/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { DialogTitle, Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/Dialog/components/common.ts
+++ b/packages/components/src/core/Dialog/components/common.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext } from "react";
 
 type SdsSize = "xs" | "s" | "m" | "l";

--- a/packages/components/src/core/Dialog/index.tsx
+++ b/packages/components/src/core/Dialog/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Dialog as RawDialog,
   DialogProps as RawDialogProps,

--- a/packages/components/src/core/Dropdown/index.tsx
+++ b/packages/components/src/core/Dropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AutocompleteProps } from "@mui/material";
 import {
   AutocompleteChangeDetails,

--- a/packages/components/src/core/Dropdown/style.ts
+++ b/packages/components/src/core/Dropdown/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import Button from "src/core/Button";
 import { CommonThemeProps, getSpaces } from "src/core/styles";

--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteInputChangeReason,
   AutocompleteRenderInputParams,

--- a/packages/components/src/core/DropdownMenu/style.ts
+++ b/packages/components/src/core/DropdownMenu/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { autocompleteClasses, Paper, Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ReactElement } from "react";

--- a/packages/components/src/core/Icon/index.tsx
+++ b/packages/components/src/core/Icon/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ForwardedRef, forwardRef } from "react";
 import { IconNameToSizes, iconMap } from "./map";
 import {

--- a/packages/components/src/core/Icon/map.ts
+++ b/packages/components/src/core/Icon/map.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { FC } from "react";
 import { ReactComponent as IconBacteriaLarge } from "../../common/svgs/IconBacteriaLarge.svg";
 import { ReactComponent as IconBacteriaSmall } from "../../common/svgs/IconBacteriaSmall.svg";

--- a/packages/components/src/core/Icon/style.ts
+++ b/packages/components/src/core/Icon/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { SvgIcon, SvgIconProps } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/InputCheckbox/index.tsx
+++ b/packages/components/src/core/InputCheckbox/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { CheckboxProps as MUICheckboxProps, SvgIcon } from "@mui/material";
 import { ReactComponent as IconCheckboxChecked } from "../../common/svgs/IconCheckboxChecked.svg";
 import { ReactComponent as IconCheckboxIndeterminate } from "../../common/svgs/IconCheckboxIndeterminate.svg";

--- a/packages/components/src/core/InputCheckbox/styles.ts
+++ b/packages/components/src/core/InputCheckbox/styles.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FormControlLabel,
   Checkbox as RawCheckbox,

--- a/packages/components/src/core/InputDropdown/index.tsx
+++ b/packages/components/src/core/InputDropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Icon from "src/core/Icon";
 import {
   IconWrapper,

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { ButtonProps } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/InputRadio/index.tsx
+++ b/packages/components/src/core/InputRadio/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { RadioProps as MUIRadioProps, SvgIcon } from "@mui/material";
 import { ReactComponent as IconRadioChecked } from "../../common/svgs/IconRadioChecked.svg";
 import { ReactComponent as IconRadioUnChecked } from "../../common/svgs/IconRadioUnchecked.svg";

--- a/packages/components/src/core/InputRadio/style.ts
+++ b/packages/components/src/core/InputRadio/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FormControlLabel,
   Radio as RawRadio,

--- a/packages/components/src/core/InputSearch/index.tsx
+++ b/packages/components/src/core/InputSearch/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TextFieldProps as RawTextFieldSearchProps } from "@mui/material";
 import React, { forwardRef, useRef, useState } from "react";
 import Button from "src/core/Button";

--- a/packages/components/src/core/InputSearch/style.ts
+++ b/packages/components/src/core/InputSearch/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import {
   buttonBaseClasses,

--- a/packages/components/src/core/InputSlider/index.tsx
+++ b/packages/components/src/core/InputSlider/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef } from "react";
 import { InputSliderExtraProps, StyledSlider } from "./style";
 

--- a/packages/components/src/core/InputSlider/style.ts
+++ b/packages/components/src/core/InputSlider/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Slider, SliderProps, sliderClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/InputText/index.tsx
+++ b/packages/components/src/core/InputText/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TextFieldProps as RawTextFieldProps } from "@mui/material";
 import { forwardRef, useRef, useState } from "react";
 import { InputTextExtraProps, StyledInputBase, StyledLabel } from "./style";

--- a/packages/components/src/core/InputText/style.ts
+++ b/packages/components/src/core/InputText/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import {
   buttonBaseClasses,

--- a/packages/components/src/core/InputToggle/index.tsx
+++ b/packages/components/src/core/InputToggle/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import { InputToggleExtraProps, Toggle } from "./style";
 

--- a/packages/components/src/core/InputToggle/style.ts
+++ b/packages/components/src/core/InputToggle/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Switch, SwitchProps, switchClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/Link/index.tsx
+++ b/packages/components/src/core/Link/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { ForwardedRef, forwardRef } from "react";
 import { LinkProps as RawLinkProps, StyledLink } from "./style";
 

--- a/packages/components/src/core/Link/style.ts
+++ b/packages/components/src/core/Link/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/react";
 import { Link, LinkProps as RawLinkProps } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/List/components/ListItem/index.tsx
+++ b/packages/components/src/core/List/components/ListItem/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ListItemProps as RawListItemProps } from "@mui/material";
 import { ListItemExtraProps, ListItemLabel, StyledListItem } from "./style";
 

--- a/packages/components/src/core/List/components/ListItem/style.ts
+++ b/packages/components/src/core/List/components/ListItem/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { SerializedStyles } from "@emotion/react";
 import { ListItem } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/List/components/ListSubheader/index.tsx
+++ b/packages/components/src/core/List/components/ListSubheader/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ListSubheaderProps as RawListSubheaderProps } from "@mui/material";
 import { StyledListSubheader } from "./style";
 

--- a/packages/components/src/core/List/components/ListSubheader/style.ts
+++ b/packages/components/src/core/List/components/ListSubheader/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { ListSubheader } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { fontHeader, getSpaces } from "src/core/styles";

--- a/packages/components/src/core/List/index.tsx
+++ b/packages/components/src/core/List/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ListProps as RawListProps } from "@mui/material";
 import { ListExtraProps, StyledList } from "./style";
 

--- a/packages/components/src/core/List/style.ts
+++ b/packages/components/src/core/List/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { List } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { CommonThemeProps, getSpaces } from "src/core/styles";

--- a/packages/components/src/core/LoadingIndicator/index.tsx
+++ b/packages/components/src/core/LoadingIndicator/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Icon from "src/core/Icon";
 import {
   LoadingIndicatorProps as RawLoadingIndicatorProps,

--- a/packages/components/src/core/LoadingIndicator/style.ts
+++ b/packages/components/src/core/LoadingIndicator/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/Menu/index.tsx
+++ b/packages/components/src/core/Menu/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { PopoverOrigin, MenuProps as RawMenuProps } from "@mui/material";
 import { StyledMenu } from "./style";
 

--- a/packages/components/src/core/Menu/style.ts
+++ b/packages/components/src/core/Menu/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Menu, menuClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { getSpaces } from "src/core/styles";

--- a/packages/components/src/core/MenuItem/index.tsx
+++ b/packages/components/src/core/MenuItem/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { MenuItemProps as RawMenuItemProps } from "@mui/material";
 import React, { ForwardedRef, forwardRef } from "react";
 import Icon, { IconNameToSizes, IconProps } from "src/core/Icon";

--- a/packages/components/src/core/MenuItem/style.ts
+++ b/packages/components/src/core/MenuItem/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Check, Remove } from "@mui/icons-material";
 import { MenuItem, menuItemClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/MenuSelect/index.tsx
+++ b/packages/components/src/core/MenuSelect/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AutocompleteFreeSoloValueMapping,
   AutocompleteInputChangeReason,

--- a/packages/components/src/core/MenuSelect/style.ts
+++ b/packages/components/src/core/MenuSelect/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Autocomplete, inputBaseClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import InputSearch from "src/core/InputSearch";

--- a/packages/components/src/core/NavigationJumpTo/index.tsx
+++ b/packages/components/src/core/NavigationJumpTo/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef, useCallback, useEffect, useState } from "react";
 import useScrollStopListener from "src/common/helpers/scrollStop";
 import { toKebabCase } from "src/common/utils";

--- a/packages/components/src/core/NavigationJumpTo/style.ts
+++ b/packages/components/src/core/NavigationJumpTo/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Tab, Tabs, TabsProps, tabsClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/NavigationJumpTo/useIntersection.ts
+++ b/packages/components/src/core/NavigationJumpTo/useIntersection.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useEffect, useState } from "react";
 
 /**

--- a/packages/components/src/core/Notification/index.tsx
+++ b/packages/components/src/core/Notification/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertProps } from "@mui/lab";
 import { Box, Slide } from "@mui/material";
 import React, { useEffect, useState } from "react";

--- a/packages/components/src/core/Notification/style.ts
+++ b/packages/components/src/core/Notification/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Alert } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/Pagination/components/PageListDropdown/index.tsx
+++ b/packages/components/src/core/Pagination/components/PageListDropdown/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from "react";
 import MenuItem from "src/core/MenuItem";
 import { Page, StyledPaginationButton } from "../../style";

--- a/packages/components/src/core/Pagination/components/PageListDropdown/style.ts
+++ b/packages/components/src/core/Pagination/components/PageListDropdown/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import Menu from "src/core/Menu";
 

--- a/packages/components/src/core/Pagination/index.tsx
+++ b/packages/components/src/core/Pagination/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef } from "react";
 import PageListDropdown from "./components/PageListDropdown";
 import {

--- a/packages/components/src/core/Pagination/style.ts
+++ b/packages/components/src/core/Pagination/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import Button from "src/core/Button";
 import {

--- a/packages/components/src/core/Pagination/usePagination.ts
+++ b/packages/components/src/core/Pagination/usePagination.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo } from "react";
 
 export const DOTS = "...";

--- a/packages/components/src/core/SegmentedControl/index.tsx
+++ b/packages/components/src/core/SegmentedControl/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ToggleButton, ToggleButtonGroupProps } from "@mui/material";
 import React from "react";
 import Icon, { IconNameToSizes } from "src/core/Icon";

--- a/packages/components/src/core/SegmentedControl/style.ts
+++ b/packages/components/src/core/SegmentedControl/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { ToggleButtonGroup, toggleButtonClasses } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { focusVisibleA11yStyle } from "src/core/styles/common/mixins/a11y";

--- a/packages/components/src/core/Table/index.tsx
+++ b/packages/components/src/core/Table/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { ForwardedRef, forwardRef } from "react";
 import { StyledTable } from "./style";
 

--- a/packages/components/src/core/Table/style.ts
+++ b/packages/components/src/core/Table/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 
 export const StyledTable = styled("table")`

--- a/packages/components/src/core/TableHeader/index.tsx
+++ b/packages/components/src/core/TableHeader/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef } from "react";
 import TableRow from "src/core/TableRow";
 import { StyledTableHeader } from "./style";

--- a/packages/components/src/core/TableHeader/style.ts
+++ b/packages/components/src/core/TableHeader/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import { getColors } from "src/core/styles";
 

--- a/packages/components/src/core/TableRow/index.tsx
+++ b/packages/components/src/core/TableRow/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { forwardRef } from "react";
 import Tooltip, { TooltipProps } from "src/core/Tooltip";
 import { RowExtraProps, StyledTableRow } from "./style";

--- a/packages/components/src/core/TableRow/style.ts
+++ b/packages/components/src/core/TableRow/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import React from "react";
 import {

--- a/packages/components/src/core/Tabs/components/LabelWithCount/index.tsx
+++ b/packages/components/src/core/Tabs/components/LabelWithCount/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef, ReactNode, useContext } from "react";
 import { TabsContext } from "../common";
 import { Count, Label, Wrapper } from "./style";

--- a/packages/components/src/core/Tabs/components/LabelWithCount/style.ts
+++ b/packages/components/src/core/Tabs/components/LabelWithCount/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 import {
   CommonThemeProps as StyleProps,

--- a/packages/components/src/core/Tabs/components/common.ts
+++ b/packages/components/src/core/Tabs/components/common.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext } from "react";
 
 export type SdsSize = "small" | "large";

--- a/packages/components/src/core/Tabs/index.tsx
+++ b/packages/components/src/core/Tabs/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/css";
 import { TabProps as RawTabProps, useTheme } from "@mui/material";
 import React, { ReactNode, forwardRef, useContext, useMemo } from "react";

--- a/packages/components/src/core/Tabs/style.tsx
+++ b/packages/components/src/core/Tabs/style.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SerializedStyles } from "@emotion/react";
 import {
   Tab as RawTab,

--- a/packages/components/src/core/Tag/index.tsx
+++ b/packages/components/src/core/Tag/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ChipProps } from "@mui/material";
 import { ExtraTagProps, SdsTagColorType, StyledTag } from "./style";
 

--- a/packages/components/src/core/Tag/style.ts
+++ b/packages/components/src/core/Tag/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { Chip, darken } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/TagFilter/index.tsx
+++ b/packages/components/src/core/TagFilter/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ChipProps } from "@mui/material";
 import React from "react";
 import { StyledTag } from "./style";

--- a/packages/components/src/core/TagFilter/style.ts
+++ b/packages/components/src/core/TagFilter/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/react";
 import { styled } from "@mui/material/styles";
 import React from "react";

--- a/packages/components/src/core/Tooltip/index.tsx
+++ b/packages/components/src/core/Tooltip/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Tooltip as RawTooltip,
   TooltipProps as RawTooltipProps,

--- a/packages/components/src/core/Tooltip/style.ts
+++ b/packages/components/src/core/Tooltip/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/css";
 import { Popper } from "@mui/material";
 import { styled } from "@mui/material/styles";

--- a/packages/components/src/core/TooltipCondensed/index.tsx
+++ b/packages/components/src/core/TooltipCondensed/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TooltipClassKey } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { forwardRef } from "react";

--- a/packages/components/src/core/TooltipCondensed/style.ts
+++ b/packages/components/src/core/TooltipCondensed/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css } from "@emotion/css";
 import { CommonThemeProps, getCorners, getSpaces } from "src/core/styles";
 

--- a/packages/components/src/core/TooltipTable/index.tsx
+++ b/packages/components/src/core/TooltipTable/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Table, TableBody, TableContainer, TableRow } from "@mui/material";
 import {
   Alert,

--- a/packages/components/src/core/TooltipTable/style.ts
+++ b/packages/components/src/core/TooltipTable/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { TableCell } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import {

--- a/packages/components/src/core/styles/common/SDSAppTheme.ts
+++ b/packages/components/src/core/styles/common/SDSAppTheme.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { AppTheme, Colors } from "./types";
 
 const fontFamily = '"Inter", sans-serif';

--- a/packages/components/src/core/styles/common/defaultTheme.ts
+++ b/packages/components/src/core/styles/common/defaultTheme.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { createTheme } from "@mui/material/styles";
 import { SDSThemeOptions } from "./types";
 import { SDSAppTheme } from "./SDSAppTheme";

--- a/packages/components/src/core/styles/common/makeThemeOptions.ts
+++ b/packages/components/src/core/styles/common/makeThemeOptions.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { colors } from "@mui/material";
 import { AppTheme, SDSThemeOptions } from "./types";
 

--- a/packages/components/src/core/styles/common/mixins/a11y.ts
+++ b/packages/components/src/core/styles/common/mixins/a11y.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export function focusVisibleA11yStyle() {
   return `
       &.Mui-focusVisible, &:focus-visible {

--- a/packages/components/src/core/styles/common/mixins/fonts.ts
+++ b/packages/components/src/core/styles/common/mixins/fonts.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { css, SerializedStyles } from "@emotion/react";
 import { TypographyStyle } from "@mui/material";
 import { Typography } from "../types";

--- a/packages/components/src/core/styles/common/selectors/theme.ts
+++ b/packages/components/src/core/styles/common/selectors/theme.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { PaletteOptions } from "@mui/material/styles";
 import {
   Borders,

--- a/packages/components/src/core/styles/common/types.ts
+++ b/packages/components/src/core/styles/common/types.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { Theme, ThemeOptions, TypographyStyle } from "@mui/material/styles";
 import { CSSProperties } from "react";
 

--- a/packages/components/src/core/styles/index.ts
+++ b/packages/components/src/core/styles/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export * from "./common/types";
 export * from "./common/defaultTheme";
 export * from "./common/SDSAppTheme";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /* eslint-disable import/export */
 import "./common/styles-dictionary/css/variables.css";
 import "./common/styles-dictionary/scss/_variables.scss";

--- a/packages/data-viz/src/core/HeatmapChart/hooks/useUpdateChart.ts
+++ b/packages/data-viz/src/core/HeatmapChart/hooks/useUpdateChart.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { throttle } from "lodash";
 import { useEffect, useMemo } from "react";
 import { CreateChartOptionsProps, createChartOptions } from "./utils";

--- a/packages/data-viz/src/core/HeatmapChart/hooks/utils.ts
+++ b/packages/data-viz/src/core/HeatmapChart/hooks/utils.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   AxisPointerComponentOption,
   DataZoomComponentOption,

--- a/packages/data-viz/src/core/HeatmapChart/index.tsx
+++ b/packages/data-viz/src/core/HeatmapChart/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ECharts, init } from "echarts";
 import {
   ForwardedRef,

--- a/packages/data-viz/src/core/HeatmapChart/style.ts
+++ b/packages/data-viz/src/core/HeatmapChart/style.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { styled } from "@mui/material/styles";
 
 export const ChartContainer = styled("div")`

--- a/packages/data-viz/src/index.ts
+++ b/packages/data-viz/src/index.ts
@@ -1,2 +1,4 @@
+"use client";
+
 export * from "./core/HeatmapChart";
 export { default as HeatmapChart } from "./core/HeatmapChart";


### PR DESCRIPTION
## Summary

**All SDS Components**
Github issue: #814 

We nee to add "use client"; in all SDS component files, so projects don’t have to do that manually themselves like here:
https://github.com/czbiohub-sf/CZBSF-Metadata-Tracker-refactor/pull/82#discussion_r1684929746

