### PR TITLE
fix(docs): fix doc pages snapshot generator script

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,9 +7,21 @@ import { fileURLToPath } from "url";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 import type { Plugin } from "vite";
+import { generateDocSnapshots } from "../docs-kit/scripts/generate-doc-snapshots.mjs";
 
 const require = createRequire(import.meta.url);
 const currentDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Write the documentation snapshot stories the glob below picks up, here rather
+ * than in the yarn scripts that start and build Storybook. A stories glob that
+ * matches nothing is not an error, so generating them anywhere Storybook itself
+ * does not reach means any other way in — `storybook build` on its own, a
+ * Chromatic build pointed at a different script — silently snapshots none of
+ * the documentation. This runs on every way in, and throws rather than let that
+ * happen quietly.
+ */
+generateDocSnapshots();
 
 const COMPONENTS_SRC = resolve(currentDir, "../packages/components/src");
 const DATA_VIZ_SRC = resolve(currentDir, "../packages/data-viz/src");
@@ -38,11 +50,11 @@ const config: StorybookConfig = {
     // The live code playground the docs' examples link out to.
     "../playground/*.stories.tsx",
     /**
-     * A story per documentation page, written from the pages themselves by
-     * `docs-kit/scripts/generate-doc-snapshots.mjs` before Storybook starts or
-     * builds. Chromatic snapshots stories and not `docs` entries, so this is
-     * what puts the documentation in front of a visual review. They are hidden
-     * from the sidebar, the pages above being the ones to read.
+     * A story per documentation page, written from the pages themselves by the
+     * `generateDocSnapshots()` call above. Chromatic snapshots stories and not
+     * `docs` entries, so this is what puts the documentation in front of a
+     * visual review. They are hidden from the sidebar, the pages above being
+     * the ones to read.
      */
     "../docs-kit/generated/*.stories.tsx",
   ],

--- a/docs-kit/scripts/generate-doc-snapshots.mjs
+++ b/docs-kit/scripts/generate-doc-snapshots.mjs
@@ -15,10 +15,14 @@
  * parameters keeps the test suites off content whose components they cover
  * already.
  *
+ * `.storybook/main.ts` calls this on the way in, so that the stories are there
+ * however Storybook was started rather than only through the yarn scripts.
+ *
  * Run: node docs-kit/scripts/generate-doc-snapshots.mjs
  */
 
 import {
+  existsSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -186,56 +190,103 @@ ${body
 `;
 }
 
-const pages = SEARCH.flatMap(walk).filter((path) =>
-  PAGES.some((pattern) => pattern.test(path))
-);
+/**
+ * Bring `docs-kit/generated` to the given stories and leave the rest of it
+ * alone: a file already holding what it should is not rewritten.
+ *
+ * The directory is reconciled rather than emptied and rebuilt because this runs
+ * whenever Storybook's config is loaded, which is more than once — a dev server
+ * and the Vitest addon can be reading the same checkout — and emptying it out
+ * from under a running watcher is not something to do for nothing.
+ */
+function reconcile(stories) {
+  mkdirSync(OUT_DIR, { recursive: true });
 
-rmSync(OUT_DIR, { force: true, recursive: true });
-mkdirSync(OUT_DIR, { recursive: true });
-
-const skipped = [];
-const omitted = [];
-const taken = new Map();
-
-for (const path of pages.sort()) {
-  const page = parse(path);
-
-  if (!page.title) {
-    skipped.push(`${path} (${page.reason})`);
-    continue;
+  for (const file of readdirSync(OUT_DIR)) {
+    if (!stories.has(file)) rmSync(resolve(OUT_DIR, file), { recursive: true });
   }
 
-  if (TOO_TALL.has(page.title)) {
-    omitted.push(page.title);
-    continue;
+  for (const [file, { source }] of stories) {
+    const path = resolve(OUT_DIR, file);
+
+    if (existsSync(path) && readFileSync(path, "utf-8") === source) continue;
+
+    writeFileSync(path, source);
   }
-
-  const file = filename(page.title);
-  const owner = taken.get(file);
-
-  // Two titles that come down to the same name would leave one page writing
-  // over the other's story, and the page written over silently unsnapshotted.
-  if (owner) {
-    skipped.push(`${path} (its title is ${owner}'s once slugged)`);
-    continue;
-  }
-
-  taken.set(file, path);
-  writeFileSync(resolve(OUT_DIR, file), story({ ...page, path }));
 }
 
-const written = taken.size;
-
-process.stdout.write(
-  `Wrote ${written} documentation snapshot ${written === 1 ? "story" : "stories"} to docs-kit/generated` +
-    (omitted.length > 0
-      ? `, leaving out ${omitted.join(" and ")} as too tall for Chromatic to capture\n`
-      : "\n")
-);
-
-if (skipped.length > 0) {
-  process.stdout.write(
-    `Warning: no snapshot story for ${skipped.join(", ")}. ` +
-      "Chromatic will not see changes to those pages.\n"
+export function generateDocSnapshots() {
+  const pages = SEARCH.flatMap(walk).filter((path) =>
+    PAGES.some((pattern) => pattern.test(path))
   );
+
+  const skipped = [];
+  const omitted = [];
+  const stories = new Map();
+
+  for (const path of pages.sort()) {
+    const page = parse(path);
+
+    if (!page.title) {
+      skipped.push(`${path} (${page.reason})`);
+      continue;
+    }
+
+    if (TOO_TALL.has(page.title)) {
+      omitted.push(page.title);
+      continue;
+    }
+
+    const file = filename(page.title);
+    const owner = stories.get(file);
+
+    // Two titles that come down to the same name would leave one page writing
+    // over the other's story, and the page written over silently unsnapshotted.
+    if (owner) {
+      skipped.push(`${path} (its title is ${owner.path}'s once slugged)`);
+      continue;
+    }
+
+    stories.set(file, { path, source: story({ ...page, path }) });
+  }
+
+  /**
+   * Pages but no stories means Chromatic is about to review none of the
+   * documentation, and a stories glob matching nothing is not an error it would
+   * ever raise. Raise it here, while there is still a build to stop.
+   */
+  if (pages.length > 0 && stories.size === 0) {
+    throw new Error(
+      `Found ${pages.length} documentation pages and wrote no snapshot stories ` +
+        "to docs-kit/generated. Chromatic would not have seen the documentation."
+    );
+  }
+
+  reconcile(stories);
+
+  const written = stories.size;
+
+  process.stdout.write(
+    `Wrote ${written} documentation snapshot ${written === 1 ? "story" : "stories"} to docs-kit/generated` +
+      (omitted.length > 0
+        ? `, leaving out ${omitted.join(" and ")} as too tall for Chromatic to capture\n`
+        : "\n")
+  );
+
+  if (skipped.length > 0) {
+    process.stdout.write(
+      `Warning: no snapshot story for ${skipped.join(", ")}. ` +
+        "Chromatic will not see changes to those pages.\n"
+    );
+  }
+
+  return { omitted, skipped, written };
+}
+
+// Run when invoked directly, as the `docs:snapshots` script still does.
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  generateDocSnapshots();
 }

--- a/package.json
+++ b/package.json
@@ -119,8 +119,8 @@
     "zod": "^4.0.17"
   },
   "scripts": {
-    "start": "yarn playground:types && yarn docs:snapshots && NODE_OPTIONS=\"--max-old-space-size=8192\" && storybook dev -p 6006 --no-open",
-    "build-storybook": "yarn playground:types && yarn docs:snapshots && storybook build -o docs-build",
+    "start": "yarn playground:types && NODE_OPTIONS=\"--max-old-space-size=8192\" storybook dev -p 6006 --no-open",
+    "build-storybook": "yarn playground:types && NODE_OPTIONS=\"--max-old-space-size=8192\" storybook build -o docs-build",
     "playground:types": "node playground/scripts/generate-types.mjs",
     "docs:snapshots": "node docs-kit/scripts/generate-doc-snapshots.mjs",
     "test-storybook": "test-storybook",


### PR DESCRIPTION
## Problem

The Storybook configuration lists the documentation snapshot stories.
A yarn script wrote these stories.
If you start Storybook in a different way, the script does not run.
Storybook then finds no stories, but it does not show an error.
Chromatic then does not compare the documentation pages.

## Changes

- `.storybook/main.ts` writes the stories. The yarn scripts do not write them.
- The script stops the build if it finds pages but writes no stories.
- The script writes only the files that are different. It does not delete the directory first.
- The `start` script sends the memory limit to Node. An incorrect `&&` stopped this before.

## Tests

- A Storybook build writes all 111 stories. The build index shows them.
- The 119 `docs-kit` tests pass.