### PR TITLE
feat(SegmentedControl): add disabled state in button definition

### DIFF
--- a/packages/components/src/core/SegmentedControl/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/SegmentedControl/__storybook__/index.stories.tsx
@@ -3,6 +3,7 @@ import { BADGE } from "@geometricpanda/storybook-addon-badges";
 import { SegmentedControl } from "./stories/default";
 import { SEGMENTED_CONTROL_EXCLUDED_CONTROLS } from "./constants";
 import { TestDemo } from "./stories/test";
+import { ControlledSegmentedControlDemo } from "./stories/controlledSegmentedControl";
 
 export default {
   argTypes: {
@@ -24,13 +25,90 @@ export default {
 export const Default = {
   args: {
     buttonDefinition: [
-      { icon: "List", tooltipText: "List A", value: "A" },
-      { icon: "List", tooltipText: "List B", value: "B" },
-      { icon: "List", tooltipText: "List C", value: "C" },
-      { icon: "List", tooltipText: "List D", value: "D" },
+      {
+        icon: "List",
+        tooltipText: "List A",
+        value: "A",
+      },
+      {
+        icon: "List",
+        tooltipText: "List B",
+        value: "B",
+      },
+      {
+        icon: "List",
+        tooltipText: "List C",
+        value: "C",
+      },
+      {
+        icon: "List",
+        tooltipText: "List D",
+        value: "D",
+      },
     ],
   },
   render: SegmentedControl,
+};
+
+// Disabled Buttons
+
+export const WithDisabledButton = {
+  args: {
+    buttonDefinition: [
+      {
+        icon: "LinesHorizontal3",
+        tooltipText: "List A",
+        value: "A",
+      },
+      {
+        disabled: true,
+        icon: "LinesHorizontal3",
+        tooltipText: "List B",
+        value: "B",
+      },
+      {
+        icon: "LinesHorizontal3",
+        tooltipText: "List C",
+        value: "C",
+      },
+      {
+        icon: "LinesHorizontal3",
+        tooltipText: "List D",
+        value: "D",
+      },
+    ],
+  },
+  render: SegmentedControl,
+};
+
+// Controlled
+
+export const ControlledSegmentedControl = {
+  args: {
+    buttonDefinition: [
+      {
+        icon: "List",
+        tooltipText: "List A",
+        value: "A",
+      },
+      {
+        icon: "List",
+        tooltipText: "List B",
+        value: "B",
+      },
+      {
+        icon: "List",
+        tooltipText: "List C",
+        value: "C",
+      },
+      {
+        icon: "List",
+        tooltipText: "List D",
+        value: "D",
+      },
+    ],
+  },
+  render: ControlledSegmentedControlDemo,
 };
 
 // Test

--- a/packages/components/src/core/SegmentedControl/__storybook__/stories/controlledSegmentedControl.tsx
+++ b/packages/components/src/core/SegmentedControl/__storybook__/stories/controlledSegmentedControl.tsx
@@ -1,0 +1,20 @@
+import { Args } from "@storybook/react";
+import { useState } from "react";
+import RawSegmentedControl from "src/core/SegmentedControl";
+
+export const ControlledSegmentedControlDemo = (props: Args): JSX.Element => {
+  const { buttonDefinition, ...rest } = props;
+
+  const [value, setValue] = useState("C");
+  return (
+    <RawSegmentedControl
+      buttonDefinition={buttonDefinition}
+      onChange={(_event, newValue) => {
+        console.log(newValue);
+        setValue(newValue);
+      }}
+      value={value}
+      {...rest}
+    />
+  );
+};

--- a/packages/components/src/core/SegmentedControl/__storybook__/stories/default.tsx
+++ b/packages/components/src/core/SegmentedControl/__storybook__/stories/default.tsx
@@ -4,11 +4,5 @@ import RawSegmentedControl from "src/core/SegmentedControl";
 export const SegmentedControl = (props: Args): JSX.Element => {
   const { buttonDefinition, ...rest } = props;
 
-  return (
-    <RawSegmentedControl
-      buttonDefinition={buttonDefinition}
-      color="error"
-      {...rest}
-    />
-  );
+  return <RawSegmentedControl buttonDefinition={buttonDefinition} {...rest} />;
 };

--- a/packages/components/src/core/SegmentedControl/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/SegmentedControl/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
+exports[`<SegmentedControl /> ControlledSegmentedControl story renders snapshot 1`] = `
 <div
   aria-label="Segmented Control"
-  class="MuiToggleButtonGroup-root css-khnnxt-MuiToggleButtonGroup-root"
+  class="MuiToggleButtonGroup-root css-5qbclc-MuiToggleButtonGroup-root"
   role="group"
 >
   <button
     aria-label="List A"
-    aria-pressed="true"
-    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall Mui-error MuiToggleButtonGroup-firstButton css-xc2fp1-MuiButtonBase-root-MuiToggleButton-root"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-firstButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
     data-mui-internal-clone-element="true"
     tabindex="0"
     type="button"
@@ -41,7 +41,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   <button
     aria-label="List B"
     aria-pressed="false"
-    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall Mui-error MuiToggleButtonGroup-middleButton css-xc2fp1-MuiButtonBase-root-MuiToggleButton-root"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
     data-mui-internal-clone-element="true"
     tabindex="0"
     type="button"
@@ -72,8 +72,8 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   </button>
   <button
     aria-label="List C"
-    aria-pressed="false"
-    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall Mui-error MuiToggleButtonGroup-middleButton css-xc2fp1-MuiButtonBase-root-MuiToggleButton-root"
+    aria-pressed="true"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
     data-mui-internal-clone-element="true"
     tabindex="0"
     type="button"
@@ -105,7 +105,7 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
   <button
     aria-label="List D"
     aria-pressed="false"
-    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall Mui-error MuiToggleButtonGroup-lastButton css-xc2fp1-MuiButtonBase-root-MuiToggleButton-root"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-lastButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
     data-mui-internal-clone-element="true"
     tabindex="0"
     type="button"
@@ -122,6 +122,277 @@ exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
           class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
           data-file-name="IconListSmall"
           data-testid="IconListSmall"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+</div>
+`;
+
+exports[`<SegmentedControl /> Default story renders snapshot 1`] = `
+<div
+  aria-label="Segmented Control"
+  class="MuiToggleButtonGroup-root css-5qbclc-MuiToggleButtonGroup-root"
+  role="group"
+>
+  <button
+    aria-label="List A"
+    aria-pressed="true"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-firstButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="A"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconListSmall"
+          data-testid="IconListSmall"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+  <button
+    aria-label="List B"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="B"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconListSmall"
+          data-testid="IconListSmall"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+  <button
+    aria-label="List C"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="C"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconListSmall"
+          data-testid="IconListSmall"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+  <button
+    aria-label="List D"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-lastButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="D"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconListSmall"
+          data-testid="IconListSmall"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+</div>
+`;
+
+exports[`<SegmentedControl /> WithDisabledButton story renders snapshot 1`] = `
+<div
+  aria-label="Segmented Control"
+  class="MuiToggleButtonGroup-root css-5qbclc-MuiToggleButtonGroup-root"
+  role="group"
+>
+  <button
+    aria-label="List A"
+    aria-pressed="true"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-firstButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="A"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconLinesHorizontal3Small"
+          data-testid="IconLinesHorizontal3Small"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+  <button
+    aria-label="List B"
+    aria-pressed="false"
+    class="MuiButtonBase-root Mui-disabled MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-disabled MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    disabled=""
+    tabindex="-1"
+    type="button"
+    value="B"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconLinesHorizontal3Small"
+          data-testid="IconLinesHorizontal3Small"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+  </button>
+  <button
+    aria-label="List C"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-middleButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="C"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconLinesHorizontal3Small"
+          data-testid="IconLinesHorizontal3Small"
+          fillcontrast="white"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+        />
+      </div>
+    </span>
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </button>
+  <button
+    aria-label="List D"
+    aria-pressed="false"
+    class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-lastButton css-1x4vipr-MuiButtonBase-root-MuiToggleButton-root"
+    data-mui-internal-clone-element="true"
+    tabindex="0"
+    type="button"
+    value="D"
+  >
+    <span
+      tabindex="-1"
+    >
+      <div
+        class="css-1ft6wgl"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-8icru1-MuiSvgIcon-root"
+          data-file-name="IconLinesHorizontal3Small"
+          data-testid="IconLinesHorizontal3Small"
           fillcontrast="white"
           focusable="false"
           height="16"

--- a/packages/components/src/core/SegmentedControl/style.ts
+++ b/packages/components/src/core/SegmentedControl/style.ts
@@ -17,6 +17,10 @@ export const StyledSegmentedControl = styled(ToggleButtonGroup, {
     const semanticColors = getSemanticColors(props);
 
     return `
+      .${toggleButtonClasses.root}.${toggleButtonClasses.disabled} {
+        border-color: ${semanticColors?.base?.border};
+      }
+
       .${toggleButtonClasses.root}.${toggleButtonClasses.selected} {
         background-color: ${semanticColors?.base?.fillOpen};
         color: ${semanticColors?.accent?.iconSelected};


### PR DESCRIPTION
## Summary

**SegmentedControl**
Github issue: #868 

- Component Refactored
- New Storybook Stories Added to Cover the Changes
- `disabled` Prop Added to the `buttonDefinition`
- Controlled/Uncontrolled State Added to the Component

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
