### PR TITLE
fix(NavHeader, NavFooter): VCP dark mode changes 

### DIFF
--- a/packages/components/src/core/NavigationHeader/NavigationHeader.types.ts
+++ b/packages/components/src/core/NavigationHeader/NavigationHeader.types.ts
@@ -1,0 +1,28 @@
+import { ButtonProps, LinkProps } from "@mui/material";
+import { ReactNode, ElementType } from "react";
+import { SdsProps, SdsIconButtonProps } from "../Button";
+import { InputSearchProps } from "../InputSearch";
+import { SdsTagColorType } from "../Tag";
+import { NavigationHeaderPrimaryNavItem } from "./components/NavigationHeaderPrimaryNav";
+import { NavigationHeaderSecondaryNavItem } from "./components/NavigationHeaderSecondaryNav";
+
+export interface NavigationHeaderProps<T extends string = string> {
+  activePrimaryNavKey?: string;
+  buttons?: (SdsProps & ButtonProps)[];
+  hasInvertedStyle?: boolean;
+  logo?: ReactNode;
+  logoUrl?: string;
+  logoLinkComponent?: ElementType;
+  logoLinkProps?: LinkProps;
+  primaryNavItems?: NavigationHeaderPrimaryNavItem<T>[];
+  primaryNavPosition?: "left" | "right";
+  searchProps?: Partial<InputSearchProps>;
+  secondaryNavItems?: NavigationHeaderSecondaryNavItem[];
+  setActivePrimaryNavKey?(key: string): void;
+  showSearch?: boolean;
+  tag?: string;
+  tagColor?: SdsTagColorType;
+  title: string;
+}
+
+export type IconButtonProps = SdsIconButtonProps & { children?: string };

--- a/packages/components/src/core/NavigationHeader/index.tsx
+++ b/packages/components/src/core/NavigationHeader/index.tsx
@@ -1,15 +1,6 @@
-import { LinkProps, useMediaQuery } from "@mui/material";
+import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import {
-  ElementType,
-  forwardRef,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import { SdsTagColorType } from "src/core/Tag";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import {
   StyledButtonSection,
   StyledDrawer,
@@ -28,44 +19,14 @@ import {
   StyledToolbar,
   StyledWideIconButton,
 } from "./style";
-import NavigationHeaderPrimaryNav, {
-  NavigationHeaderPrimaryNavItem,
-} from "./components/NavigationHeaderPrimaryNav";
-import { InputSearchProps } from "../InputSearch";
-import NavigationHeaderSecondaryNav, {
-  NavigationHeaderSecondaryNavItem,
-} from "./components/NavigationHeaderSecondaryNav";
-import {
-  SdsProps,
-  ButtonProps,
-  SdsButtonProps,
-  SdsIconButtonProps,
-  SdsMinimalButtonProps,
-} from "../Button";
+import NavigationHeaderPrimaryNav from "./components/NavigationHeaderPrimaryNav";
+import NavigationHeaderSecondaryNav from "./components/NavigationHeaderSecondaryNav";
+import { ButtonProps, SdsButtonProps, SdsMinimalButtonProps } from "../Button";
 import Icon from "../Icon";
-
-export type { NavigationHeaderSecondaryNavItem } from "./components/NavigationHeaderSecondaryNav";
-
-export interface NavigationHeaderProps<T extends string = string> {
-  activePrimaryNavKey?: string;
-  buttons?: (SdsProps & ButtonProps)[];
-  hasInvertedStyle?: boolean;
-  logo?: ReactNode;
-  logoUrl?: string;
-  logoLinkComponent?: ElementType;
-  logoLinkProps?: LinkProps;
-  primaryNavItems?: NavigationHeaderPrimaryNavItem<T>[];
-  primaryNavPosition?: "left" | "right";
-  searchProps?: Partial<InputSearchProps>;
-  secondaryNavItems?: NavigationHeaderSecondaryNavItem[];
-  setActivePrimaryNavKey?(key: string): void;
-  showSearch?: boolean;
-  tag?: string;
-  tagColor?: SdsTagColorType;
-  title: string;
-}
-
-export type IconButtonProps = SdsIconButtonProps & { children?: string };
+import {
+  IconButtonProps,
+  NavigationHeaderProps,
+} from "./NavigationHeader.types";
 
 const NavigationHeader = forwardRef<HTMLDivElement, NavigationHeaderProps>(
   <T extends string = string>(


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Github issue: [#XXXX](link)

Copy issue description here

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
