### PR TITLE
fix(MenuItem): Add display flex to icon wrapper to fix the icon position

### DIFF
--- a/packages/components/src/core/Autocomplete/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Autocomplete/__tests__/__snapshots__/index.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -292,7 +292,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -333,7 +333,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -379,7 +379,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -425,7 +425,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -471,7 +471,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -666,7 +666,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -712,7 +712,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -758,7 +758,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -799,7 +799,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -840,7 +840,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -881,7 +881,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"
@@ -921,7 +921,7 @@ exports[`<Autocomplete /> ControlledOpen story renders snapshot 1`] = `
                   tabindex="-1"
                 >
                   <span
-                    class="css-1715doo"
+                    class="css-17socgo"
                   >
                     <svg
                       aria-hidden="true"

--- a/packages/components/src/core/MenuItem/style.ts
+++ b/packages/components/src/core/MenuItem/style.ts
@@ -202,6 +202,7 @@ export const StyledIconWrapper = styled("span")`
     const iconSizes = getIconSizes(props);
 
     return `
+      display: flex;
       align-self: start;
       margin-right: ${spaces?.m}px;
       margin-top: ${spaces?.xxxs}px;


### PR DESCRIPTION
## Summary

**MenuItem**
Jira Ticket: https://czi.atlassian.net/browse/SCIDS-1122?atlOrigin=eyJpIjoiMmQ0M2FjNjdjMzY4NGI2YzgzZjUyZDlmZmFlNDhlZWIiLCJwIjoiaiJ9

<div style="display: flex; align-items: center; justify-content: center">
<img width="261" alt="Before" src="https://github.com/user-attachments/assets/bc620f84-f618-4d69-b802-da93dcea893c" />
===>
<img width="256" alt="After" src="https://github.com/user-attachments/assets/8e67a6d0-8fca-4066-b169-6f7bb16533c9" />

</div>
