### PR TITLE
fix: Add showSectionHeader prop to TooltipTable

### DIFF
--- a/packages/components/src/core/TooltipTable/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/TooltipTable/__storybook__/index.stories.tsx
@@ -17,6 +17,9 @@ export default {
       control: { type: "radio" },
       options: ["right", "left"],
     },
+    showSectionHeader: {
+      control: { type: "boolean" },
+    },
   },
   component: TooltipTableContent,
   parameters: {
@@ -32,6 +35,7 @@ export const Default = {
     contentAlert: "None",
     data: TOOLTIP_TABLE_DATA,
     itemAlign: "right",
+    showSectionHeader: true,
   },
 };
 

--- a/packages/components/src/core/TooltipTable/index.tsx
+++ b/packages/components/src/core/TooltipTable/index.tsx
@@ -16,7 +16,13 @@ export type { TooltipTableContentProps };
  * @see https://mui.com/material-ui/react-table/
  */
 const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
-  const { contentAlert, data, itemAlign = "right", ...rest } = props;
+  const {
+    contentAlert,
+    data,
+    itemAlign = "right",
+    showSectionHeader = true,
+    ...rest
+  } = props;
 
   return (
     <TableContainer {...rest}>
@@ -26,9 +32,11 @@ const TooltipTableContent = (props: TooltipTableContentProps): JSX.Element => {
           disabled={section.disabled}
           key={`${section.label + String(index)}`}
         >
-          <SectionLabel disabled={section.disabled} label={section.label}>
-            {section.label}
-          </SectionLabel>
+          {showSectionHeader && (
+            <SectionLabel disabled={section.disabled} label={section.label}>
+              {section.label}
+            </SectionLabel>
+          )}
           <Table size="small">
             <TableBody>
               {section.dataRows.map((row, rowIndex) => (

--- a/packages/components/src/core/TooltipTable/style.ts
+++ b/packages/components/src/core/TooltipTable/style.ts
@@ -22,6 +22,7 @@ export interface TooltipTableExtraProps extends CommonThemeProps {
   }>;
   contentAlert?: string | JSX.Element;
   itemAlign?: "left" | "right";
+  showSectionHeader?: boolean;
 }
 
 const sdsPropNames = ["contentAlert", "itemAlign"];


### PR DESCRIPTION
## Summary

**TooltipTable**
Jira issue: https://czi.atlassian.net/browse/SCIDS-1118

 Added a new showSectionHeader prop to control showing/hiding the section headers.