### PR TITLE
build: set interop to auto for output config

### DIFF
--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -27,12 +27,14 @@ const config = [
         banner: "\"use client\";",
         file: pkg.main,
         format: "cjs",
+        interop: "auto"
       },
       {
         // Ensures "use client" is added at the top of each output file.
         banner: "\"use client\";",
         file: pkg.module,
         format: "esm",
+        interop: "auto"
       },
     ],
     plugins: [

--- a/packages/data-viz/rollup.config.mjs
+++ b/packages/data-viz/rollup.config.mjs
@@ -27,12 +27,14 @@ const config = [
         banner: "\"use client\";",
         file: pkg.main,
         format: "cjs",
+        interop: "auto"
       },
       {
         // Ensures "use client" is added at the top of each output file.
         banner: "\"use client\";",
         file: pkg.module,
         format: "esm",
+        interop: "auto"
       },
     ],
     plugins: [


### PR DESCRIPTION
## Summary

Adding `auto` to `interop` config so that it can automatically manage the compatibility for imports/exports between CommonJS and ES modules. (ref: https://rollupjs.org/configuration-options/#output-interop)

### Why ###

Our unit tests (via Vitest) with SDS components were failing with the following error:
```
Error: TypeError: styled is not a function
❯ Object.<anonymous> node_modules/@czi-sds/components/dist/index.cjs.js:1309:30
```

This happened after we upgraded SDS from `20.5.0` to `21.6.1`. We suspect something on the output has changed because of the [SDS migration from babel SWC](https://github.com/chanzuckerberg/sci-components/pull/841).


### Testing ###
- I copied the new CJS output file and replace the existing one in our codebase's node_modules. Ran our unit tests, the error no longer appears and the tests passed.
- Components on storybook are still the same and functioning

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
