### PR TITLE
chore: Pin SDS as peer dependency of data-vis

### DIFF
--- a/packages/data-viz/package.json
+++ b/packages/data-viz/package.json
@@ -53,6 +53,7 @@
     "namespace-check": "tsc --p tsconfig-namespace-check.json"
   },
   "peerDependencies": {
+    "@czi-sds/components": "^24.0.0",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/packages/data-viz/package.json
+++ b/packages/data-viz/package.json
@@ -54,10 +54,7 @@
   },
   "peerDependencies": {
     "@czi-sds/components": "^24.0.0",
-    "@emotion/css": "^11.11.2",
-    "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "echarts": "^6.0.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,6 +1894,7 @@ __metadata:
     simplex-noise: "npm:^4.0.1"
     style-dictionary: "npm:^4.1.0"
   peerDependencies:
+    "@czi-sds/components": ^24.0.0
     "@emotion/css": ^11.11.2
     "@emotion/react": ^11.11.3
     "@emotion/styled": ^11.11.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,7 @@ __metadata:
     style-dictionary: "npm:^4.1.0"
   peerDependencies:
     "@czi-sds/components": ^24.0.0
-    "@emotion/css": ^11.11.2
-    "@emotion/react": ^11.11.3
     "@emotion/styled": ^11.11.0
-    "@mui/icons-material": ^9.0.0
     "@mui/material": ^9.0.0
     echarts: ^6.0.0
     lodash: ^4.17.21


### PR DESCRIPTION
## Summary

BREAKING CHANGES: Previously, `components` was being inlined into the index file of `data-viz` at whatever `main` was when the package was published, instead of being a real NPM `dependency`. This meant that:

- The SDS components would be inconsistent between `components` and `data-viz`.
- `data-viz` had to list the dependencies of SDS as its own dependencies instead of just letting NPM take care of it, which confuses Rolldown because it sees `dependencies` of `data-viz` that aren't actually being used by `data-viz` (just `components`), causing it to produce weird imports. One of those imports triggers a bug in Turbopack that makes the current version of `data-viz` break with latest Next.js.

```
┌─────────────────────────────────┬──────────────────┬──────────────────┐
│              File               │ Before (inlined) │ After (peer dep) │
├─────────────────────────────────┼──────────────────┼──────────────────┤
│ index.esm.js                    │ 1,018 kB         │ 34 kB            │
├─────────────────────────────────┼──────────────────┼──────────────────┤
│ index.cjs.js                    │ 1,287 kB         │ 37 kB            │
├─────────────────────────────────┼──────────────────┼──────────────────┤
│ index.esm.d.ts / index.cjs.d.ts │ 160 kB each      │ 11 kB each       │
└─────────────────────────────────┴──────────────────┴──────────────────┘
```

## Checklist

- [ ] Default Story in Storybook
- [ ] Test Story in Storybook
- [ ] Tests written
- [ ] Semantic Variables from `defaultTheme.ts` used wherever possible
- [ ] If updating an existing component, depreciate flag has been used where necessary
- [ ] Documents updated
- [ ] Chromatic build verified by @chanzuckerberg/sds-design
