### PR TITLE
fix(segmentedcontrol): allow all buttons to be deselected

### DIFF
--- a/packages/components/src/core/SegmentedControl/index.tsx
+++ b/packages/components/src/core/SegmentedControl/index.tsx
@@ -42,13 +42,11 @@ const SegmentedControl = (props: SegmentedControlProps) => {
     event: React.MouseEvent<HTMLElement>,
     newActive: string | null
   ) => {
-    if (newActive !== null) {
-      if (!isControlled) {
-        setActive(newActive);
-      }
-      if (onChangeProp) {
-        onChangeProp(event, newActive);
-      }
+    if (!isControlled) {
+      setActive(newActive);
+    }
+    if (onChangeProp) {
+      onChangeProp(event, newActive);
     }
   };
 


### PR DESCRIPTION
## Summary

**SegmentedControl**
Github issue: #890 

Changed the `SegmentedControl` component to allow all buttons to be deselected. Before, it always required one button to stay active, but now that restriction is gone. I updated the `handleActive` function to remove the condition that forced a selection.

## Checklist

- [x] Default Story in Storybook
- [x] LivePreview Story in Storybook
- [x] Test Story in Storybook
- [x] Tests written
- [x] Variables from `defaultTheme.ts` used wherever possible
- [x] If updating an existing component, depreciate flag has been used where necessary
- [x] Chromatic build verified by @chanzuckerberg/sds-design
