### PR TITLE
refactor(inputradio): ReactNode for caption and tailwind classes support

### DIFF
--- a/packages/components/src/core/InputRadio/__storybook__/index.stories.tsx
+++ b/packages/components/src/core/InputRadio/__storybook__/index.stories.tsx
@@ -24,6 +24,9 @@ export default {
       },
       options: ["checked", "unchecked"],
     },
+    classes: {
+      control: { type: "object" },
+    },
   },
   component: InputRadio,
   title: "Components/Inputs/InputRadio",
@@ -37,6 +40,16 @@ export const Default = {
     disabled: false,
     intent: "default",
     label: "Label",
+    classes: {
+      root: "",
+      labelCaptionContainer: "",
+      label: "",
+      caption: "",
+      radioButton: "",
+      radioCheckedIcon: "",
+      radioCheckedIconDot: "",
+      radioDefaultIcon: "",
+    },
   },
 };
 

--- a/packages/components/src/core/InputRadio/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/InputRadio/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<InputRadio /> Default story renders snapshot 1`] = `
   >
     <span
       caption="Caption"
-      class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1h62c7l-MuiButtonBase-root-MuiRadio-root"
+      class="MuiButtonBase-root PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary css-1h62c7l-MuiButtonBase-root-MuiRadio-root"
       intent="default"
     >
       <input

--- a/packages/components/src/core/InputRadio/index.tsx
+++ b/packages/components/src/core/InputRadio/index.tsx
@@ -11,15 +11,26 @@ import {
   StyledRadioLabel,
 } from "./style";
 import React from "react";
+import { EMPTY_OBJECT } from "src/common/utils";
 
 export interface RadioContentProps
   extends Omit<MUIRadioProps, "color" | "defaultChecked"> {
-  caption?: string;
+  caption?: React.ReactNode;
   intent?: "default" | "negative" | "notice" | "positive";
   label?: React.ReactNode;
   radioProps?: Partial<MUIRadioProps>;
   stage?: "checked" | "unchecked";
   value?: string;
+  classes?: {
+    root?: string;
+    labelCaptionContainer?: string;
+    label?: string;
+    caption?: string;
+    radioButton?: string;
+    radioCheckedIcon?: string;
+    radioCheckedIconDot?: string;
+    radioDefaultIcon?: string;
+  };
 }
 
 export type RadioProps = RadioContentProps & RadioExtraProps;
@@ -35,11 +46,23 @@ const InputRadio = (props: RadioProps): JSX.Element => {
     radioProps,
     stage,
     value,
+    classes = EMPTY_OBJECT,
   } = props;
 
   // (masoudmanson): We don't need to pass the label prop to the radio component
   // so we are destructuring it here.
   const { label, ...restProps } = props;
+
+  const {
+    root,
+    labelCaptionContainer,
+    label: labelClassName,
+    caption: captionClassName,
+    radioButton: radioButtonClassName,
+    radioCheckedIcon: radioCheckedIconClassName,
+    radioCheckedIconDot: radioCheckedIconDotClassName,
+    radioDefaultIcon: radioDefaultIconClassName,
+  }: RadioProps["classes"] = classes;
 
   let newProps: MUIRadioProps;
   switch (stage) {
@@ -67,13 +90,19 @@ const InputRadio = (props: RadioProps): JSX.Element => {
   const captionId = caption ? `${value}-caption` : undefined;
 
   const finalLabel = caption ? (
-    <StyledLabelContainer>
-      <StyledRadioLabel id={labelId}>{label}</StyledRadioLabel>
-      <StyledRadioCaption id={captionId}>{caption}</StyledRadioCaption>
+    <StyledLabelContainer className={labelCaptionContainer}>
+      <StyledRadioLabel id={labelId} className={labelClassName}>
+        {label}
+      </StyledRadioLabel>
+      <StyledRadioCaption id={captionId} className={captionClassName}>
+        {caption}
+      </StyledRadioCaption>
     </StyledLabelContainer>
   ) : (
-    <StyledLabelContainer>
-      <StyledRadioLabel id={labelId}>{label}</StyledRadioLabel>
+    <StyledLabelContainer className={labelCaptionContainer}>
+      <StyledRadioLabel id={labelId} className={labelClassName}>
+        {label}
+      </StyledRadioLabel>
     </StyledLabelContainer>
   );
 
@@ -81,12 +110,18 @@ const InputRadio = (props: RadioProps): JSX.Element => {
     <StyledFormControlLabel
       control={
         <StyledRadioButton
+          className={radioButtonClassName}
           checkedIcon={
-            <StyledRadioCheckedIcon>
-              <StyledRadioDot />
+            <StyledRadioCheckedIcon className={radioCheckedIconClassName}>
+              <StyledRadioDot className={radioCheckedIconDotClassName} />
             </StyledRadioCheckedIcon>
           }
-          icon={<StyledRadioDefaultIcon intent={intent} />}
+          icon={
+            <StyledRadioDefaultIcon
+              intent={intent}
+              className={radioDefaultIconClassName}
+            />
+          }
           intent={intent}
           {...radioProps}
           {...newProps}
@@ -95,6 +130,7 @@ const InputRadio = (props: RadioProps): JSX.Element => {
       disabled={disabled}
       label={finalLabel}
       value={value}
+      className={root}
     />
   );
 };


### PR DESCRIPTION
## Summary

**InputRadio**

Slack Request: https://czi-sci.slack.com/archives/C032S43KKFV/p1760034026995769

### Changes
1. ReactNode Caption Support

2. Custom Classes Support
Added a new classes prop that accepts an object with customizable className overrides for all internal elements:
`root` - Main FormControlLabel wrapper
`labelCaptionContainer` - Container for label and caption
`label` - Label element
`caption` - Caption element
`radioButton` - Radio button component
`radioCheckedIcon` - Checked state icon
`radioCheckedIconDot` - Inner dot of checked icon
`radioDefaultIcon` - Unchecked state icon