### PR TITLE
fix: Update panel header margin-bottom to use spaces.xl instead of spaces.xxl

### DIFF
--- a/packages/components/src/core/Panel/style.ts
+++ b/packages/components/src/core/Panel/style.ts
@@ -98,7 +98,7 @@ export const StyledHeaderComponent = styled("div")`
     const spaces = getSpaces(props);
 
     return css`
-      margin-bottom: ${spaces?.xxl}px;
+      margin-bottom: ${spaces?.xl}px;
       display: flex;
       justify-content: space-between;
       align-items: start;


### PR DESCRIPTION
## Summary

**Panel**
Github issue: https://czi.atlassian.net/browse/SCIDS-1127?atlOrigin=eyJpIjoiMTUzNjMwNzZiZDQ4NGVkNGJjNDk5MTU5NTRmMTYyZTgiLCJwIjoiaiJ9


