### PR TITLE
fix(navigationheader): fixed dark mode and inverted mode styles

### DIFF
--- a/packages/components/src/core/NavigationHeader/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/NavigationHeader/__tests__/__snapshots__/index.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`<NavigationHeder /> Default story renders snapshot 1`] = `
       </button>
     </section>
     <section
-      class="css-cfbgjd"
+      class="css-1yzs9wj"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1o8pmhx-MuiButtonBase-root-MuiButton-root"
@@ -495,7 +495,7 @@ exports[`<NavigationHeder /> DropdownWithSections story renders snapshot 1`] = `
       </button>
     </section>
     <section
-      class="css-cfbgjd"
+      class="css-1yzs9wj"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-9jgpsg-MuiButtonBase-root-MuiButton-root"
@@ -777,7 +777,7 @@ exports[`<NavigationHeder /> matches the snapshot 1`] = `
         </button>
       </section>
       <section
-        class="css-cfbgjd"
+        class="css-1yzs9wj"
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1o8pmhx-MuiButtonBase-root-MuiButton-root"

--- a/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
+++ b/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
@@ -168,10 +168,14 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
                           <StyledDivider
                             hasSection={!!section}
                             isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
                           />
                         )}
                         {section && hasMultipleSections && (
-                          <StyledSectionHeader isNarrow={isNarrow}>
+                          <StyledSectionHeader
+                            isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
+                          >
                             {section}
                           </StyledSectionHeader>
                         )}
@@ -233,10 +237,14 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
                           <StyledDivider
                             hasSection={!!section}
                             isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
                           />
                         )}
                         {section && hasMultipleSections && (
-                          <StyledSectionHeader isNarrow={isNarrow}>
+                          <StyledSectionHeader
+                            isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
+                          >
                             {section}
                           </StyledSectionHeader>
                         )}

--- a/packages/components/src/core/NavigationHeader/components/NavigationHeaderSecondaryNav/index.tsx
+++ b/packages/components/src/core/NavigationHeader/components/NavigationHeaderSecondaryNav/index.tsx
@@ -122,10 +122,14 @@ export default function NavigationHeaderSecondaryNav({
                           <StyledDivider
                             hasSection={!!section}
                             isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
                           />
                         )}
                         {section && hasMultipleSections && (
-                          <StyledSectionHeader isNarrow={isNarrow}>
+                          <StyledSectionHeader
+                            isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
+                          >
                             {section}
                           </StyledSectionHeader>
                         )}
@@ -185,10 +189,14 @@ export default function NavigationHeaderSecondaryNav({
                           <StyledDivider
                             hasSection={!!section}
                             isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
                           />
                         )}
                         {section && hasMultipleSections && (
-                          <StyledSectionHeader isNarrow={isNarrow}>
+                          <StyledSectionHeader
+                            isNarrow={isNarrow}
+                            hasInvertedStyle={hasInvertedStyle}
+                          >
                             {section}
                           </StyledSectionHeader>
                         )}

--- a/packages/components/src/core/NavigationHeader/components/style.ts
+++ b/packages/components/src/core/NavigationHeader/components/style.ts
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 import {
   CommonThemeProps,
   fontCapsXxxxs,
-  getBorders,
   getSemanticColors,
   getSpaces,
   Spaces,
@@ -43,17 +42,37 @@ export const StyledSectionHeader = styled(ListSubheader, {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
   ${(props: ExtraHeaderProps) => {
-    const { isNarrow } = props;
+    const { isNarrow, hasInvertedStyle } = props;
 
     const semanticColors = getSemanticColors(props);
     const spaces = getSpaces(props);
+
+    function getBackgroundColor() {
+      if (isNarrow) {
+        return hasInvertedStyle
+          ? semanticColors?.base.backgroundPrimaryInverse
+          : semanticColors?.base.backgroundPrimary;
+      }
+
+      return semanticColors?.base?.surface;
+    }
+
+    function getTextColor() {
+      if (isNarrow) {
+        return hasInvertedStyle
+          ? semanticColors?.base.textSecondaryInverse
+          : semanticColors?.base.textSecondary;
+      }
+
+      return semanticColors?.base?.textSecondary;
+    }
 
     return css`
       &.MuiListSubheader-root {
         ${fontCapsXxxxs(props)}
         top: 0;
-        color: ${semanticColors?.base?.textSecondary};
-        background-color: ${semanticColors?.base?.surface};
+        color: ${getTextColor()};
+        background-color: ${getBackgroundColor()};
         padding: ${spaces?.xxs}px ${isNarrow ? spaces?.xl : spaces?.s}px;
         margin-bottom: 0;
       }
@@ -64,27 +83,38 @@ export const StyledSectionHeader = styled(ListSubheader, {
 interface StyledDividerProps extends CommonThemeProps {
   hasSection?: boolean;
   isNarrow?: boolean;
+  hasInvertedStyle?: boolean;
 }
 
 export const StyledDivider = styled(Divider, {
   shouldForwardProp: (prop: string) => !doNotForwardProps.includes(prop),
 })`
   ${(props: StyledDividerProps) => {
-    const { hasSection, isNarrow } = props;
+    const { hasSection, isNarrow, hasInvertedStyle } = props;
 
     const spaces = getSpaces(props);
-    const borders = getBorders(props);
+    const semanticColors = getSemanticColors(props);
 
     // Calculate margin based on section and narrow state
     const getMarginBottom = () => {
       return hasSection ? spaces?.s : isNarrow ? 0 : spaces?.xxs;
     };
 
+    const getBorderColor = () => {
+      if (isNarrow) {
+        return hasInvertedStyle
+          ? semanticColors?.base?.dividerInverse
+          : semanticColors?.base?.divider;
+      }
+
+      return semanticColors?.base?.divider;
+    };
+
     return css`
       &.MuiDivider-root {
         position: relative;
         margin: 0 0 ${getMarginBottom()}px;
-        border-bottom: ${borders?.base?.divider};
+        border-bottom: solid 1px ${getBorderColor()};
         padding-bottom: ${isNarrow ? 0 : spaces?.xxs}px;
       }
     `;

--- a/packages/components/src/core/NavigationHeader/style.ts
+++ b/packages/components/src/core/NavigationHeader/style.ts
@@ -495,6 +495,7 @@ export const StyledButtonSection = styled("section", {
 })`
   display: flex;
   align-items: center;
+  z-index: 10;
 
   .MuiButtonBase-root {
     ${fontBody("l", "semibold", /* isNarrow */ true)}


### PR DESCRIPTION
## Summary

**NavigationHeader**

Jira issue: https://czi.atlassian.net/browse/SCIDS-1205?atlOrigin=eyJpIjoiNjkyMWEzOGNkY2ExNDk3ZDlkMmNhZDRlNDY5YzRmNTAiLCJwIjoiaiJ9

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
