### PR TITLE
fix(styles): Inverted styles on Button and InputSearch ignore custom themes.

### DIFF
--- a/packages/components/src/core/styles/common/SDSAppTheme.ts
+++ b/packages/components/src/core/styles/common/SDSAppTheme.ts
@@ -163,7 +163,7 @@ const sharedAppTheme: Omit<AppTheme, "colors" | "mode"> = {
   fontWeights: {
     bold: 700,
     light: 300,
-    medium: 800,
+    medium: 500,
     regular: 400,
     semibold: 600,
   },


### PR DESCRIPTION
## Summary

**NavigationHeader, Button, InputSearch**
Github issue: [Jira Ticket](https://czi.atlassian.net/jira/software/c/projects/SCIDS/list?selectedIssue=SCIDS-935)


### The Issue

The current implementation of inverted styles in some sub-components of NavigationHeader does not respect custom theme overrides. While the default light and dark SDS themes work correctly, custom themes—such as modified color values—are ignored, causing the components to revert to the default SDS theme instead.


### Affected Components

- Button
- InputSearch
- NavigationHeader

### Expected Behavior

Inverted styles should adapt to custom theme overrides instead of defaulting to the SDS theme.

### Next Steps

- [ ] Investigate a fix to ensure inverted styles work correctly with custom themes.
- [ ] If a fix isn’t feasible, consider overriding inverted style themes for affected sub-components.


## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
