### PR TITLE
fix(notification): fix close button position and styles

### DIFF
--- a/packages/components/src/core/Notification/index.tsx
+++ b/packages/components/src/core/Notification/index.tsx
@@ -3,7 +3,11 @@ import { Box, Slide } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import Button from "src/core/Button";
 import Icon, { IconNameToSizes, IconProps } from "src/core/Icon";
-import { StyledButtonWrapper, StyledNotification } from "./style";
+import {
+  StyledButtonWrapper,
+  StyledCloseButton,
+  StyledNotification,
+} from "./style";
 
 export type NotificationIntentType =
   | "accent"
@@ -105,14 +109,15 @@ const Notification = ({
             onClose={onClose ? handleClose : undefined}
             action={
               onClose ? (
-                <Button
+                <StyledCloseButton
                   onClick={handleClose}
                   sdsStyle="minimal"
                   sdsType="secondary"
                   data-testid="notificationCloseButton"
+                  backgroundOnHover={false}
                 >
                   <Icon sdsIcon="XMark" sdsSize="s" />
-                </Button>
+                </StyledCloseButton>
               ) : null
             }
             icon={getIcon()}

--- a/packages/components/src/core/Notification/style.ts
+++ b/packages/components/src/core/Notification/style.ts
@@ -9,10 +9,10 @@ import {
   getSpaces,
 } from "src/core/styles";
 import { ExposedNotificationProps } from ".";
+import Button from "../Button";
 
 interface NotificationExtraProps
-  extends CommonThemeProps,
-    ExposedNotificationProps {}
+  extends CommonThemeProps, ExposedNotificationProps {}
 
 interface NotificationButtonWrapperProps extends CommonThemeProps {
   buttonPosition?: "left" | "right";
@@ -111,6 +111,18 @@ export const StyledButtonWrapper = styled("div")`
     return `
       display: flex;
       justify-content: ${buttonPosition === "left" ? "flex-start" : "flex-end"};
+    `;
+  }}
+`;
+
+export const StyledCloseButton = styled(Button)`
+  ${(props: CommonThemeProps) => {
+    const spaces = getSpaces(props);
+
+    return `
+      position: absolute;
+      right: ${spaces?.m}px;
+      top: ${spaces?.m}px;
     `;
   }}
 `;


### PR DESCRIPTION
## Summary

**Structural Element:** Notification

Fixes the Notification dismiss (X) control so it sits in the top-right corner per design and no longer shows an unwanted hover background.

- Introduces `StyledCloseButton` with absolute positioning using theme spacing (`spaces.m` for `top` / `right`)
- Swaps the close `action` from a plain `Button` to `StyledCloseButton`
- Sets `backgroundOnHover={false}` on the close control for a minimal dismiss affordance

## Checklist

- [x] Default Story in Storybook _(existing Notification stories)_
- [x] Test Story in Storybook _(not required for this styling fix)_
- [x] Tests written _(snapshot updates for close button markup/styles)_
- [x] Semantic Variables from `defaultTheme.ts` used wherever possible (`getSpaces` for positioning)
- [x] If updating an existing component, depreciate flag has been used where necessary _(N/A — bug fix, no API change)_
- [x] ZeroHeight Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design