### PR TITLE
fix(ButtonIcon): add sdsStyle to doNotForwardProps

### DIFF
--- a/packages/components/src/core/ButtonIcon/style.ts
+++ b/packages/components/src/core/ButtonIcon/style.ts
@@ -163,6 +163,7 @@ const doNotForwardProps = [
   "on",
   "sdsSize",
   "sdsType",
+  "sdsStyle",
   "sdsIcon",
   "sdsIconProps",
 ];


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)** Genes?
Github issue: N/A

### Background
When using an icon styled ButtonDropdown, there will be a console error message about prop `sdsStyle` being passed in the DOM.

`<ButtonDropdown />` renders `<ButtonIcon />` when `sdsStyle="icon"`. While `<ButtonIcon />` doesn't do more with the `sdsStyle` prop beyond that point, all the props (along with `sdsStyle`) are still being passed into the underlying components. There will still be a console error since `"sdsStyle"` wasn't included in the list of `doNotForwardProps`.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
