### PR TITLE
fix(inputdropdown): fix label

### DIFF
--- a/packages/components/src/core/ComplexFilter/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/ComplexFilter/__tests__/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<ComplexFilter /> Default story renders snapshot 1`] = `
     width="250"
   >
     <span
-      class="css-1lgdwzz"
+      class="css-g6qgry"
     >
       <div>
         <span

--- a/packages/components/src/core/Dropdown/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/Dropdown/__tests__/__snapshots__/index.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
   aria-expanded="false"
   aria-haspopup="listbox"
   aria-label="Dropdown input"
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1iba8vc-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-phif88-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"
 >
   <span
-    class="css-1lgdwzz"
+    class="css-g6qgry"
   >
     <div>
       <span
@@ -51,13 +51,13 @@ exports[`<Dropdown /> MultiColumnWithButtons story renders snapshot 1`] = `
   aria-expanded="false"
   aria-haspopup="listbox"
   aria-label="Dropdown input"
-  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1iba8vc-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-phif88-MuiButtonBase-root-MuiButton-root"
   label="Click Target"
   tabindex="0"
   type="button"
 >
   <span
-    class="css-1lgdwzz"
+    class="css-g6qgry"
   >
     <div>
       <span

--- a/packages/components/src/core/InputDropdown/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/InputDropdown/__storybook__/index.stories.tsx
@@ -59,7 +59,7 @@ export default {
     },
     width: {
       control: {
-        type: "number",
+        type: "text",
       },
     },
   },

--- a/packages/components/src/core/InputDropdown/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputDropdown/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`<InputDropdown /> Default story renders snapshot 1`] = `
 <div>
   <button
     aria-label="Dropdown input"
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1iba8vc-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-phif88-MuiButtonBase-root-MuiButton-root"
     data-testid="InputDropdown"
     label="Label"
     tabindex="0"
     type="button"
   >
     <span
-      class="css-1lgdwzz"
+      class="css-g6qgry"
     >
       <div>
         <span

--- a/packages/components/src/core/InputDropdown/index.tsx
+++ b/packages/components/src/core/InputDropdown/index.tsx
@@ -139,7 +139,14 @@ function renderLabelTypeLabelText({
 }: RenderLabelTextProps) {
   if (isMinimal) return label;
 
-  return (counter || value) && shouldPutAColonAfterLabel ? `${label}:` : label;
+  return (counter || value) && shouldPutAColonAfterLabel ? (
+    <>
+      {label}
+      {":"}
+    </>
+  ) : (
+    label
+  );
 }
 
 function renderValueTypeLabelText({
@@ -154,14 +161,26 @@ function renderValueTypeLabelText({
   if (!value || multiple) {
     if (isMinimal) return label;
 
-    return !!counter && shouldPutAColonAfterLabel ? `${label}:` : label;
+    return !!counter && shouldPutAColonAfterLabel ? (
+      <>
+        {label}
+        {":"}
+      </>
+    ) : (
+      label
+    );
   }
 
   if (isMinimal) return value;
 
-  return (!!counter || !!details) && shouldPutAColonAfterLabel
-    ? `${value}:`
-    : value;
+  return (!!counter || !!details) && shouldPutAColonAfterLabel ? (
+    <>
+      {value}
+      {":"}
+    </>
+  ) : (
+    value
+  );
 }
 
 function renderDetailsText({

--- a/packages/components/src/core/InputDropdown/style.ts
+++ b/packages/components/src/core/InputDropdown/style.ts
@@ -52,7 +52,7 @@ export interface InputDropdownProps
   value?: ReactNode;
   shouldTruncateMinimalDetails?: boolean;
   shouldPutAColonAfterLabel?: boolean;
-  width?: number;
+  width?: string;
   className?: string;
   // (masoudmanson): This is a temporary fix for the issue where the style prop
   // is not correctly passed to the underlying Button component when asserting as
@@ -78,7 +78,7 @@ const inputDropdownStyles = (props: InputDropdownProps): SerializedStyles => {
     cursor: pointer;
     padding: ${spaces?.xs}px ${spaces?.m}px;
     justify-content: start;
-    width: ${width}px;
+    width: ${/^\d+$/.test(width) ? `${width}px` : width};
     min-width: 90px !important;
 
     &.MuiButton-text {
@@ -500,7 +500,7 @@ export const LabelWrapper = styled("span", {
     align-items: center;
     display: inline-flex;
     justify-content: start;
-    width: calc(100% - 24px); /* 24px is the width of the icon */
+    width: 100%;
     overflow: hidden;
   }
 `;


### PR DESCRIPTION
## Summary

**InputDropdown**

Slack issue: https://czi-sci.slack.com/archives/C032S43KKFV/p1759560447385269

we're seeing a small bug in the label for the Dropdown component in sds. If I create a new sds app using:
```
$ npx create-next-app --example https://github.com/chanzuckerberg/create-sds-app tmp
$ cd tmp && yarn
```
and then make the following change (wrap the label in an element:
```
diff --git a/app/page.tsx b/app/page.tsx
index 2229e24..48eaf54 100644
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ export default function Home() {
       <CodeExampleWrapper>
         <p>Example SDS Dropdown:</p>
         <Dropdown
-          label="Select Size"
+          label=<span>Select Size</span>
           options={sizeOptions}
           value={selectedSize}
           multiple={false}
```
We see the `[object Object]` in the dropdown rather than the label (see screenshot below). Interestingly, if we add `shouldPutAColonAfterLabel: false`, to `InputDropdownProps` , the issue goes away, which I hope helps debugging! Thanks for any help you can provide with this. 

<img width="480" height="295" alt="image" src="https://github.com/user-attachments/assets/883b3d6b-7cfc-4e66-a292-598a9020e6bf" />
