### PR TITLE
feat(workflows): update workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Summary
 
 **Structural Element (Base, Gene, DNA, Chromosome or Cell)**
-Github issue: [#XXXX](link)
+Jira issue: [#XXXX](link)
 
 Copy issue description here
 
@@ -12,5 +12,5 @@ Copy issue description here
 - [ ] Tests written
 - [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
 - [ ] If updating an existing component, depreciate flag has been used where necessary
-- [ ] ZeroHeight Documents updated
+- [ ] Documents updated
 - [ ] Chromatic build verified by @chanzuckerberg/sds-design

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       # Step 1: Checkout the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds
@@ -30,7 +30,7 @@ jobs:
 
       # Step 4: Publish the project to Chromatic
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v17
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Authenticate using the GitHub token
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }} # Provide the Chromatic project token for authentication

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       # Step 1: Use the 'amannn/action-semantic-pull-request' action to validate the PR commit
-      - uses: amannn/action-semantic-pull-request@v3.4.2
+      - uses: amannn/action-semantic-pull-request@v6
         with:
           validateSingleCommit: true # Specify to validate a single commit
         env:

--- a/.github/workflows/namespace-check.yml
+++ b/.github/workflows/namespace-check.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds
@@ -46,13 +46,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds
@@ -74,13 +74,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js and Cache yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds
@@ -75,7 +75,7 @@ jobs:
       - name: Commit changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(release): Publish"
           branch: ${{ github.head_ref }}
@@ -104,7 +104,7 @@ jobs:
         id: createpr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             const ownerAndRepo = '${{ github.repository }}';
@@ -160,7 +160,7 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: prod
@@ -189,6 +189,6 @@ jobs:
     steps:
       # Step 1: Create a GitHub release for the latest version
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "${{ matrix.cfg.name }}@${{ matrix.cfg.version }}"

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       # Step 1: Check out the repository code
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       # Step 2: Set up Node.js environment and cache Yarn dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version" # Specify the Node.js version from '.node-version' file
           cache: "yarn" # Cache Yarn dependencies for faster builds

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The Science Design System (SDS) brings consistency and universal standards to CZ
 
 NOTE: Since most of the czi-sds components are built on top of Material UI's equivalent, it's also super useful to use their [API documentation](https://mui.com/) to learn about what you can do with the components. Many czi-sds components are style wrappers that pass props through to the MUI component without modifying them.
 
-## Migrating to SDS 24.0.0
+## Migrating to SDS 23.8.0 (Material UI v9)
 
-SDS `24.0.0` is a **breaking release** that moves the Material UI peer dependency from v5 to v9. If you are upgrading an existing app from an older `@czi-sds/components` version, follow the step-by-step guide in [MIGRATION.md](./MIGRATION.md).
+SDS `23.8.0` is a **breaking release** that moves the Material UI peer dependency from v5 to v9. If you are upgrading an existing app from an older `@czi-sds/components` version, follow the step-by-step guide in [migration-docs/migrate-to-23.8.0.md](./migration-docs/migrate-to-23.8.0.md). If a newer version of SDS is published, install that one instead — the same MUI v9 migration steps apply.
 
 That guide covers dependency updates, MUI import and prop API changes (`slots` / `slotProps`), SDS-specific call-site updates, icon renames, and a verification checklist.
 

--- a/migration-docs/migrate-to-23.8.0.md
+++ b/migration-docs/migrate-to-23.8.0.md
@@ -1,6 +1,6 @@
-# Migration Guide: SDS 24.0.0 (Material UI v9)
+# Migration Guide: SDS 23.8.0 (Material UI v9)
 
-This guide is for upgrading **older versions of SDS** to **`@czi-sds/components@24.0.0`** (and the matching `@czi-sds/data-viz` release). That major moves the MUI peer dependency from **Material UI v5** to **Material UI v9**. This is a **breaking release**.
+This guide is for upgrading **older versions of SDS** to **`@czi-sds/components@23.8.0`** (and the matching `@czi-sds/data-viz` release). That major moves the MUI peer dependency from **Material UI v5** to **Material UI v9**. This is a **breaking release**.
 
 > The SDS components themselves have been fully migrated internally. Most of the work in this guide is about (1) your project's dependencies and (2) any MUI props or types you pass _through_ SDS components or import directly from MUI.
 
@@ -28,11 +28,19 @@ This guide is for upgrading **older versions of SDS** to **`@czi-sds/components@
 
 ## For AI coding agents — read first
 
-You are upgrading a **consumer project** that depends on `@czi-sds/components` (and possibly `@czi-sds/data-viz`) from an older SDS version to **`@czi-sds/components@24.0.0`**, which moves the MUI peer dependency from **v5 to v9**. Follow this playbook top to bottom. Do not stop at the first error — collect and fix all categories below, then verify.
+> **⚠️ Target the latest SDS version, not necessarily `23.8.0`.** `23.8.0` is the **first** release on the Material UI v9 peer-dependency line and is used throughout this guide as the reference version. Before you start, check the latest published version:
+>
+> ```bash
+> npm view @czi-sds/components version
+> ```
+>
+> If a newer `@czi-sds/components` (and the matching `@czi-sds/data-viz`) is available, install **that** version instead — every migration step in this guide still applies, since any version `>= 23.8.0` is on MUI v9. Substitute the latest version wherever `23.8.0` appears below. Only pin to `23.8.0` if the latest version fails to install or introduces changes not covered here.
+
+You are upgrading a **consumer project** that depends on `@czi-sds/components` (and possibly `@czi-sds/data-viz`) from an older SDS version to **`@czi-sds/components@23.8.0` or later**, which moves the MUI peer dependency from **v5 to v9**. Follow this playbook top to bottom. Do not stop at the first error — collect and fix all categories below, then verify.
 
 ### Objective
 
-Make the consumer project install **SDS 24.0.0** + MUI v9 peer deps and compile, build, and test cleanly, by updating **only the consumer's own code and config** to the new APIs described in this guide.
+Make the consumer project install **SDS 23.8.0** + MUI v9 peer deps and compile, build, and test cleanly, by updating **only the consumer's own code and config** to the new APIs described in this guide.
 
 ### Operating rules (guardrails)
 
@@ -70,9 +78,9 @@ Work through these once, top to bottom. The order matters: deps must change **be
 
 ## At a glance
 
-| Area                  | Before                        | After (SDS 24.0.0)                                                                                                                                        |
+| Area                  | Before                        | After (SDS 23.8.0)                                                                                                                                        |
 | --------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@czi-sds/components` | `< 24` (MUI v5 peers)         | `24.0.0` (MUI v9 peers)                                                                                                                                   |
+| `@czi-sds/components` | `< 24` (MUI v5 peers)         | `23.8.0` (MUI v9 peers)                                                                                                                                   |
 | `@mui/material`       | `^5.16.8`                     | `^9.0.0`                                                                                                                                                  |
 | `@mui/icons-material` | `^5.16.8`                     | `^9.0.0`                                                                                                                                                  |
 | `@mui/base`           | `5.0.0-beta.70`               | **removed** (merged into `@mui/material`)                                                                                                                 |
@@ -108,7 +116,7 @@ Decision rules derived from the above:
 - **Next.js present** ⇒ also bump `@mui/material-nextjs` ([Step 1](#step-1--update-dependencies)).
 - **`@mui/base` imports** ⇒ always migrate off `@mui/base` and uninstall it ([Step 3](#step-3--update-mui-imports-muibase-removed-alert-left-muilab)).
 - **`@mui/lab` imports** ⇒ do **not** uninstall yet. After moving `Alert` / `AlertProps` to `@mui/material` ([Step 3](#step-3--update-mui-imports-muibase-removed-alert-left-muilab)), re-check: remove `@mui/lab` only if nothing still imports from it. Keep (and bump to a v9-compatible version) if the app still uses other lab exports (e.g. `Timeline`, `LoadingButton`).
-- Record the current SDS version so you can confirm it moved to **`@czi-sds/components@24.0.0`** after install.
+- Record the current SDS version so you can confirm it moved to **`@czi-sds/components@23.8.0`** after install.
 
 ---
 
@@ -118,10 +126,10 @@ SDS peer dependencies changed. Update your `package.json` to install MUI v9 and 
 
 ```bash
 # with npm
-npm i @czi-sds/components@24.0.0 @emotion/css @emotion/react @emotion/styled @mui/material@^9 @mui/icons-material@^9 react react-dom
+npm i @czi-sds/components@23.8.0 @emotion/css @emotion/react @emotion/styled @mui/material@^9 @mui/icons-material@^9 react react-dom
 
 # with yarn
-yarn add @czi-sds/components@24.0.0 @emotion/css @emotion/react @emotion/styled @mui/material@^9 @mui/icons-material@^9 react react-dom
+yarn add @czi-sds/components@23.8.0 @emotion/css @emotion/react @emotion/styled @mui/material@^9 @mui/icons-material@^9 react react-dom
 ```
 
 Always remove `@mui/base`:
@@ -165,7 +173,7 @@ react                 (>=18)
 react-dom             (>=18)
 ```
 
-> If you use `@czi-sds/data-viz`, bump it to the release published with SDS 24.0.0 — it has the same MUI v9 peer-dependency requirements.
+> If you use `@czi-sds/data-viz`, bump it to the release published with SDS 23.8.0 — it has the same MUI v9 peer-dependency requirements.
 
 ---
 
@@ -560,7 +568,7 @@ rg -n "@mui/lab" --glob '!**/node_modules/**'    # expect: none, OR only intenti
 
 Then confirm each item:
 
-- [ ] `@czi-sds/components` is on `24.0.0` (or a compatible `^24` release) in `package.json`.
+- [ ] `@czi-sds/components` is on `23.8.0` (or a compatible `^24` release) in `package.json`.
 - [ ] `@mui/material` and `@mui/icons-material` are on `^9` in `package.json`.
 - [ ] `@mui/base` is removed from `package.json`.
 - [ ] `@mui/lab` decision applied: removed if unused after the `Alert` / `AlertProps` move; kept and bumped to a v9-compatible major if anything still imports from it.


### PR DESCRIPTION
## Summary

**Structural Element (Base, Gene, DNA, Chromosome or Cell)**
Base

Jira issue: [#XXXX](link)

Two related maintenance updates:

1. **CI: bump all GitHub Actions to Node 24 runtimes.** GitHub began forcing Node 20 actions onto Node 24 in June 2026 and will remove Node 20 entirely in fall 2026, which was surfacing deprecation warnings in our Release workflow (e.g. `actions/checkout@v3`, `actions/github-script@v6`, `actions/setup-node@v3`, `stefanzweifel/git-auto-commit-action@v4`).
2. **Docs: fix and clarify the migration guide references.** Point the README at the correct migration doc and tell readers/AI agents to target the latest published SDS version rather than pinning to `23.8.0`.

### CI / workflow changes

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v3` | `v7` |
| `actions/setup-node` | `v3` | `v7` |
| `actions/github-script` | `v6` | `v9` |
| `stefanzweifel/git-auto-commit-action` | `v4` | `v7` |
| `softprops/action-gh-release` | `v1` | `v3` |
| `amannn/action-semantic-pull-request` | `v3.4.2` | `v6` |
| `chromaui/action` | `v1` | `v17` |
| `JamesIves/github-pages-deploy-action` | `v4` | `v4` (already Node 24) |

Files touched: `release.yml`, `push-tests.yml`, `namespace-check.yml`, `storybook.yml`, `storybook-tests.yml`, `chromatic.yml`, `commitlint.yml`.

### Docs changes

- **`README.md`** — the migration section previously advertised "SDS 24.0.0" and linked to `MIGRATION.md`, which no longer exists (broken link). Updated the heading to the actual published version (`23.8.0`, Material UI v9) and repointed the link to `./migration-docs/migrate-to-23.8.0.md`. Added a note to install a newer version if one is published.
- **`migration-docs/migrate-to-23.8.0.md`** — added a callout in the "For AI coding agents — read first" section instructing agents to check `npm view @czi-sds/components version` and install the latest version instead of pinning `23.8.0` (any version `>= 23.8.0` is on MUI v9, so the same steps apply).

### Notes
- All updated actions require Actions runner `v2.327.1+`, which GitHub-hosted `ubuntu-latest` already provides.
- `actions/github-script@v9` is ESM-only (`require('@actions/github')` no longer works). Our `release.yml` script only uses the injected `github.rest.*` client, so it's unaffected.
- `chromaui/action` and `amannn/action-semantic-pull-request` are major bumps; existing inputs/config remain compatible.
- Commented-out steps in `release.yml` were left untouched.

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design