### PR TITLE
fix(navigationheader): fix chevron icon sizes

### DIFF
--- a/packages/components/src/core/NavigationHeader/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/components/src/core/NavigationHeader/__tests__/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`<NavigationHeader /> DrawerStyle story renders snapshot 1`] = `
         class="css-v5o7zy e1szsfg80"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-17x9ul4-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-1oxa8py-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -63,7 +63,7 @@ exports[`<NavigationHeader /> DrawerStyle story renders snapshot 1`] = `
           class="css-79elbk e1jzgkxb35"
         >
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             href="https://www.google.com"
             items="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
             rel="noopener noreferrer"
@@ -113,7 +113,7 @@ exports[`<NavigationHeader /> DrawerStyle story renders snapshot 1`] = `
           class="css-79elbk e1jzgkxb35"
         >
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             href="/services"
             items="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
             tabindex="0"
@@ -161,7 +161,7 @@ exports[`<NavigationHeader /> DrawerStyle story renders snapshot 1`] = `
           class="css-79elbk e1jzgkxb35"
         >
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             href="https://www.google.com"
             items="[object Object],[object Object],[object Object]"
             rel="noopener noreferrer"
@@ -216,7 +216,7 @@ exports[`<NavigationHeader /> DrawerStyle story renders snapshot 1`] = `
         class="css-79elbk e1jzgkxb35"
       >
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-v4yuu4-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-kjy7da-MuiButtonBase-root-MuiButton-root"
           href="/research"
           items="[object Object],[object Object]"
           tabindex="0"
@@ -359,7 +359,7 @@ exports[`<NavigationHeader /> DropdownStyle story renders snapshot 1`] = `
         class="css-v5o7zy e1szsfg80"
       >
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
           role="button"
           tabindex="0"
         >
@@ -387,7 +387,7 @@ exports[`<NavigationHeader /> DropdownStyle story renders snapshot 1`] = `
           />
         </a>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -424,7 +424,7 @@ exports[`<NavigationHeader /> DropdownStyle story renders snapshot 1`] = `
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
           items="[object Object],[object Object]"
           tabindex="0"
           type="button"
@@ -550,7 +550,7 @@ exports[`<NavigationHeader /> DropdownStyle story renders snapshot 1`] = `
       class="css-v5o7zy e1szsfg80"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-v4yuu4-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-kjy7da-MuiButtonBase-root-MuiButton-root"
         items="[object Object],[object Object]"
         tabindex="0"
         type="button"
@@ -590,7 +590,7 @@ exports[`<NavigationHeader /> DropdownStyle story renders snapshot 1`] = `
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-v4yuu4-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-kjy7da-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
@@ -795,7 +795,7 @@ exports[`<NavigationHeader /> matches the snapshot 1`] = `
           class="css-v5o7zy e1szsfg80"
         >
           <a
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             role="button"
             tabindex="0"
           >
@@ -823,7 +823,7 @@ exports[`<NavigationHeader /> matches the snapshot 1`] = `
             />
           </a>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -860,7 +860,7 @@ exports[`<NavigationHeader /> matches the snapshot 1`] = `
             />
           </button>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-6frunh-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-12oozbf-MuiButtonBase-root-MuiButton-root"
             items="[object Object],[object Object]"
             tabindex="0"
             type="button"
@@ -986,7 +986,7 @@ exports[`<NavigationHeader /> matches the snapshot 1`] = `
         class="css-v5o7zy e1szsfg80"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-v4yuu4-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-kjy7da-MuiButtonBase-root-MuiButton-root"
           items="[object Object],[object Object]"
           tabindex="0"
           type="button"
@@ -1026,7 +1026,7 @@ exports[`<NavigationHeader /> matches the snapshot 1`] = `
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeLarge MuiButton-textSizeLarge MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-v4yuu4-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary ei1tb9o0 e1gcweb20 css-kjy7da-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >

--- a/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
+++ b/packages/components/src/core/NavigationHeader/components/NavigationHeaderPrimaryNav/index.tsx
@@ -234,6 +234,7 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
           href={defaultUrl}
           target={target}
           rel={rel}
+          size="medium"
         >
           <StyledLabel
             itemType={item.itemType}
@@ -289,6 +290,7 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
           sdsStyle="minimal"
           innerSdsStyle={sdsStyle}
           navVariant="primary"
+          size="medium"
         >
           <StyledLabel
             itemType={item.itemType}
@@ -456,6 +458,7 @@ export default function NavigationHeaderPrimaryNav<T extends string>({
         isNarrow={isNarrow}
         innerSdsStyle={sdsStyle}
         navVariant="primary"
+        size="medium"
       >
         <StyledLabel
           active={isActive}

--- a/packages/components/src/core/NavigationHeader/components/NavigationHeaderSecondaryNav/index.tsx
+++ b/packages/components/src/core/NavigationHeader/components/NavigationHeaderSecondaryNav/index.tsx
@@ -168,6 +168,7 @@ export default function NavigationHeaderSecondaryNav<T extends string>({
           href={defaultUrl}
           target={target}
           rel={rel}
+          size="medium"
         >
           <StyledLabelTextWrapper active={isDrawerOpen} isNarrow={isNarrow}>
             {label as ReactNode}
@@ -209,6 +210,7 @@ export default function NavigationHeaderSecondaryNav<T extends string>({
             setActiveDropdownKey(key);
             parentOnClick?.(e);
           }}
+          size="medium"
         >
           <StyledLabelTextWrapper active={isDropdownOpen} isNarrow={isNarrow}>
             {label as ReactNode}
@@ -353,6 +355,7 @@ export default function NavigationHeaderSecondaryNav<T extends string>({
         isNarrow={isNarrow}
         sdsStyle="minimal"
         navVariant="secondary"
+        size="medium"
       >
         {label as ReactNode}
         {tag && (


### PR DESCRIPTION
## Summary

**NavigationHeader**

The chevron icons in the Primary and Secondary Nav Items were larger than the icons defined in the design. This PR fixes the size inconsistency.

Before:

https://github.com/user-attachments/assets/69a407f9-1472-4b2e-89c4-17a4b192d476

After:

https://github.com/user-attachments/assets/18f61dba-3b8c-4a98-9e1e-28065a333d70

