### PR TITLE
fix(navigationheader): add onClick for PrimaryNavItems of type dropdown

### DIFF
--- a/packages/components/src/core/NavigationHeader/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/NavigationHeader/__storybook__/index.stories.tsx
@@ -198,6 +198,7 @@ export const Default = {
       {
         key: "2",
         label: "Primary",
+        onClick: () => console.log("You clicked on a Text PrimaryNavItem!"),
         tag: "Beta",
         tagColor: "beta",
       },
@@ -211,11 +212,12 @@ export const Default = {
           },
           {
             label: "Show an Alert!",
-            onClick: () => alert("You clicked on a dropdown item!"),
+            onClick: () => alert("You clicked on a dropdown menu item!"),
           },
         ],
         key: "3",
         label: "Primary",
+        onClick: () => console.log("You clicked on a Dropdown PrimaryNavItem!"),
       },
     ],
     scrollElevation: true,

--- a/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
+++ b/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
@@ -19,6 +19,7 @@ interface BaseNavigationHeaderPrimaryNavItem<T extends string>
   extends Record<string, unknown> {
   key: T;
   label: ReactNode;
+  onClick?: (e: React.SyntheticEvent) => void;
 }
 
 export interface TextNavigationHeaderPrimaryNavItem<T extends string>
@@ -26,7 +27,6 @@ export interface TextNavigationHeaderPrimaryNavItem<T extends string>
   itemType: "text";
   tag?: string;
   tagColor?: SdsTagColorType;
-  onClick?: (e: React.SyntheticEvent) => void;
 }
 
 interface DropdownItem {
@@ -69,6 +69,7 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
   const [menuWidth, setMenuWidth] = useState<number | string>("100%");
 
   const open = Boolean(anchorEl);
+
   function onClose() {
     setAnchorEl(null);
   }
@@ -85,7 +86,14 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
   return (
     <StyledSection isNarrow={isNarrow}>
       {items.map((item) => {
-        const { key, label, tag, tagColor, ...rest } = item;
+        const {
+          key,
+          label,
+          tag,
+          tagColor,
+          onClick: parentOnClick,
+          ...rest
+        } = item;
         const isActive = key === value;
 
         if (item.itemType === "dropdown" && !isNarrow) {
@@ -102,6 +110,7 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
                 onClick={(e) => {
                   setAnchorEl(e.currentTarget);
                   onChange(key);
+                  parentOnClick?.(e);
                 }}
                 hasInvertedStyle={hasInvertedStyle}
                 isNarrow={isNarrow}


### PR DESCRIPTION
## Summary

**NavigationHeader**
Jira Ticket: https://czi.atlassian.net/browse/SCIDS-1162

VCP Bug Report: 

> The `guide_navbar_clicked` event is broken. I just realized it wasn't firing when you clicked the Tutorial drop down in the top nav bar and checked Amplitude which says it hasn't seen the event since June 20th. 

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
