### PR TITLE
feat(Panel): add isBackdropClickEnabled prop

### DIFF
--- a/packages/components/src/core/Panel/Panel.types.ts
+++ b/packages/components/src/core/Panel/Panel.types.ts
@@ -5,6 +5,7 @@ export interface BasicPanelProps extends Omit<DrawerProps, "variant"> {
   sdsType: "basic"; // Discriminator
   position?: "left" | "right";
   width?: number | string;
+  isBackdropClickEnabled?: boolean;
 }
 
 export interface OverlayPanelProps extends Omit<DrawerProps, "variant"> {
@@ -14,6 +15,7 @@ export interface OverlayPanelProps extends Omit<DrawerProps, "variant"> {
   HeaderComponent?: React.ReactNode;
   closeButtonOnClick?: PanelHeaderCloseProps["onClick"];
   CloseButtonComponent?: PanelHeaderCloseProps["CloseButtonComponent"];
+  isBackdropClickEnabled?: boolean;
 }
 
 // Discriminated Union

--- a/packages/components/src/core/Panel/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/Panel/__storybook__/index.stories.tsx
@@ -8,6 +8,13 @@ import { ScrollBehaviorDemo } from "./stories/scrollBehavior";
 
 export default {
   argTypes: {
+    isBackdropClickEnabled: {
+      control: {
+        type: "boolean",
+      },
+      description:
+        "If true, clicking on the backdrop will close the panel. Only applies to overlay panels.",
+    },
     position: {
       control: {
         type: "select",

--- a/packages/components/src/core/Panel/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Panel/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Panel /> Default story renders snapshot 1`] = `
 <div
   class="MuiDrawer-root MuiDrawer-docked css-979780-MuiDrawer-docked"
+  slotprops="[object Object]"
 >
   <div
     class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiDrawer-paper MuiDrawer-paperAnchorLeft MuiDrawer-paperAnchorDockedLeft css-12i7wg6-MuiPaper-root-MuiDrawer-paper"

--- a/packages/components/src/core/Panel/index.tsx
+++ b/packages/components/src/core/Panel/index.tsx
@@ -17,10 +17,15 @@ function isOverlayPanelProps(props: PanelProps): props is OverlayPanelProps {
   return props.sdsType === "overlay";
 }
 
+const SLOT_PROPS = {
+  backdrop: {
+    invisible: true,
+  },
+};
+
 /**
  * @see https://mui.com/material-ui/react-drawer/
  */
-
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
   const {
     children,
@@ -28,6 +33,7 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
     position = "left",
     width,
     ModalProps,
+    isBackdropClickEnabled = false,
   } = props;
 
   const drawerWidth =
@@ -77,7 +83,8 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
         // not lock the page scroll when it is open.
         disableScrollLock: true,
       }}
-      hideBackdrop={true}
+      slotProps={SLOT_PROPS}
+      hideBackdrop={!isBackdropClickEnabled}
     >
       {isOverlayPanelProps(props) && (
         <StyledHeaderComponent>

--- a/packages/components/src/core/Panel/style.ts
+++ b/packages/components/src/core/Panel/style.ts
@@ -24,6 +24,7 @@ const doNotForwardProps = [
   "disableScrollLock",
   "closeButtonOnClick",
   "CloseButtonComponent",
+  "isBackdropClickEnabled",
 ];
 
 const basicPanelStyles = (props: PanelExtraProps): SerializedStyles => {


### PR DESCRIPTION
## Summary

[Slack](https://czi-sci.slack.com/archives/C032S43KKFV/p1748901205834829?thread_ts=1748546055.776889&cid=C032S43KKFV)

For mobile UX, we actually want the panel to close when clicking outside of it

1. Conditionally add Backdrop to `Panel` component
2. Set `Backdrop` to be transparent to match existing design, since we only want the backdropClick functionality and not its presentation

VCP mobile UX Panel usage example:
<img width="1062" alt="Screenshot 2025-06-04 at 10 35 16 AM" src="https://github.com/user-attachments/assets/490423cc-043e-424a-bb14-065b77e8e22e" />

https://github.com/user-attachments/assets/f9e62590-f78b-4525-b68b-f1c757b631d4

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
