### PR TITLE
fix(rollup): add "use client;" banner on top of rollup outputs files

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -26,10 +26,12 @@ const config = [
     input: "src/index.ts",
     output: [
       {
+        banner: "'use client';",
         file: pkg.main,
         format: "cjs",
       },
       {
+        banner: "'use client';",
         file: pkg.module,
         format: "esm",
       },


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Github issue: #814 
Old PR: #825 

We need to add "use client"; in all SDS component files so that projects don’t have to do it manually, as shown here:
[Example PR Discussion](https://github.com/czbiohub-sf/CZBSF-Metadata-Tracker-refactor/pull/82#discussion_r1684929746).

Thanks to @tihuan (https://github.com/chanzuckerberg/sci-components/pull/825#pullrequestreview-2228530236), we now know that setting a banner in the Rollup config will automatically add the "use client"; directive to the top of output files.

Since we don’t use preserveModules: true in our Rollup configs, we don’t need to use the [rollup-plugin-preserve-directives](https://github.com/Ephem/rollup-plugin-preserve-directives), which would otherwise add the directive to every single module file!

Refrences:
https://github.com/rollup/rollup/issues/4699#issuecomment-2273497055
https://github.com/rollup/rollup/issues/4699#issuecomment-2275883910