### PR TITLE
feat(release): release data-viz 1.0.0

### DIFF
--- a/packages/data-viz/README.md
+++ b/packages/data-viz/README.md
@@ -9,10 +9,8 @@ Full documentation (usage, scripts, contributing) lives in the [repository READM
 Peer dependencies:
 
 ```
-@emotion/css
-@emotion/react
+@czi-sds/components
 @emotion/styled
-@mui/icons-material
 @mui/material
 echarts
 lodash
@@ -22,10 +20,10 @@ react-dom
 
 ```bash
 # npm
-npm i @czi-sds/data-viz @czi-sds/components @emotion/css @emotion/react @emotion/styled @mui/material @mui/icons-material echarts lodash react react-dom
+npm i @czi-sds/data-viz @czi-sds/components @emotion/styled @mui/material echarts lodash react react-dom
 
 # yarn
-yarn add @czi-sds/data-viz @czi-sds/components @emotion/css @emotion/react @emotion/styled @mui/material @mui/icons-material echarts lodash react react-dom
+yarn add @czi-sds/data-viz @czi-sds/components @emotion/styled @mui/material echarts lodash react react-dom
 ```
 
 > **React 18 note:** Material UI ships `react-is@19`. If your app uses React 18, pin `react-is` to match (Yarn `resolutions` / npm `overrides`), e.g. `"react-is": "^18.3.1"`.


### PR DESCRIPTION
## Summary

Follow-up to #1156, which pinned `@czi-sds/components` as a peer dependency of `@czi-sds/data-viz` but was typed `chore:`, so Lerna only published a patch (`0.20.1`). This PR carries the `BREAKING CHANGE` marker so the next release bumps `@czi-sds/data-viz` to `1.0.0`, and updates the README peer-dependency docs to match.

BREAKING CHANGE: `@czi-sds/components@^24.0.0` is now a required peer dependency of `@czi-sds/data-viz`; `@emotion/css`, `@emotion/react`, and `@mui/icons-material` are no longer peer dependencies.

> **Note for merging:** squash-merge and keep the `BREAKING CHANGE:` line in the squashed commit body — Lerna reads it to compute the major bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)