### PR TITLE
feat(Dropdown): Add optional prop - isSearchAutoFocus

### DIFF
--- a/packages/components/src/core/Dropdown/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/Dropdown/__storybook__/index.stories.tsx
@@ -17,7 +17,11 @@ import { PopperPlacementDemo } from "./stories/popperPlacement";
 
 export default {
   argTypes: {
-    DropdownMenuProps: { control: { type: "object" } },
+    DropdownMenuProps: {
+      control: {
+        type: "object",
+      },
+    },
     buttonPosition: {
       control: {
         labels: ["left", "right"],
@@ -41,7 +45,17 @@ export default {
         type: "boolean",
       },
     },
-    label: { control: { type: "text" } },
+    isSearchAutoFocus: {
+      control: {
+        type: "boolean",
+      },
+      defaultValue: true,
+    },
+    label: {
+      control: {
+        type: "text",
+      },
+    },
     multiple: {
       control: {
         type: "boolean",
@@ -96,6 +110,7 @@ export const Default = {
     buttons: false,
     closeOnBlur: true,
     disabled: false,
+    isSearchAutoFocus: true,
     isTriggerChangeOnOptionClick: false,
     label: DROPDOWN_LABEL,
     multiple: true,

--- a/packages/components/src/core/Dropdown/index.tsx
+++ b/packages/components/src/core/Dropdown/index.tsx
@@ -42,6 +42,7 @@ export interface ExtraDropdownProps<
     | AutocompleteSingleColumnOption<T>[]
     | AutocompleteMultiColumnOption<T, Multiple, DisableClearable, FreeSolo>[];
   search?: boolean;
+  isSearchAutoFocus?: boolean;
   DropdownMenuProps?: Partial<
     SdsDropdownMenuProps<T, Multiple, DisableClearable, FreeSolo>
   >;
@@ -85,6 +86,7 @@ const Dropdown = <
     label = "",
     multiple = false,
     search = false,
+    isSearchAutoFocus = true,
     buttonPosition = "right",
     buttons = false,
     // By default, most dropdowns will close when the user clicks outside the dropdown.
@@ -154,7 +156,10 @@ const Dropdown = <
         width={250}
         onChange={handleChange}
         value={isMultiColumn ? value : multiple ? pendingValue : value}
-        {...DropdownMenuProps}
+        {...{
+          isSearchAutoFocus,
+          ...DropdownMenuProps,
+        }}
         {...rest}
       >
         {shouldShowButtons ? (

--- a/packages/components/src/core/DropdownMenu/index.tsx
+++ b/packages/components/src/core/DropdownMenu/index.tsx
@@ -113,6 +113,7 @@ const DropdownMenu = <
     PaperComponent = StyledPaper,
     PopperPlacement = "bottom-start",
     PopperBaseProps = {},
+    isSearchAutoFocus = true,
     search = false,
     title,
     headerComponentSlot,
@@ -142,10 +143,10 @@ const DropdownMenu = <
   const DefaultInputBaseProps = useMemo(() => {
     return {
       ...InputBaseProps,
-      autoFocus: true,
+      autoFocus: isSearchAutoFocus,
       onClick: noop,
     };
-  }, [InputBaseProps]);
+  }, [InputBaseProps, isSearchAutoFocus]);
 
   return (
     <PopperComponent

--- a/packages/components/src/core/DropdownMenu/style.ts
+++ b/packages/components/src/core/DropdownMenu/style.ts
@@ -15,6 +15,7 @@ export interface StyleProps extends CommonThemeProps {
   count?: number;
   icon?: ReactElement;
   search?: boolean;
+  isSearchAutoFocus?: boolean;
   title?: string;
   isMultiColumn?: boolean;
 }
@@ -118,7 +119,7 @@ export const StyledPaper = styled(Paper, {
       // as it has been added to the parent container
       .MuiAutocomplete-root .MuiFormControl-root.MuiTextField-root {
         margin-right: 0;
-        margin-bottom: 0;  
+        margin-bottom: 0;
       }
     `;
   }}


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Github issue: [#XXXX](link)

Request from [Slack](https://czi-sci.slack.com/archives/C032S43KKFV/p1748541194214919)

Need to add an optional prop `isSearchAutoFocus` on `Dropdown` and `DropdownMenu` to allow disabling DropdownMenu's InputBase `autoFocus` value

`<Dropdown isSearchAutoFocus={false} ... />`

<img width="1278" alt="Screenshot 2025-05-30 at 1 21 48 PM" src="https://github.com/user-attachments/assets/334bfaba-eede-42a5-acb1-898580cdcbc0" />


https://github.com/user-attachments/assets/87ac12aa-04f0-42b0-a7ed-327a122f4528


## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
