### PR TITLE
refactor(tooltip): rename sdsStyle prop to invertStyle

### DIFF
--- a/packages/components/src/common/warnings.ts
+++ b/packages/components/src/common/warnings.ts
@@ -7,7 +7,7 @@ export enum SDSWarningTypes {
   MenuSelectDeprecated = "menuSelectDeprecated",
   TooltipSubtitle = "tooltipSubtitle",
   TooltipWidth = "tooltipWidth",
-  TooltipInverted = "tooltipInverted",
+  TooltipInvertStyle = "tooltipInvertStyle",
 }
 
 export const SDS_WARNINGS = {
@@ -48,10 +48,10 @@ export const SDS_WARNINGS = {
     hasWarned: false,
     message: "Warning: The 'wide' width is only available for light tooltips!",
   },
-  [SDSWarningTypes.TooltipInverted]: {
+  [SDSWarningTypes.TooltipInvertStyle]: {
     hasWarned: false,
     message:
-      "Warning: Tooltips using the inverted prop will be deprecated. Please use sdsStyle: 'dark' | 'light' instead!",
+      "Warning: Tooltips using the inverted or sdsStyle prop will be deprecated. Please use invertStyle instead!",
   },
 };
 

--- a/packages/components/src/common/warnings.ts
+++ b/packages/components/src/common/warnings.ts
@@ -51,7 +51,7 @@ export const SDS_WARNINGS = {
   [SDSWarningTypes.TooltipInvertStyle]: {
     hasWarned: false,
     message:
-      "Warning: Tooltips using the inverted or sdsStyle prop will be deprecated. Please use invertStyle instead!",
+      "Warning: Tooltips using the inverted or sdsStyle prop will be deprecated. Please use hasInvertedStyle instead!",
   },
 };
 

--- a/packages/components/src/core/Tooltip/__storybook__/constants.ts
+++ b/packages/components/src/core/Tooltip/__storybook__/constants.ts
@@ -21,7 +21,7 @@ export const TOOLTIP_PLACEMENT_STYLES = {
   display: "grid",
   gridColumnGap: "50px",
   gridRowGap: "50px",
-  gridTemplateColumns: "repeat(3, 130px",
+  gridTemplateColumns: "repeat(3, 130px)",
   gridTemplateRows: "repeat(5, 60px)",
   justifyContent: "center",
   padding: "100px",
@@ -33,7 +33,7 @@ export const TOOLTIP_SUBTITLE_OPTIONS = [
   undefined,
 ];
 export const TOOLTIP_ARROW_OPTIONS = [true];
-export const TOOLTIP_ARROW_OFFSET_OPTIONS = [undefined, -120, -60, 0, 60, 120];
+export const TOOLTIP_ARROW_OFFSET_OPTIONS = [undefined, -112, -60, 0, 60, 112];
 export const TOOLTIP_WIDTH_OPTIONS: TooltipExtraProps["width"][] = [
   "default",
   "wide",

--- a/packages/components/src/core/Tooltip/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/Tooltip/__storybook__/index.stories.tsx
@@ -11,6 +11,9 @@ export default {
     arrowOffset: {
       control: { type: "number" },
     },
+    invertStyle: {
+      control: { type: "boolean" },
+    },
     placement: {
       control: { type: "select" },
       options: [
@@ -27,10 +30,6 @@ export default {
         "top",
         "top-end",
       ],
-    },
-    sdsStyle: {
-      control: { type: "radio" },
-      options: ["dark", "light"],
     },
     title: {
       control: { type: "text" },
@@ -53,8 +52,8 @@ export default {
 
 export const Default = {
   args: {
+    invertStyle: true,
     placement: "top",
-    sdsStyle: "dark",
     subtitle: "dolor sit amet",
     title: "Lorem ipsum",
     width: "default",

--- a/packages/components/src/core/Tooltip/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/Tooltip/__storybook__/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
     arrowOffset: {
       control: { type: "number" },
     },
-    invertStyle: {
+    hasInvertedStyle: {
       control: { type: "boolean" },
     },
     placement: {
@@ -52,7 +52,6 @@ export default {
 
 export const Default = {
   args: {
-    invertStyle: true,
     placement: "top",
     subtitle: "dolor sit amet",
     title: "Lorem ipsum",

--- a/packages/components/src/core/Tooltip/index.tsx
+++ b/packages/components/src/core/Tooltip/index.tsx
@@ -35,7 +35,7 @@ const Tooltip = forwardRef(function Tooltip(
   const {
     arrowOffset,
     classes,
-    hasInvertedStyle,
+    hasInvertedStyle = true,
     inverted,
     sdsStyle = "dark",
     subtitle,

--- a/packages/components/src/core/Tooltip/index.tsx
+++ b/packages/components/src/core/Tooltip/index.tsx
@@ -35,8 +35,9 @@ const Tooltip = forwardRef(function Tooltip(
   const {
     arrowOffset,
     classes,
+    invertStyle,
     inverted,
-    sdsStyle = "light",
+    sdsStyle = "dark",
     subtitle,
     title,
     width = "default",
@@ -46,15 +47,15 @@ const Tooltip = forwardRef(function Tooltip(
 
   const { children } = rest;
 
-  if (inverted) {
-    showWarningIfFirstOccurence(SDSWarningTypes.TooltipInverted);
+  if (inverted || sdsStyle) {
+    showWarningIfFirstOccurence(SDSWarningTypes.TooltipInvertStyle);
   }
 
-  if (width === "wide" && sdsStyle === "dark") {
+  if (width === "wide" && (sdsStyle === "dark" || invertStyle)) {
     showWarningIfFirstOccurence(SDSWarningTypes.TooltipWidth);
   }
 
-  if (subtitle && sdsStyle === "light") {
+  if (subtitle && (sdsStyle === "light" || !invertStyle)) {
     showWarningIfFirstOccurence(SDSWarningTypes.TooltipSubtitle);
   }
 
@@ -64,8 +65,7 @@ const Tooltip = forwardRef(function Tooltip(
     /* stylelint-disable property-no-unknown -- false positive */
     arrowOffset,
     classes,
-    inverted,
-    sdsStyle,
+    invertStyle: invertStyleValue(inverted, sdsStyle, invertStyle),
     theme,
     width,
     /* stylelint-enable property-no-unknown -- false positive */
@@ -90,11 +90,11 @@ const Tooltip = forwardRef(function Tooltip(
   const content = (
     <>
       {title}
-      {sdsStyle === "dark" && subtitle && <Subtitle>{subtitle}</Subtitle>}
+      {invertStyle && subtitle && <Subtitle>{subtitle}</Subtitle>}
     </>
   );
 
-  const leaveDelay = inverted || sdsStyle === "dark" ? 0 : 500;
+  const leaveDelay = invertStyle || inverted || sdsStyle === "dark" ? 0 : 500;
 
   return (
     <RawTooltip
@@ -114,6 +114,26 @@ const Tooltip = forwardRef(function Tooltip(
     />
   );
 });
+
+/**
+ * (masoudmanson): Temporary function to handle the inversion of the tooltip
+ * based on the sdsStyle, invert and invertStyle props.
+ * Once the sdsStyle and invert props are completely removed,
+ * this function will be removed as well.
+ */
+function invertStyleValue(
+  inverted: boolean | undefined,
+  sdsStyle: "light" | "dark" | undefined,
+  invertStyle: boolean | undefined
+) {
+  return invertStyle !== undefined
+    ? invertStyle
+    : sdsStyle === "dark"
+      ? true
+      : sdsStyle === "light"
+        ? false
+        : inverted;
+}
 
 function mergeClass({
   props,

--- a/packages/components/src/core/Tooltip/index.tsx
+++ b/packages/components/src/core/Tooltip/index.tsx
@@ -35,7 +35,7 @@ const Tooltip = forwardRef(function Tooltip(
   const {
     arrowOffset,
     classes,
-    invertStyle,
+    hasInvertedStyle,
     inverted,
     sdsStyle = "dark",
     subtitle,
@@ -51,11 +51,11 @@ const Tooltip = forwardRef(function Tooltip(
     showWarningIfFirstOccurence(SDSWarningTypes.TooltipInvertStyle);
   }
 
-  if (width === "wide" && (sdsStyle === "dark" || invertStyle)) {
+  if (width === "wide" && (sdsStyle === "dark" || hasInvertedStyle)) {
     showWarningIfFirstOccurence(SDSWarningTypes.TooltipWidth);
   }
 
-  if (subtitle && (sdsStyle === "light" || !invertStyle)) {
+  if (subtitle && (sdsStyle === "light" || !hasInvertedStyle)) {
     showWarningIfFirstOccurence(SDSWarningTypes.TooltipSubtitle);
   }
 
@@ -65,7 +65,7 @@ const Tooltip = forwardRef(function Tooltip(
     /* stylelint-disable property-no-unknown -- false positive */
     arrowOffset,
     classes,
-    invertStyle: invertStyleValue(inverted, sdsStyle, invertStyle),
+    hasInvertedStyle: invertStyleValue(inverted, sdsStyle, hasInvertedStyle),
     theme,
     width,
     /* stylelint-enable property-no-unknown -- false positive */
@@ -90,11 +90,12 @@ const Tooltip = forwardRef(function Tooltip(
   const content = (
     <>
       {title}
-      {invertStyle && subtitle && <Subtitle>{subtitle}</Subtitle>}
+      {hasInvertedStyle && subtitle && <Subtitle>{subtitle}</Subtitle>}
     </>
   );
 
-  const leaveDelay = invertStyle || inverted || sdsStyle === "dark" ? 0 : 500;
+  const leaveDelay =
+    hasInvertedStyle || inverted || sdsStyle === "dark" ? 0 : 500;
 
   return (
     <RawTooltip
@@ -117,17 +118,17 @@ const Tooltip = forwardRef(function Tooltip(
 
 /**
  * (masoudmanson): Temporary function to handle the inversion of the tooltip
- * based on the sdsStyle, invert and invertStyle props.
+ * based on the sdsStyle, invert and hasInvertedStyle props.
  * Once the sdsStyle and invert props are completely removed,
  * this function will be removed as well.
  */
 function invertStyleValue(
   inverted: boolean | undefined,
   sdsStyle: "light" | "dark" | undefined,
-  invertStyle: boolean | undefined
+  hasInvertedStyle: boolean | undefined
 ) {
-  return invertStyle !== undefined
-    ? invertStyle
+  return hasInvertedStyle !== undefined
+    ? hasInvertedStyle
     : sdsStyle === "dark"
       ? true
       : sdsStyle === "light"

--- a/packages/components/src/core/Tooltip/style.ts
+++ b/packages/components/src/core/Tooltip/style.ts
@@ -15,8 +15,11 @@ export interface TooltipExtraProps extends CommonThemeProps {
   // TODO(185930): remove custom `followCursor` prop when we upgrade to MUIv5
   arrowOffset?: number;
   followCursor?: boolean;
+  // @deprecated Use `invertStyle` instead
   inverted?: boolean;
+  // @deprecated Use `invertStyle` instead
   sdsStyle?: "dark" | "light";
+  invertStyle?: boolean;
   subtitle?: string;
   width?: "default" | "wide";
 }
@@ -76,7 +79,7 @@ export const Subtitle = styled("div")`
 `;
 
 export const tooltipCss = (props: TooltipExtraProps): string => {
-  const { inverted, sdsStyle, width, followCursor } = props;
+  const { invertStyle = true, inverted, sdsStyle, width, followCursor } = props;
 
   const shadows = getShadows(props);
 
@@ -84,7 +87,9 @@ export const tooltipCss = (props: TooltipExtraProps): string => {
     &.MuiTooltip-tooltip {
       box-shadow: ${shadows?.m};
 
-      ${sdsStyle === "dark" || inverted ? dark(props) : light(props)}
+      ${sdsStyle === "dark" || inverted || invertStyle
+        ? dark(props)
+        : light(props)}
       ${width === "wide" && sdsStyle === "light" && wide()}
 
       ${followCursor === true && tableStyles(props)}
@@ -93,7 +98,7 @@ export const tooltipCss = (props: TooltipExtraProps): string => {
 };
 
 export const arrowCss = (props: TooltipExtraProps): string => {
-  const { inverted, sdsStyle, arrowOffset } = props;
+  const { invertStyle, inverted, sdsStyle, arrowOffset } = props;
 
   const semanticColors = getSemanticColors(props);
 
@@ -101,7 +106,7 @@ export const arrowCss = (props: TooltipExtraProps): string => {
     &.MuiTooltip-arrow {
       /* (bethbertozzi): !important is needed to fight inline style */
       left: ${arrowOffset}px !important;
-      color: ${inverted || sdsStyle === "dark"
+      color: ${invertStyle || inverted || sdsStyle === "dark"
         ? semanticColors?.base?.surfacePrimaryInverse
         : semanticColors?.base?.surfacePrimary};
       &:before {

--- a/packages/components/src/core/Tooltip/style.ts
+++ b/packages/components/src/core/Tooltip/style.ts
@@ -15,11 +15,11 @@ export interface TooltipExtraProps extends CommonThemeProps {
   // TODO(185930): remove custom `followCursor` prop when we upgrade to MUIv5
   arrowOffset?: number;
   followCursor?: boolean;
-  // @deprecated Use `invertStyle` instead
+  // @deprecated Use `hasInvertedStyle` instead
   inverted?: boolean;
-  // @deprecated Use `invertStyle` instead
+  // @deprecated Use `hasInvertedStyle` instead
   sdsStyle?: "dark" | "light";
-  invertStyle?: boolean;
+  hasInvertedStyle?: boolean;
   subtitle?: string;
   width?: "default" | "wide";
 }
@@ -79,7 +79,13 @@ export const Subtitle = styled("div")`
 `;
 
 export const tooltipCss = (props: TooltipExtraProps): string => {
-  const { invertStyle = true, inverted, sdsStyle, width, followCursor } = props;
+  const {
+    hasInvertedStyle = true,
+    inverted,
+    sdsStyle,
+    width,
+    followCursor,
+  } = props;
 
   const shadows = getShadows(props);
 
@@ -87,7 +93,7 @@ export const tooltipCss = (props: TooltipExtraProps): string => {
     &.MuiTooltip-tooltip {
       box-shadow: ${shadows?.m};
 
-      ${sdsStyle === "dark" || inverted || invertStyle
+      ${sdsStyle === "dark" || inverted || hasInvertedStyle
         ? dark(props)
         : light(props)}
       ${width === "wide" && sdsStyle === "light" && wide()}
@@ -98,7 +104,7 @@ export const tooltipCss = (props: TooltipExtraProps): string => {
 };
 
 export const arrowCss = (props: TooltipExtraProps): string => {
-  const { invertStyle, inverted, sdsStyle, arrowOffset } = props;
+  const { hasInvertedStyle, inverted, sdsStyle, arrowOffset } = props;
 
   const semanticColors = getSemanticColors(props);
 
@@ -106,7 +112,7 @@ export const arrowCss = (props: TooltipExtraProps): string => {
     &.MuiTooltip-arrow {
       /* (bethbertozzi): !important is needed to fight inline style */
       left: ${arrowOffset}px !important;
-      color: ${invertStyle || inverted || sdsStyle === "dark"
+      color: ${hasInvertedStyle || inverted || sdsStyle === "dark"
         ? semanticColors?.base?.surfacePrimaryInverse
         : semanticColors?.base?.surfacePrimary};
       &:before {


### PR DESCRIPTION
## Summary

**Tooltip**
Github issue: #896 

Connor and I chatted about this and decided to go with a boolean prop called invertStyle with the dark background being the default value (which is "false")

invertStyle: false = dark background Tooltip
invertStyle: true = light background Tooltip
We'll use the same prop on the NavFooter and NavHeader components.

## Checklist

- [ ] Default Story in Storybook
- [ ] LivePreview Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
